### PR TITLE
Set version to appropriate value for development

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ def get_requirements():
 
 setup(
     name="pubtools-pulp",
-    version="1.1.0",
+    version="0.1.0",
     packages=find_packages(exclude=["tests"]),
     url="https://github.com/release-engineering/pubtools-pulp",
     license="GNU General Public License",


### PR DESCRIPTION
Version should be less than 1.0.0 until interfaces are deemed
stable.