### PR TITLE
Extend, fix & add docs with sphinx-argparse

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -45,6 +45,7 @@ extensions = [
     "sphinx.ext.napoleon",
     "sphinx.ext.githubpages",
     "sphinx.ext.viewcode",
+    "sphinxarg.ext",
 ]
 
 # Add any paths that contain templates here, relative to this directory.
@@ -88,10 +89,10 @@ html_theme = "alabaster"
 #
 html_theme_options = {
     "github_user": "release-engineering",
-    "github_repo": "pubtools-pulpl",
+    "github_repo": "pubtools-pulp",
     "github_button": False,
     "github_banner": True,
-    "description": "A library for Pulp task CLI",
+    "description": "Publishing tools for Pulp",
     "extra_nav_links": {
         "Source": "https://github.com/release-engineering/pubtools-pulp",
         "PyPI": "https://pypi.org/project/pubtools-pulp",
@@ -130,9 +131,4 @@ html_sidebars = {
 autoclass_content = "both"
 autodoc_member_order = "bysource"
 autodoc_inherit_docstrings = False
-intersphinx_mapping = {
-    "python": ("https://docs.python.org/3", None),
-    "requests": ("https://2.python-requests.org/en/master/", None),
-    "more-executors": ("https://rohanpm.github.io/more-executors/", None),
-    "attrs": ("https://www.attrs.org/en/stable/", None),
-}
+intersphinx_mapping = {"python": ("https://docs.python.org/3", None)}

--- a/docs/garbage-collect.rst
+++ b/docs/garbage-collect.rst
@@ -1,0 +1,23 @@
+garbage-collect
+===============
+
+.. argparse::
+   :module: pubtools.pulp.tasks.garbage_collect
+   :func: doc_parser
+   :prog: garbage-collect
+
+Example
+.......
+
+A typical invocation of garbage-collect would look like this:
+
+.. code-block::
+
+  garbage-collect \
+    --url https://pulp.example.com/ \
+    --user admin \
+    --password XXXXX \
+    --gc-threshold 14
+
+In this example, temporary repositories older than 2 weeks would be
+deleted from the remote Pulp server.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,4 +1,13 @@
 pubtools-pulp
 =============
 
-A library for Pulp task CLI.
+Publishing tools for Pulp.
+
+This project includes a collection of tools and workflows for publishing
+content via `Pulp <https://pulpproject.org/>`_.
+
+.. toctree::
+   :maxdepth: 1
+   :caption: Command Reference:
+
+   garbage-collect

--- a/pubtools/pulp/task.py
+++ b/pubtools/pulp/task.py
@@ -96,7 +96,6 @@ class PulpTask(object):
 
         e.g. self.parser.add_argument("option", help="help text")
         """
-        raise NotImplementedError()
 
     def run(self):
         """Implement a specific task"""

--- a/pubtools/pulp/tasks/garbage_collect.py
+++ b/pubtools/pulp/tasks/garbage_collect.py
@@ -10,16 +10,20 @@ LOG = logging.getLogger("garbage-collect")
 
 
 class GarbageCollect(PulpTask):
-    """A class for the pulp task of garbage collect.
+    """Perform garbage collection on Pulp data.
 
-    The task accepts --gc-threshold as a cli option to delete the
-    repos that older than the provided threshold (defaults to 5).
+    Garbage collection consists of deleting temporary Pulp repositories
+    (created by certain tools) older than a certain age.  Future versions
+    of this command may also perform other types of garbage collection.
+
+    This command is suitable for use periodically; for example, from a weekly
+    scheduled trigger.
     """
 
     def add_args(self):
         self.parser.add_argument(
             "--gc-threshold",
-            help="# of days beyond with gc applies",
+            help="delete repos older than this many days",
             type=int,
             default=5,
         )
@@ -58,3 +62,7 @@ class GarbageCollect(PulpTask):
 
 def entry_point():
     GarbageCollect().main()
+
+
+def doc_parser():
+    return GarbageCollect().parser

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
 six
-attrs
 pubtools-pulplib

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 
 def get_description():
-    return "A library for Pulp tasks"
+    return "Publishing tools for Pulp"
 
 
 def get_long_description():

--- a/tests/test_pulp_task.py
+++ b/tests/test_pulp_task.py
@@ -20,13 +20,6 @@ def test_task_run():
         task.run()
 
 
-def test_add_args():
-    """raises if add_args() is not implemeted"""
-    task = PulpTask()
-    with pytest.raises(NotImplementedError):
-        task.add_args()
-
-
 def test_init_args(p_add_args):
     """Checks whether the args from cli are available for the task"""
     task = PulpTask()

--- a/tests/test_pulp_task.py
+++ b/tests/test_pulp_task.py
@@ -51,3 +51,21 @@ def test_main(p_add_args):
     with patch("sys.argv", arg):
         with patch("pubtools.pulp.task.PulpTask.run"):
             assert task.main() == 0
+
+
+def test_description():
+    """description is initialized from subclass docstring, de-dented."""
+
+    class MyTask(PulpTask):
+        """This is an example task subclass.
+
+        It has a realistic multi-line doc string:
+
+            ...and may have several levels of indent.
+        """
+
+    assert MyTask().description == (
+        "This is an example task subclass.\n\n"
+        "It has a realistic multi-line doc string:\n\n"
+        "    ...and may have several levels of indent."
+    )

--- a/tests/test_task_interface.py
+++ b/tests/test_task_interface.py
@@ -1,0 +1,26 @@
+"""Tests ensuring all task modules have a consistent interface."""
+import argparse
+import sys
+import pytest
+
+
+@pytest.fixture(params=["pubtools.pulp.tasks.garbage_collect"])
+def task_module(request):
+    __import__(request.param)
+    return sys.modules[request.param]
+
+
+def test_doc_parser(task_module):
+    """Every task module should have a doc_parser which can be called
+    with no arguments and returns an ArgumentParser.
+
+    This supports the generation of docs from argument parsers."""
+    fn = getattr(task_module, "doc_parser")
+    parser = fn()
+    assert isinstance(parser, argparse.ArgumentParser)
+
+
+def test_entry_point(task_module):
+    """Every task module should have a callable entry_point."""
+    fn = getattr(task_module, "entry_point")
+    assert callable(fn)

--- a/tox.ini
+++ b/tox.ini
@@ -44,6 +44,7 @@ commands=
 [testenv:docs]
 deps=
 	sphinx
+	sphinx-argparse
 	alabaster
 use_develop=true
 commands=


### PR DESCRIPTION
Initial version of "command reference" docs.
Each command should be documented on its own page.

This documentation can be (partially) generated from the
ArgumentParser objects, to document all supported arguments with
their help text.

Some minor refactoring was needed to ensure that ArgumentParser
objects can be created & accessed without running tasks.
Most notably, the usage of attrs was dropped as it mainly
seems to be getting in the way, and we don't much benefit from
any attrs features here.