### PR TITLE
Introduce clear-repo command

### DIFF
--- a/docs/clear-repo.rst
+++ b/docs/clear-repo.rst
@@ -1,0 +1,63 @@
+clear-repo
+==========
+
+.. argparse::
+   :module: pubtools._pulp.tasks.clear_repo
+   :func: doc_parser
+   :prog: pubtools-pulp-clear-repo
+
+
+Example
+.......
+
+A typical invocation of clear-repo would look like this:
+
+.. code-block::
+
+  pubtools-pulp-clear-repo \
+    --pulp-url https://pulp.example.com/ \
+    --pulp-user admin \
+    --pulp-password XXXXX \
+    my-repo1 my-repo2 ...
+
+All content of the mentioned repositories would be removed.
+
+
+Example: skipping publish
+.........................
+
+If you know that there's no point in publishing Pulp repositories
+(for example, you're about to push new content into repos after
+clearing them), you can speed up the task by skipping publish:
+
+.. code-block::
+
+  pubtools-pulp-clear-repo \
+    --pulp-url https://pulp.example.com/ \
+    --pulp-user admin \
+    --pulp-password XXXXX \
+    --skip publish \
+    my-repo1 my-repo2 ...
+
+
+Example: with cache flush
+.........................
+
+If your Pulp server is configured to publish to an Akamai CDN,
+usage of the Akamai FastPurge API for cache flushing may be enabled
+to flush cache after publishing repositories.
+
+This is enabled by providing a value for ``--fastpurge-root-url``.
+FastPurge credentials may also be provided; if omitted, the command
+will attempt to use a local
+`edgerc <https://developer.akamai.com/introduction/Conf_Client.html>`_
+file for authentication.
+
+.. code-block::
+
+  pubtools-pulp-clear-repo \
+    --pulp-url https://pulp.example.com/ \
+    --pulp-user admin \
+    --pulp-password XXXXX \
+    --fastpurge-root-url https://cdn.example.com/ \
+    my-repo1 my-repo2 ...

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -10,4 +10,5 @@ content via `Pulp <https://pulpproject.org/>`_.
    :maxdepth: 1
    :caption: Command Reference:
 
+   clear-repo
    garbage-collect

--- a/pubtools/_pulp/arguments.py
+++ b/pubtools/_pulp/arguments.py
@@ -1,0 +1,45 @@
+import os
+
+
+def from_environ(key, delegate_converter=lambda x: x):
+    """A converter for use as an argparse "type" argument which supports
+    reading values from the environment.
+
+    Expected usage is like this:
+
+      add_argument('--my-password', default='', type=from_environ('MY_PASSWORD'))
+
+    Or if you need a non-string type, you can combine with another converter:
+
+      add_argument('--threads', default='', type=from_environ('THREADS', int))
+
+    Reasons to do this instead of just default=os.environ.get(...) include:
+
+    - resolve the env var when arguments are parsed rather than when the parser is
+      set up; helpful for writing autotests
+
+    - ensure the default value can't end up in output of --help (which could leak
+      passwords from env vars)
+
+    Arguments:
+        key (str)
+            Name of environment variable to look up.
+        delegate_converter (callable)
+            A converter for the looked up environment variable.
+
+    Returns:
+        object
+            The argument value looked up from environment & converted.
+    """
+    return FromEnvironmentConverter(key, delegate_converter)
+
+
+class FromEnvironmentConverter(object):
+    def __init__(self, key, delegate):
+        self.key = key
+        self.delegate = delegate
+
+    def __call__(self, value):
+        if not value:
+            value = os.environ.get(self.key)
+        return self.delegate(value)

--- a/pubtools/_pulp/services/__init__.py
+++ b/pubtools/_pulp/services/__init__.py
@@ -1,0 +1,4 @@
+from .collector import CollectorService
+from .fastpurge_ import FastPurgeClientService
+from .pulp import PulpClientService
+from .udcache import UdCacheClientService

--- a/pubtools/_pulp/services/base.py
+++ b/pubtools/_pulp/services/base.py
@@ -1,0 +1,43 @@
+from argparse import ArgumentParser
+
+
+class Service(object):
+    """Mix-in class to be inherited for access to specific services.
+
+    The Service class is used as follows:
+
+    - for a particular service needed by certain tasks (e.g. a Pulp client,
+      a FastPurge client), implement a subclass of Service
+    - in the subclass, if there are associated command-line arguments, override
+      add_service_args to configure those
+    - in the subclass, add the properties which should be exposed by that service
+      (often just one)
+
+    Once done, every task which needs that service can inherit from the needed
+    service implementation(s) to access it with consistent argument handling.
+    """
+
+    def add_args(self):
+        # Overrides the method from PulpTask.
+        # These classes can be mixed in both before and after PulpTask,
+        # hence the dynamic add_args and parser lookups.
+        super_add_args = getattr(super(Service, self), "add_args", lambda: None)
+        super_add_args()
+
+        parser = getattr(self, "parser", ArgumentParser())
+        self.add_service_args(parser)
+
+    def add_service_args(self, parser):
+        # Implement me in subclasses to add arguments particular to a service
+        # (if any).
+        # Make sure to call super() when overriding.
+        pass
+
+    @property
+    def _service_args(self):
+        # Subclasses call this instead of self.args to avoid pylint warnings
+        # everywhere.
+        #
+        # Expected to be mixed in with a class providing "args" property.
+        assert hasattr(self, "args"), "BUG: Service inheritor must provide 'args'"
+        return self.args  # pylint: disable=no-member

--- a/pubtools/_pulp/services/collector.py
+++ b/pubtools/_pulp/services/collector.py
@@ -1,0 +1,27 @@
+import threading
+
+import pushcollector
+
+from .base import Service
+
+
+class CollectorService(Service):
+    """A service providing a pushcollector instance.
+
+    Tasks could just as easily call Collector.get() directly.
+    The main reason for this service class is to ensure
+    a single Collector instance is used for a task's duration.
+    """
+
+    def __init__(self, *args, **kwargs):
+        self.__lock = threading.Lock()
+        self.__instance = None
+        super(CollectorService, self).__init__(*args, **kwargs)
+
+    @property
+    def collector(self):
+        """A Collector instance used during a task."""
+        with self.__lock:
+            if not self.__instance:
+                self.__instance = pushcollector.Collector.get()
+        return self.__instance

--- a/pubtools/_pulp/services/fastpurge_.py
+++ b/pubtools/_pulp/services/fastpurge_.py
@@ -1,0 +1,90 @@
+import threading
+
+# Note: *this* file is named "fastpurge_" to avoid the below import
+# breaking on Python 2.x
+from fastpurge import FastPurgeClient
+
+from pubtools._pulp.arguments import from_environ
+from .base import Service
+
+
+class FastPurgeClientService(Service):
+    """A service providing a FastPurge client.
+
+    The client will only be available if the caller provides
+    at least the --fastpurge-root-url argument.
+    """
+
+    def __init__(self, *args, **kwargs):
+        self.__lock = threading.Lock()
+        self.__instance = None
+        super(FastPurgeClientService, self).__init__(*args, **kwargs)
+
+    def add_service_args(self, parser):
+        super(FastPurgeClientService, self).add_service_args(parser)
+
+        group = parser.add_argument_group("Akamai FastPurge environment")
+
+        group.add_argument(
+            "--fastpurge-host", help="FastPurge hostname (xxx.purge.akamaiapis.net)"
+        )
+        group.add_argument("--fastpurge-client-token", help="Fast Purge client token")
+        group.add_argument(
+            "--fastpurge-client-secret",
+            help=(
+                "FastPurge client secret "
+                "(or set FASTPURGE_SECRET environment variable)"
+            ),
+            default="",
+            type=from_environ("FASTPURGE_SECRET"),
+        )
+        group.add_argument("--fastpurge-access-token", help="FastPurge access token")
+
+        group.add_argument(
+            "--fastpurge-root-url",
+            help=(
+                "Root URL of CDN for all cache purges "
+                "(or set FASTPURGE_ROOT_URL environment variable). "
+                "If omitted, FastPurge features are disabled."
+            ),
+            default="",
+            type=from_environ("FASTPURGE_ROOT_URL"),
+        )
+
+    @property
+    def fastpurge_root_url(self):
+        """Root URL for all FastPurge cache flushes (e.g. "https://cdn.example.com/").
+
+        May be None if not passed by user, in which case cache flushing should be skipped.
+        """
+        return self._service_args.fastpurge_root_url
+
+    @property
+    def fastpurge_client(self):
+        """A FastPurge client used during task, instantiated on demand.
+
+        May be None depending on command-line arguments, in which case cache flushing
+        should be skipped.
+        """
+        with self.__lock:
+            if not self.__instance:
+                self.__instance = self.__get_instance()
+        return self.__instance
+
+    def __get_instance(self):
+        if not self.fastpurge_root_url:
+            # If no root URL is defined, we can't flush anything;
+            # return None for client to indicate that flushing is disabled
+            return None
+
+        fastpurge_args = {}
+
+        for key in ["host", "client_secret", "client_token", "access_token"]:
+            arg_name = "fastpurge_" + key
+            arg_value = getattr(self._service_args, arg_name)
+            if arg_value:
+                fastpurge_args[key] = arg_value
+
+        # If there's any argument provided, then we pass args to the client.
+        # Otherwise, we pass None and we expect ~/.edgerc to be used.
+        return FastPurgeClient(auth=(fastpurge_args or None))

--- a/pubtools/_pulp/services/pulp.py
+++ b/pubtools/_pulp/services/pulp.py
@@ -1,0 +1,69 @@
+import threading
+import os
+import logging
+import warnings
+
+from pubtools import pulplib
+
+from .base import Service
+
+LOG = logging.getLogger("pubtools.pulp")
+
+
+class PulpClientService(Service):
+    """A service providing a Pulp client.
+
+    If this service is inherited, Pulp-related arguments become mandatory
+    in order to run the task.
+    """
+
+    def __init__(self, *args, **kwargs):
+        self.__lock = threading.Lock()
+        self.__instance = None
+        super(PulpClientService, self).__init__(*args, **kwargs)
+
+    def add_service_args(self, parser):
+        super(PulpClientService, self).add_service_args(parser)
+
+        group = parser.add_argument_group("Pulp environment")
+        group.add_argument("--pulp-url", help="Pulp server URL", required=True)
+        group.add_argument("--pulp-user", help="Pulp username", default=None)
+        group.add_argument(
+            "--pulp-password",
+            help="Pulp password (or set PULP_PASSWORD environment variable)",
+            default=None,
+        )
+        group.add_argument(
+            "--pulp-insecure",
+            action="store_true",
+            help="Allow unverified HTTPS connection to Pulp",
+        )
+
+    @property
+    def pulp_client(self):
+        """A Pulp client used during task, instantiated on demand."""
+        with self.__lock:
+            if not self.__instance:
+                self.__instance = self.__get_instance()
+        return self.__instance
+
+    def __get_instance(self):
+        auth = None
+        args = self._service_args
+
+        # checks if pulp password is available as environment variable
+        if args.pulp_user:
+            pulp_password = args.pulp_password or os.environ.get("PULP_PASSWORD")
+            if not pulp_password:
+                LOG.warning("No pulp password provided for %s", args.pulp_user)
+            auth = (args.pulp_user, pulp_password)
+
+        kwargs = {"auth": auth}
+
+        if args.pulp_insecure:
+            kwargs["verify"] = False
+
+            # Thank you, but we don't need to hear about this for every single request
+            warnings.filterwarnings("once", r"Unverified HTTPS request is being made")
+
+        return pulplib.Client(args.pulp_url, **kwargs)

--- a/pubtools/_pulp/services/udcache.py
+++ b/pubtools/_pulp/services/udcache.py
@@ -1,0 +1,61 @@
+import threading
+
+from pubtools._pulp.ud import UdCacheClient
+from pubtools._pulp.arguments import from_environ
+
+from .base import Service
+
+
+class UdCacheClientService(Service):
+    """A service providing a UD cache flush client.
+
+    A client will only be available if the user provided UD-related
+    arguments to the command.
+    """
+
+    def __init__(self, *args, **kwargs):
+        self.__lock = threading.Lock()
+        self.__instance = None
+        super(UdCacheClientService, self).__init__(*args, **kwargs)
+
+    def add_service_args(self, parser):
+        super(UdCacheClientService, self).add_service_args(parser)
+
+        group = parser.add_argument_group("Unified Downloads Cache environment")
+
+        group.add_argument(
+            "--udcache-url",
+            help=(
+                "Base URL of UD cache flush API; "
+                "if omitted, UD cache flush features are disabled."
+            ),
+        )
+        group.add_argument("--udcache-user", help="Username for UD cache flush")
+        group.add_argument(
+            "--udcache-password",
+            help="Password for UD cache flush (or set UDCACHE_PASSWORD)",
+            default="",
+            type=from_environ("UDCACHE_PASSWORD"),
+        )
+
+    @property
+    def udcache_client(self):
+        """A UD cache client used during task, instantiated on demand.
+
+        May return None if needed arguments for UD cache flush are not provided,
+        in which case cache flush should be skipped.
+        """
+        with self.__lock:
+            if not self.__instance:
+                self.__instance = self.__get_instance()
+        return self.__instance
+
+    def __get_instance(self):
+        args = self._service_args
+        if not args.udcache_url:
+            # UD cache flushing will be disabled
+            return None
+
+        return UdCacheClient(
+            url=args.udcache_url, auth=(args.udcache_user, args.udcache_password)
+        )

--- a/pubtools/_pulp/step.py
+++ b/pubtools/_pulp/step.py
@@ -1,0 +1,137 @@
+import logging
+import threading
+from more_executors.futures import f_sequence, f_return
+
+LOG = logging.getLogger("pubtools.pulp")
+
+
+class StepDecorator(object):
+    """Implementation of PulpTask.step decorator. See that method for more info."""
+
+    def __init__(self, name):
+        self._name = name
+
+    @property
+    def human_name(self):
+        return self._name
+
+    @property
+    def machine_name(self):
+        return self._name.replace(" ", "-").lower()
+
+    def __call__(self, fn):
+        def new_fn(instance, *args, **kwargs):
+            if self.should_skip(instance):
+                LOG.info(
+                    "%s: skipped",
+                    self.human_name,
+                    extra={"event": {"type": "%s-skip" % self.machine_name}},
+                )
+                return args[0] if args else None
+
+            logger = StepLogger(self)
+            logger.log_start(args)
+
+            try:
+                ret = fn(instance, *args, **kwargs)
+            except SystemExit as exc:
+                if exc.code == 0:
+                    logger.log_return()
+                else:
+                    logger.log_error()
+                raise
+            except Exception:
+                logger.log_error()
+                raise
+
+            logger.log_return(ret)
+
+            return ret
+
+        return new_fn
+
+    def should_skip(self, instance):
+        skip = (getattr(instance.args, "skip", None) or "").split(",")
+        return self.machine_name in skip
+
+
+# helpers used in implementation of decorator
+def is_future(x):
+    return hasattr(x, "add_done_callback")
+
+
+def as_futures(args):
+    arg0 = args[0] if args else None
+    if is_future(arg0):
+        return [arg0]
+
+    if isinstance(arg0, list) and arg0 and is_future(arg0[0]):
+        return arg0
+
+    return None
+
+
+class StepLogger(object):
+    # Implements logging when entering/exiting/failing a step.
+    # The main point of this class is to keep track of whether
+    # entering a step has been logged, and make sure exiting a step
+    # can't be logged before entering.
+    def __init__(self, step):
+        self.step = step
+        self.lock = threading.RLock()
+        self.log_opened = False
+
+    def log_start(self, args=None):
+        input_future = as_futures(args)
+
+        def do_log():
+            with self.lock:
+                if self.log_opened:
+                    return
+                self.log_opened = True
+
+                LOG.info(
+                    "%s: started",
+                    self.step.human_name,
+                    extra={"event": {"type": "%s-start" % self.step.machine_name}},
+                )
+
+        if not input_future:
+            # This function doesn't take futures as input: then it's
+            # about to start immediately
+            do_log()
+            return
+
+        # This function takes future(s) as input: then the step is
+        # only considered to start once *at least one* of the input futures
+        # has completed
+        for f in input_future:
+            f.add_done_callback(lambda f: do_log() if not f.exception() else None)
+
+    def log_error(self):
+        self.log_start()
+
+        LOG.error(
+            "%s: failed",
+            self.step.human_name,
+            extra={"event": {"type": "%s-error" % self.step.machine_name}},
+        )
+
+    def log_return(self, return_value=None):
+        return_future = as_futures([return_value]) or [f_return(None)]
+
+        def do_log():
+            self.log_start()
+
+            LOG.info(
+                "%s: finished",
+                self.step.human_name,
+                extra={"event": {"type": "%s-end" % self.step.machine_name}},
+            )
+
+        # The step is considered completed once *all* returned futures
+        # have completed
+        completed = f_sequence(return_future)
+        completed.add_done_callback(
+            lambda f: self.log_error() if completed.exception() else do_log()
+        )

--- a/pubtools/_pulp/tasks/clear_repo.py
+++ b/pubtools/_pulp/tasks/clear_repo.py
@@ -1,0 +1,324 @@
+import logging
+import sys
+import os
+from functools import partial
+import attr
+
+from more_executors.futures import f_map, f_flat_map, f_sequence
+from pubtools.pulplib import (
+    Criteria,
+    ContainerImageRepository,
+    PublishOptions,
+    FileUnit,
+    RpmUnit,
+    ModulemdUnit,
+)
+
+from pubtools._pulp.task import PulpTask
+from pubtools._pulp.services import (
+    CollectorService,
+    FastPurgeClientService,
+    UdCacheClientService,
+    PulpClientService,
+)
+
+step = PulpTask.step
+
+
+LOG = logging.getLogger("pubtools.pulp")
+
+
+@attr.s
+class ClearedRepo(object):
+    """Represents a single repo which has been cleared."""
+
+    tasks = attr.ib()
+    """The completed Pulp tasks for clearing this repo."""
+
+    repo = attr.ib()
+    """The repo which was cleared."""
+
+
+class ClearRepo(
+    CollectorService,
+    FastPurgeClientService,
+    UdCacheClientService,
+    PulpClientService,
+    PulpTask,
+):
+    """Remove all contents from one or more Pulp repositories.
+
+    This command will remove contents from repositories and record
+    information on what was removed.  Removal may optionally be
+    filtered to selected content types.
+    """
+
+    @property
+    def content_type(self):
+        type_strs = (self.args.content_type or "").split(",")
+        # Only return non-None if there were really any types given.
+        # Otherwise, return None to let library defaults apply
+        return [x for x in type_strs if x] or None
+
+    def add_args(self):
+        super(ClearRepo, self).add_args()
+
+        self.parser.add_argument(
+            "--skip", help="skip given comma-separated sub-steps", type=str
+        )
+        self.parser.add_argument(
+            "--content-type",
+            help="remove only content of these comma-separated type(s)",
+            type=str,
+        )
+        self.parser.add_argument("repo", nargs="+", help="Repositories to be cleared")
+
+    def fail(self, *args, **kwargs):
+        LOG.error(*args, **kwargs)
+        sys.exit(30)
+
+    @step("Check repos")
+    def get_repos(self):
+        # Returns all repos to be operated on by this task.
+        # Eagerly loads the repos so we fail early if the user passed any nonexistent
+        # repo.
+        repo_ids = self.args.repo
+        found_repo_ids = []
+
+        out = []
+        search = self.pulp_client.search_repository(Criteria.with_id(repo_ids))
+        for repo in search.result().as_iter():
+            out.append(repo)
+            found_repo_ids.append(repo.id)
+
+        # Bail out if user requested repos which don't exist
+        missing = set(repo_ids) - set(found_repo_ids)
+
+        missing = sorted(list(missing))
+        if missing:
+            self.fail("Requested repo(s) don't exist: %s", ", ".join(missing))
+
+        # Bail out if we'd be processing any container image repos.
+        # We don't support this now because:
+        #
+        # - recording push items isn't implemented yet and it's not clear
+        #   how to implement it (as we traditionally used docker-image-*.tar.gz
+        #   filenames from brew as push item filename, but those aren't available
+        #   in pulp metadata)
+        #
+        # - no known use-case for clearing them
+        #
+        container_repo_ids = sorted(
+            [repo.id for repo in out if isinstance(repo, ContainerImageRepository)]
+        )
+        if container_repo_ids:
+            self.fail(
+                "Container image repo(s) provided, not supported: %s"
+                % ", ".join(sorted(container_repo_ids))
+            )
+
+        return out
+
+    def log_remove(self, cleared_repo):
+        # Given a repo which has been cleared, log some messages
+        # summarizing the removed unit(s)
+        content_types = {}
+
+        for task in cleared_repo.tasks:
+            for unit in task.units:
+                type_id = unit.content_type_id
+                content_types[type_id] = content_types.get(type_id, 0) + 1
+
+        task_ids = ", ".join(sorted([t.id for t in cleared_repo.tasks]))
+        repo_id = cleared_repo.repo.id
+        if not content_types:
+            LOG.warning("%s: no content removed, tasks: %s", repo_id, task_ids)
+        else:
+            removed_types = []
+            for key in sorted(content_types.keys()):
+                removed_types.append("%s %s(s)" % (content_types[key], key))
+            removed_types = ", ".join(removed_types)
+
+            LOG.info("%s: removed %s, tasks: %s", repo_id, removed_types, task_ids)
+
+        return cleared_repo
+
+    @step("Clear content")
+    def clear_content(self, repos):
+        out = []
+
+        for repo in repos:
+            f = repo.remove_content(type_ids=self.content_type)
+            f = f_map(f, partial(ClearedRepo, repo=repo))
+            f = f_map(f, self.log_remove)
+            out.append(f)
+
+        return out
+
+    @step("Record push items")
+    def record_clears(self, cleared_repo_fs):
+        return [f_flat_map(f, self.record_cleared_repo) for f in cleared_repo_fs]
+
+    def record_cleared_repo(self, cleared_repo):
+        push_items = []
+        for task in cleared_repo.tasks:
+            push_items.extend(self.push_items_for_task(task))
+        return self.collector.update_push_items(push_items)
+
+    def push_items_for_task(self, task):
+        out = []
+        for unit in task.units:
+            push_item = self.push_item_for_unit(unit)
+            if push_item:
+                out.append(push_item)
+        return out
+
+    def push_item_for_unit(self, unit):
+        for (unit_type, fn) in [
+            (ModulemdUnit, self.push_item_for_modulemd),
+            (RpmUnit, self.push_item_for_rpm),
+            (FileUnit, self.push_item_for_file),
+        ]:
+            if isinstance(unit, unit_type):
+                return fn(unit)
+
+    def push_item_for_modulemd(self, unit):
+        out = {}
+        out["state"] = "DELETED"
+        out["origin"] = "pulp"
+
+        # Note: N:S:V:C:A format here is kept even if some part
+        # of the data is missing (never expected to happen).
+        # For example, if C was missing, you'll get N:S:V::A
+        # so the arch part can't be misinterpreted as context.
+        nsvca = ":".join(
+            [unit.name, unit.stream, str(unit.version), unit.context, unit.arch]
+        )
+
+        out["filename"] = nsvca
+
+        return out
+
+    def push_item_for_rpm(self, unit):
+        out = {}
+
+        out["state"] = "DELETED"
+        out["origin"] = "pulp"
+
+        filename_parts = [
+            unit.name,
+            "-",
+            unit.version,
+            "-",
+            unit.release,
+            ".",
+            unit.arch,
+            ".rpm",
+        ]
+        out["filename"] = "".join(filename_parts)
+
+        out["checksums"] = {}
+        if unit.sha256sum:
+            out["checksums"]["sha256"] = unit.sha256sum
+        if unit.md5sum:
+            out["checksums"]["md5"] = unit.md5sum
+
+        out["signing_key"] = unit.signing_key
+
+        return out
+
+    def push_item_for_file(self, unit):
+        return {
+            "state": "DELETED",
+            "origin": "pulp",
+            "filename": unit.path,
+            "checksums": {"sha256": unit.sha256sum},
+        }
+
+    @step("Publish")
+    def publish(self, repo_fs):
+        return [
+            f_flat_map(f, lambda r: r.publish(PublishOptions(clean=True)))
+            for f in repo_fs
+        ]
+
+    @step("Flush UD cache")
+    def flush_ud(self, repos):
+        client = self.udcache_client
+        if not client:
+            LOG.info("UD cache flush is not enabled.")
+            return []
+
+        out = []
+        for repo in repos:
+            out.append(client.flush_repo(repo.id))
+            if repo.eng_product_id:
+                out.append(client.flush_product(repo.eng_product_id))
+
+        return out
+
+    @step("Flush CDN cache")
+    def flush_cdn(self, repos):
+        if not self.fastpurge_client:
+            LOG.info("CDN cache flush is not enabled.")
+            return []
+
+        def purge_repo(repo):
+            to_flush = []
+            for url in repo.mutable_urls:
+                flush_url = os.path.join(
+                    self.fastpurge_root_url, repo.relative_url, url
+                )
+                to_flush.append(flush_url)
+
+            LOG.debug("Flush: %s", to_flush)
+            flush = self.fastpurge_client.purge_by_url(to_flush)
+            return f_map(flush, lambda _: repo)
+
+        return [purge_repo(r) for r in repos if r.relative_url]
+
+    def run(self):
+        to_await = []
+
+        # Get the repos we'll be dealing with.
+        # This is blocking so we'll fail early on missing/bad repos.
+        repos = self.get_repos()
+
+        # Start clearing repos.
+        cleared_repos_fs = self.clear_content(repos)
+
+        # As clearing completes, record pushitem info on what was removed.
+        # We don't have to wait on this before continuing.
+        to_await.extend(self.record_clears(cleared_repos_fs))
+
+        # Don't need the repo clearing tasks for anything more.
+        repos_fs = [f_map(f, lambda cr: cr.repo) for f in cleared_repos_fs]
+
+        # Now move repos into the desired state:
+
+        # They should be published.
+        publish_fs = self.publish(repos_fs)
+
+        # Wait for all repo publishes to complete before continuing.
+        # Why: cache flush is what makes changes visible, and we want that to be
+        # as near atomic as we can get (i.e. changes appear in every repo "at once",
+        # rather than as each repo is published).
+        f_sequence(publish_fs).result()
+
+        # They should have UD cache flushed.
+        to_await.extend(self.flush_ud(repos))
+
+        # They should have CDN cache flushed.
+        to_await.extend(self.flush_cdn(repos))
+
+        # Now make sure we wait for everything to finish.
+        for f in to_await:
+            f.result()
+
+
+def entry_point(cls=ClearRepo):
+    cls().main()
+
+
+def doc_parser():
+    return ClearRepo().parser

--- a/pubtools/_pulp/tasks/garbage_collect.py
+++ b/pubtools/_pulp/tasks/garbage_collect.py
@@ -4,12 +4,13 @@ from datetime import datetime, timedelta
 from pubtools.pulplib import Criteria, Matcher
 
 from pubtools._pulp.task import PulpTask
+from pubtools._pulp.services import PulpClientService
 
 
 LOG = logging.getLogger("garbage-collect")
 
 
-class GarbageCollect(PulpTask):
+class GarbageCollect(PulpClientService, PulpTask):
     """Perform garbage collection on Pulp data.
 
     Garbage collection consists of deleting temporary Pulp repositories
@@ -21,6 +22,8 @@ class GarbageCollect(PulpTask):
     """
 
     def add_args(self):
+        super(GarbageCollect, self).add_args()
+
         self.parser.add_argument(
             "--gc-threshold",
             help="delete repos older than this many days",

--- a/pubtools/_pulp/ud.py
+++ b/pubtools/_pulp/ud.py
@@ -1,0 +1,102 @@
+import threading
+import os
+import logging
+
+import requests
+from more_executors import Executors
+from more_executors.futures import f_map
+
+LOG = logging.getLogger("pubtools-pulp")
+
+
+class UdCacheClient(object):
+    # Client for flushing UD cache.
+
+    def __init__(self, url, max_retry_sleep=None, **kwargs):
+        """Create a new UD cache flush client.
+
+        Arguments:
+            url (str)
+                Base URL of UD cache flushing API.
+            max_retry_sleep (float)
+                Max number of seconds to sleep between retries.
+                Mainly provided so that tests can reduce the time needed to retry.
+            kwargs
+                Remaining arguments are used to initialize the requests.Session()
+                used within this class (e.g. "verify", "auth").
+        """
+        self._url = url
+        self._tls = threading.local()
+
+        retry_args = {}
+        if max_retry_sleep:
+            retry_args["max_sleep"] = max_retry_sleep
+
+        self._session_attrs = kwargs
+        self._executor = (
+            Executors.thread_pool()
+            .with_map(self._check_http_response)
+            .with_retry(**retry_args)
+        )
+
+    @staticmethod
+    def _check_http_response(response):
+        response.raise_for_status()
+
+    @property
+    def _session(self):
+        if not hasattr(self._tls, "session"):
+            self._tls.session = requests.Session()
+            for (key, value) in self._session_attrs.items():
+                setattr(self._tls.session, key, value)
+        return self._tls.session
+
+    def _get(self, *args, **kwargs):
+        return self._session.get(*args, **kwargs)
+
+    def _on_failure(self, object_type, object_id, exception):
+        LOG.error("Invalidating %s %s failed: %s", object_type, object_id, exception)
+        raise exception
+
+    def _flush_object(self, object_type, object_id):
+        url = os.path.join(
+            self._url, "internal/rcm/flush-cache", object_type, object_id
+        )
+
+        LOG.info("Invalidating %s %s", object_type, object_id)
+
+        # This is pretty odd, but yes, an HTTP *GET* here is used to flush cache.
+        out = self._executor.submit(self._get, url)
+
+        # Wrap with logging on failure
+        out = f_map(
+            out, error_fn=lambda ex: self._on_failure(object_type, object_id, ex)
+        )
+
+        return out
+
+    def flush_product(self, product_id):
+        """Flush a particular product by ID.
+
+        Arguments:
+            product_id (int)
+                Engineering product ID (e.g. 270).
+
+        Returns:
+            Future[None]
+                A future resolved once flush has completed.
+        """
+        return self._flush_object("eng-product", product_id)
+
+    def flush_repo(self, repo_id):
+        """Flush a particular repository by ID.
+
+        Arguments:
+            repo_id (str)
+                Pulp repository ID.
+
+        Returns:
+            Future[None]
+                A future resolved once flush has completed.
+        """
+        return self._flush_object("repo", repo_id)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,5 @@
 six
-pubtools-pulplib>=1.3.0
+pubtools-pulplib>=1.5.0
+fastpurge
+more_executors>=2.2.0
+pushcollector

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,8 @@ setup(
     python_requires=">=2.6",
     entry_points={
         "console_scripts": [
-            "pubtools-pulp-garbage-collect = pubtools._pulp.tasks.garbage_collect:entry_point"
+            "pubtools-pulp-garbage-collect = pubtools._pulp.tasks.garbage_collect:entry_point",
+            "pubtools-pulp-clear-repo = pubtools._pulp.tasks.clear_repo:entry_point",
         ]
     },
     project_urls={

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,3 +1,3 @@
 pytest
 mock
-more-executors>=2.1.2
+requests_mock

--- a/tests/clear_repo/test_clear_repo.py
+++ b/tests/clear_repo/test_clear_repo.py
@@ -77,7 +77,7 @@ class FakeClearRepo(ClearRepo):
             # If it did create one, it should be this
             assert isinstance(from_super, FastPurgeClient)
 
-        # We'll substitute our own, only if UD client is being used
+        # We'll substitute our own, only if fastpurge client is being used
         return self._fastpurge_client if from_super else None
 
 

--- a/tests/clear_repo/test_clear_repo.py
+++ b/tests/clear_repo/test_clear_repo.py
@@ -1,0 +1,326 @@
+import sys
+
+from more_executors.futures import f_return
+
+from pubtools.pulplib import (
+    Client,
+    FakeController,
+    FileRepository,
+    FileUnit,
+    YumRepository,
+    ContainerImageRepository,
+    ModulemdUnit,
+    RpmUnit,
+)
+from fastpurge import FastPurgeClient
+
+import pubtools._pulp.tasks.clear_repo
+from pubtools._pulp.tasks.clear_repo import ClearRepo
+from pubtools._pulp.ud import UdCacheClient
+
+
+class FakeUdCache(object):
+    def __init__(self):
+        self.flushed_repos = []
+        self.flushed_products = []
+
+    def flush_repo(self, repo_id):
+        self.flushed_repos.append(repo_id)
+        return f_return()
+
+    def flush_product(self, product_id):
+        self.flushed_products.append(product_id)
+        return f_return()
+
+
+class FakeFastPurge(object):
+    def __init__(self):
+        self.purged_urls = []
+
+    def purge_by_url(self, urls):
+        self.purged_urls.extend(urls)
+        return f_return()
+
+
+class FakeClearRepo(ClearRepo):
+    """clear-repo with services overridden for test"""
+
+    def __init__(self, *args, **kwargs):
+        super(FakeClearRepo, self).__init__(*args, **kwargs)
+        self.pulp_client_controller = FakeController()
+        self._udcache_client = FakeUdCache()
+        self._fastpurge_client = FakeFastPurge()
+
+    @property
+    def pulp_client(self):
+        # Super should give a Pulp client
+        assert isinstance(super(FakeClearRepo, self).pulp_client, Client)
+        # But we'll substitute our own
+        return self.pulp_client_controller.client
+
+    @property
+    def udcache_client(self):
+        # Super may or may not give a UD client, depends on arguments
+        from_super = super(FakeClearRepo, self).udcache_client
+        if from_super:
+            # If it did create one, it should be this
+            assert isinstance(from_super, UdCacheClient)
+
+        # We'll substitute our own, only if UD client is being used
+        return self._udcache_client if from_super else None
+
+    @property
+    def fastpurge_client(self):
+        # Super may or may not give a fastpurge client, depends on arguments
+        from_super = super(FakeClearRepo, self).fastpurge_client
+        if from_super:
+            # If it did create one, it should be this
+            assert isinstance(from_super, FastPurgeClient)
+
+        # We'll substitute our own, only if UD client is being used
+        return self._fastpurge_client if from_super else None
+
+
+def test_missing_repos(command_tester):
+    """Command fails when pointed at nonexistent repos."""
+    # This one test covers the entry point
+
+    command_tester.test(
+        lambda: pubtools._pulp.tasks.clear_repo.entry_point(FakeClearRepo),
+        [
+            "test-clear-repo",
+            "--pulp-url",
+            "https://pulp.example.com/",
+            "--verbose",
+            "repo1",
+            "repo2",
+            "repo3",
+        ],
+    )
+
+
+def test_clear_empty_repo(command_tester, fake_collector):
+    """Clearing a repo which is already empty succeeds."""
+
+    task_instance = FakeClearRepo()
+
+    repo = FileRepository(id="some-filerepo")
+
+    task_instance.pulp_client_controller.insert_repository(repo)
+
+    command_tester.test(
+        task_instance.main,
+        [
+            "test-clear-repo",
+            "--pulp-url",
+            "https://pulp.example.com/",
+            "--verbose",
+            "some-filerepo",
+        ],
+    )
+
+    # No push items recorded
+    assert not fake_collector.items
+
+
+def test_clear_file_repo(command_tester, fake_collector):
+    """Clearing a repo with file content succeeds."""
+
+    task_instance = FakeClearRepo()
+
+    repo = FileRepository(
+        id="some-filerepo",
+        eng_product_id=123,
+        relative_url="some/publish/url",
+        mutable_urls=["mutable1", "mutable2"],
+    )
+
+    files = [
+        FileUnit(path="hello.txt", size=123, sha256sum="a" * 64),
+        FileUnit(path="with/subdir.json", size=0, sha256sum="b" * 64),
+    ]
+
+    fakepulp = task_instance.pulp_client_controller
+    fakepulp.insert_repository(repo)
+    fakepulp.insert_units(repo, files)
+
+    # It should run with expected output.
+    command_tester.test(
+        task_instance.main,
+        [
+            "test-clear-repo",
+            "--pulp-url",
+            "https://pulp.example.com/",
+            "--pulp-insecure",
+            "--fastpurge-host",
+            "fakehost-xxx.example.net",
+            "--fastpurge-client-secret",
+            "abcdef",
+            "--fastpurge-client-token",
+            "efg",
+            "--fastpurge-access-token",
+            "tok",
+            "--fastpurge-root-url",
+            "https://cdn.example.com/",
+            "--udcache-url",
+            "https://ud.example.com/",
+            "--verbose",
+            "some-filerepo",
+        ],
+    )
+
+    # It should record that it removed these push items:
+    assert sorted(fake_collector.items, key=lambda pi: pi["filename"]) == [
+        {
+            "state": "DELETED",
+            "origin": "pulp",
+            "filename": "hello.txt",
+            "checksums": {"sha256": "a" * 64},
+        },
+        {
+            "state": "DELETED",
+            "origin": "pulp",
+            "filename": "with/subdir.json",
+            "checksums": {"sha256": "b" * 64},
+        },
+    ]
+
+    # It should have published the Pulp repo
+    assert [hist.repository.id for hist in fakepulp.publish_history] == [
+        "some-filerepo"
+    ]
+
+    # It should have flushed these URLs
+    assert sorted(task_instance.fastpurge_client.purged_urls) == [
+        "https://cdn.example.com/some/publish/url/mutable1",
+        "https://cdn.example.com/some/publish/url/mutable2",
+    ]
+
+    # It should have flushed these UD objects
+    assert task_instance.udcache_client.flushed_repos == ["some-filerepo"]
+    assert task_instance.udcache_client.flushed_products == [123]
+
+
+def test_clear_file_skip_publish(command_tester):
+    """Clearing a repo with file content while skipping publish succeeds."""
+
+    task_instance = FakeClearRepo()
+
+    repo = FileRepository(
+        id="some-filerepo",
+        eng_product_id=123,
+        relative_url="some/publish/url",
+        mutable_urls=[],
+    )
+
+    files = [FileUnit(path="hello.txt", size=123, sha256sum="a" * 64)]
+
+    task_instance.pulp_client_controller.insert_repository(repo)
+    task_instance.pulp_client_controller.insert_units(repo, files)
+
+    # It should run with expected output.
+    command_tester.test(
+        task_instance.main,
+        [
+            "test-clear-repo",
+            "--pulp-url",
+            "https://pulp.example.com/",
+            "--skip",
+            "foo,publish,bar",
+            "--verbose",
+            "some-filerepo",
+        ],
+    )
+
+    # It should not have published Pulp repos
+    assert task_instance.pulp_client_controller.publish_history == []
+
+
+def test_clear_yum_repo(command_tester, fake_collector, monkeypatch):
+    """Clearing a repo with yum content succeeds."""
+
+    task_instance = FakeClearRepo()
+
+    repo = YumRepository(
+        id="some-yumrepo", relative_url="some/publish/url", mutable_urls=["repomd.xml"]
+    )
+
+    files = [
+        RpmUnit(
+            name="bash",
+            version="1.23",
+            release="1.test8",
+            arch="x86_64",
+            sha256sum="a" * 64,
+            md5sum="b" * 32,
+            signing_key="aabbcc",
+        ),
+        ModulemdUnit(
+            name="mymod", stream="s1", version=123, context="a1c2", arch="s390x"
+        ),
+    ]
+
+    task_instance.pulp_client_controller.insert_repository(repo)
+    task_instance.pulp_client_controller.insert_units(repo, files)
+
+    # Let's try setting the cache flush root via env.
+    monkeypatch.setenv("FASTPURGE_ROOT_URL", "https://cdn.example2.com/")
+
+    # It should run with expected output.
+    command_tester.test(
+        task_instance.main,
+        [
+            "test-clear-repo",
+            "--pulp-url",
+            "https://pulp.example.com/",
+            "--verbose",
+            "--fastpurge-host",
+            "fakehost-xxx.example.net",
+            "--fastpurge-client-secret",
+            "abcdef",
+            "--fastpurge-client-token",
+            "efg",
+            "--fastpurge-access-token",
+            "tok",
+            "some-yumrepo",
+        ],
+    )
+
+    # It should record that it removed these push items:
+    assert sorted(fake_collector.items, key=lambda pi: pi["filename"]) == [
+        {
+            "state": "DELETED",
+            "origin": "pulp",
+            "filename": "bash-1.23-1.test8.x86_64.rpm",
+            "checksums": {"sha256": "a" * 64, "md5": "b" * 32},
+            "signing_key": "aabbcc",
+        },
+        {"state": "DELETED", "origin": "pulp", "filename": "mymod:s1:123:a1c2:s390x"},
+    ]
+
+    # It should have flushed these URLs
+    assert task_instance.fastpurge_client.purged_urls == [
+        "https://cdn.example2.com/some/publish/url/repomd.xml"
+    ]
+
+
+def test_clear_container_repo(command_tester):
+    """Clearing a container image repo is not allowed."""
+
+    task_instance = FakeClearRepo()
+
+    repo = ContainerImageRepository(id="some-containerrepo")
+
+    task_instance.pulp_client_controller.insert_repository(repo)
+
+    # It should run with expected output.
+    command_tester.test(
+        task_instance.main,
+        [
+            "test-clear-repo",
+            "--pulp-url",
+            "https://pulp.example.com/",
+            "--verbose",
+            "some-containerrepo",
+        ],
+    )

--- a/tests/collector.py
+++ b/tests/collector.py
@@ -1,0 +1,19 @@
+class FakeCollector(object):
+    """Fake backend for PushCollector.
+
+    Tests can access the attributes on this collector to see
+    which push items & files were created during a task.
+    """
+
+    def __init__(self):
+        self.items = []
+        self.file_content = {}
+
+    def update_push_items(self, items):
+        self.items.extend(items)
+
+    def attach_file(self, filename, content):
+        self.file_content[filename] = content
+
+    def append_file(self, filename, content):
+        self.file_content[filename] = self.file_content.get(filename, b"") + content

--- a/tests/command.py
+++ b/tests/command.py
@@ -1,0 +1,146 @@
+"""Helpers for testing commands."""
+from __future__ import print_function
+import logging
+import sys
+import os
+import traceback
+import json
+import difflib
+
+LOGS_DIR = os.path.join(os.path.dirname(__file__), "logs")
+
+
+class CommandTester(object):
+    """CommandTester is a helper class to run a command, capture its output and
+    compare against expected.
+
+    An instance may be obtained via command_tester fixture.
+    """
+
+    def __init__(self, node, caplog):
+        self._node = node
+        self._caplog = caplog
+
+    def test(self, fn, args):
+        """Put args into sys.argv, then test the given function.
+
+        Logs at INFO level and higher will be captured and compared against
+        test data under "test/logs" directory. 'extra' metadata in logs will
+        also be tested using JSONL files.
+
+        To update test logs in case of an intentional change, set the
+        UPDATE_BASELINES environment variable to 1.
+        """
+        self._caplog.set_level(logging.INFO)
+
+        sys.argv[:] = args
+        exception = None
+        try:
+            fn()
+        except AssertionError:
+            # Let these raise directly
+            raise
+        except SystemExit as ex:
+            exception = ex
+        except Exception as ex:
+            traceback.print_exc()
+            exception = ex
+
+        records = self._caplog.records
+        self._compare_outcome(records, exception)
+
+    @property
+    def logfile_basename(self):
+        out = self._node.nodeid
+
+        # Example node ID:
+        #   tests/clear_repo/test_clear_repo.py::test_typical
+        #
+        # Desired output:
+        #   <logdir>/clear_repo/test_clear_repo/test_typical
+        #
+        if out.startswith("tests/"):
+            out = out[len("tests/") :]
+        out = out.replace(".py", "")
+        out = out.replace("::", "/")
+
+        return os.path.join(LOGS_DIR, out)
+
+    def _get_actual_plaintext(self, records):
+        out = ""
+        for record in records:
+            out += "[%8s] %s\n" % (record.levelname, record.message)
+        return out
+
+    def _get_actual_jsonl(self, records):
+        out = []
+        for record in records:
+            if hasattr(record, "event"):
+                out.append({"event": record.event})
+
+        return "\n".join([json.dumps(x) for x in out])
+
+    def _update_baseline(self, filename, content):
+        if not content:
+            # Don't bother creating empty files for tests with no output
+            return
+
+        dirname = os.path.dirname(filename)
+        if not os.path.exists(dirname):
+            os.makedirs(dirname)
+
+        open(filename, "wt").write(content)
+
+    def _compare_expected(self, text, suffix, exception=None):
+        filename = self.logfile_basename + suffix
+        expected_content = None
+
+        if not text.endswith("\n"):
+            text += "\n"
+
+        if os.path.exists(filename):
+            expected_content = open(filename, "rt").read()
+
+        if expected_content != text:
+            if (
+                os.environ.get("UPDATE_BASELINES", "0") == "1"
+                or expected_content is None
+            ):
+                return self._update_baseline(filename, text)
+
+            from_lines = expected_content.split("\n")
+            to_lines = text.split("\n")
+            diff = difflib.unified_diff(
+                from_lines,
+                to_lines,
+                fromfile="<output of test>",
+                tofile=filename,
+                lineterm="",
+            )
+            diff = list(diff)
+
+            exception_changed = diff[-2].startswith("+# Raised:")
+            diff = "\n".join(diff)
+            message = (
+                "Output differs from expected (set UPDATE_BASELINES=1 if intended):\n"
+                + diff
+            )
+
+            if exception_changed and exception:
+                # if exception differs from expected, re-raise it for the sake of
+                # a meaningful backtrace and ability to run "py.test --pdb"
+                print(message)
+                raise exception
+
+            raise AssertionError(message)
+
+    def _compare_outcome(self, records, exception):
+
+        plaintext = self._get_actual_plaintext(records)
+        if exception:
+            plaintext += "# Raised: %s\n" % exception
+
+        self._compare_expected(plaintext, ".txt", exception)
+
+        jsonl = self._get_actual_jsonl(records)
+        self._compare_expected(jsonl, ".jsonl")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,72 @@
+import sys
+
+import requests_mock
+import pytest
+
+from pushcollector import Collector
+
+from .command import CommandTester
+from .collector import FakeCollector
+
+
+@pytest.fixture(autouse=True)
+def save_argv():
+    """Saves and restores sys.argv around each test.
+
+    This is an autouse fixture, so tests can freely modify
+    sys.argv without concern.
+    """
+    orig_argv = sys.argv[:]
+    yield
+    sys.argv[:] = orig_argv
+
+
+@pytest.fixture(autouse=True)
+def home_tmpdir(tmpdir, monkeypatch):
+    """Points HOME environment variable underneath tmpdir
+    for the duration of tests.
+
+    This is an autouse fixture because certain used libraries
+    are influenced by files under $HOME, and for tests which
+    actually need it, we should explicitly set up anything
+    needed there instead of inheriting the user's environment.
+    """
+    homedir = str(tmpdir.mkdir("home"))
+    monkeypatch.setenv("HOME", homedir)
+
+
+@pytest.fixture(autouse=True)
+def requests_mocker():
+    """Mock all requests.
+
+    This is an autouse fixture so that tests can't accidentally
+    perform real requests without being noticed.
+    """
+    with requests_mock.Mocker() as m:
+        yield m
+
+
+@pytest.fixture(autouse=True)
+def fake_collector():
+    """Install fake in-memory backend for pushcollector library.
+    Recorded push items can be tested via this instance.
+
+    This is an autouse fixture so that all tests will automatically
+    use the fake backend.
+    """
+    collector = FakeCollector()
+
+    Collector.register_backend("pubtools-pulp-test", lambda: collector)
+    Collector.set_default_backend("pubtools-pulp-test")
+
+    yield collector
+
+    Collector.set_default_backend(None)
+
+
+@pytest.fixture
+def command_tester(request, caplog):
+    """Yields a configured instance of CommandTester class for
+    running commands and testing output against expected.
+    """
+    yield CommandTester(request.node, caplog)

--- a/tests/garbage_collect/test_garbage_collect.py
+++ b/tests/garbage_collect/test_garbage_collect.py
@@ -31,13 +31,17 @@ def _get_fake_controller(*args):
     return controller
 
 
+def _patch_pulp_client(client):
+    return patch("pubtools._pulp.services.PulpClientService.pulp_client", client)
+
+
 def _run_test(*repos):
     controller = _get_fake_controller(*repos)
     gc = GarbageCollect()
     arg = ["", "--pulp-url", "http://some.url", "--verbose"]
 
     with patch("sys.argv", arg):
-        with patch("pubtools._pulp.task.PulpTask.pulp_client", controller.client):
+        with _patch_pulp_client(controller.client):
             gc.main()
     return controller
 
@@ -110,7 +114,7 @@ def test_gc_error(mock_logger):
 
     with patch("sys.argv", arg):
         with patch.object(controller.client, "_delete_repository") as repo_delete:
-            with patch("pubtools._pulp.task.PulpTask.pulp_client", controller.client):
+            with _patch_pulp_client(controller.client):
                 repo_delete.return_value = f_return(
                     [
                         Task(
@@ -138,7 +142,7 @@ def test_entry_point(mock_logger):
     arg = ["", "--pulp-url", "http://some.url", "--verbose"]
 
     with patch("sys.argv", arg):
-        with patch("pubtools._pulp.task.PulpTask.pulp_client", controller.client):
+        with _patch_pulp_client(controller.client):
             entry_point()
 
     mock_logger.info.assert_any_call(

--- a/tests/logs/clear_repo/test_clear_repo/test_clear_container_repo.jsonl
+++ b/tests/logs/clear_repo/test_clear_repo/test_clear_container_repo.jsonl
@@ -1,0 +1,2 @@
+{"event": {"type": "check-repos-start"}}
+{"event": {"type": "check-repos-error"}}

--- a/tests/logs/clear_repo/test_clear_repo/test_clear_container_repo.txt
+++ b/tests/logs/clear_repo/test_clear_repo/test_clear_container_repo.txt
@@ -1,0 +1,4 @@
+[    INFO] Check repos: started
+[   ERROR] Container image repo(s) provided, not supported: some-containerrepo
+[   ERROR] Check repos: failed
+# Raised: 30

--- a/tests/logs/clear_repo/test_clear_repo/test_clear_empty_repo.jsonl
+++ b/tests/logs/clear_repo/test_clear_repo/test_clear_empty_repo.jsonl
@@ -1,0 +1,12 @@
+{"event": {"type": "check-repos-start"}}
+{"event": {"type": "check-repos-end"}}
+{"event": {"type": "clear-content-start"}}
+{"event": {"type": "clear-content-end"}}
+{"event": {"type": "record-push-items-start"}}
+{"event": {"type": "record-push-items-end"}}
+{"event": {"type": "publish-start"}}
+{"event": {"type": "publish-end"}}
+{"event": {"type": "flush-ud-cache-start"}}
+{"event": {"type": "flush-ud-cache-end"}}
+{"event": {"type": "flush-cdn-cache-start"}}
+{"event": {"type": "flush-cdn-cache-end"}}

--- a/tests/logs/clear_repo/test_clear_repo/test_clear_empty_repo.txt
+++ b/tests/logs/clear_repo/test_clear_repo/test_clear_empty_repo.txt
@@ -1,0 +1,15 @@
+[    INFO] Check repos: started
+[    INFO] Check repos: finished
+[    INFO] Clear content: started
+[ WARNING] some-filerepo: no content removed, tasks: e3e70682-c209-4cac-629f-6fbed82c07cd
+[    INFO] Clear content: finished
+[    INFO] Record push items: started
+[    INFO] Record push items: finished
+[    INFO] Publish: started
+[    INFO] Publish: finished
+[    INFO] Flush UD cache: started
+[    INFO] UD cache flush is not enabled.
+[    INFO] Flush UD cache: finished
+[    INFO] Flush CDN cache: started
+[    INFO] CDN cache flush is not enabled.
+[    INFO] Flush CDN cache: finished

--- a/tests/logs/clear_repo/test_clear_repo/test_clear_file_repo.jsonl
+++ b/tests/logs/clear_repo/test_clear_repo/test_clear_file_repo.jsonl
@@ -1,0 +1,12 @@
+{"event": {"type": "check-repos-start"}}
+{"event": {"type": "check-repos-end"}}
+{"event": {"type": "clear-content-start"}}
+{"event": {"type": "clear-content-end"}}
+{"event": {"type": "record-push-items-start"}}
+{"event": {"type": "record-push-items-end"}}
+{"event": {"type": "publish-start"}}
+{"event": {"type": "publish-end"}}
+{"event": {"type": "flush-ud-cache-start"}}
+{"event": {"type": "flush-ud-cache-end"}}
+{"event": {"type": "flush-cdn-cache-start"}}
+{"event": {"type": "flush-cdn-cache-end"}}

--- a/tests/logs/clear_repo/test_clear_repo/test_clear_file_repo.txt
+++ b/tests/logs/clear_repo/test_clear_repo/test_clear_file_repo.txt
@@ -1,0 +1,13 @@
+[    INFO] Check repos: started
+[    INFO] Check repos: finished
+[    INFO] Clear content: started
+[    INFO] some-filerepo: removed 2 iso(s), tasks: e3e70682-c209-4cac-629f-6fbed82c07cd
+[    INFO] Clear content: finished
+[    INFO] Record push items: started
+[    INFO] Record push items: finished
+[    INFO] Publish: started
+[    INFO] Publish: finished
+[    INFO] Flush UD cache: started
+[    INFO] Flush UD cache: finished
+[    INFO] Flush CDN cache: started
+[    INFO] Flush CDN cache: finished

--- a/tests/logs/clear_repo/test_clear_repo/test_clear_file_skip_publish.jsonl
+++ b/tests/logs/clear_repo/test_clear_repo/test_clear_file_skip_publish.jsonl
@@ -1,0 +1,11 @@
+{"event": {"type": "check-repos-start"}}
+{"event": {"type": "check-repos-end"}}
+{"event": {"type": "clear-content-start"}}
+{"event": {"type": "clear-content-end"}}
+{"event": {"type": "record-push-items-start"}}
+{"event": {"type": "record-push-items-end"}}
+{"event": {"type": "publish-skip"}}
+{"event": {"type": "flush-ud-cache-start"}}
+{"event": {"type": "flush-ud-cache-end"}}
+{"event": {"type": "flush-cdn-cache-start"}}
+{"event": {"type": "flush-cdn-cache-end"}}

--- a/tests/logs/clear_repo/test_clear_repo/test_clear_file_skip_publish.txt
+++ b/tests/logs/clear_repo/test_clear_repo/test_clear_file_skip_publish.txt
@@ -1,0 +1,14 @@
+[    INFO] Check repos: started
+[    INFO] Check repos: finished
+[    INFO] Clear content: started
+[    INFO] some-filerepo: removed 1 iso(s), tasks: e3e70682-c209-4cac-629f-6fbed82c07cd
+[    INFO] Clear content: finished
+[    INFO] Record push items: started
+[    INFO] Record push items: finished
+[    INFO] Publish: skipped
+[    INFO] Flush UD cache: started
+[    INFO] UD cache flush is not enabled.
+[    INFO] Flush UD cache: finished
+[    INFO] Flush CDN cache: started
+[    INFO] CDN cache flush is not enabled.
+[    INFO] Flush CDN cache: finished

--- a/tests/logs/clear_repo/test_clear_repo/test_clear_yum_repo.jsonl
+++ b/tests/logs/clear_repo/test_clear_repo/test_clear_yum_repo.jsonl
@@ -1,0 +1,12 @@
+{"event": {"type": "check-repos-start"}}
+{"event": {"type": "check-repos-end"}}
+{"event": {"type": "clear-content-start"}}
+{"event": {"type": "clear-content-end"}}
+{"event": {"type": "record-push-items-start"}}
+{"event": {"type": "record-push-items-end"}}
+{"event": {"type": "publish-start"}}
+{"event": {"type": "publish-end"}}
+{"event": {"type": "flush-ud-cache-start"}}
+{"event": {"type": "flush-ud-cache-end"}}
+{"event": {"type": "flush-cdn-cache-start"}}
+{"event": {"type": "flush-cdn-cache-end"}}

--- a/tests/logs/clear_repo/test_clear_repo/test_clear_yum_repo.txt
+++ b/tests/logs/clear_repo/test_clear_repo/test_clear_yum_repo.txt
@@ -1,0 +1,14 @@
+[    INFO] Check repos: started
+[    INFO] Check repos: finished
+[    INFO] Clear content: started
+[    INFO] some-yumrepo: removed 1 modulemd(s), 1 rpm(s), tasks: e3e70682-c209-4cac-629f-6fbed82c07cd
+[    INFO] Clear content: finished
+[    INFO] Record push items: started
+[    INFO] Record push items: finished
+[    INFO] Publish: started
+[    INFO] Publish: finished
+[    INFO] Flush UD cache: started
+[    INFO] UD cache flush is not enabled.
+[    INFO] Flush UD cache: finished
+[    INFO] Flush CDN cache: started
+[    INFO] Flush CDN cache: finished

--- a/tests/logs/clear_repo/test_clear_repo/test_missing_repos.jsonl
+++ b/tests/logs/clear_repo/test_clear_repo/test_missing_repos.jsonl
@@ -1,0 +1,2 @@
+{"event": {"type": "check-repos-start"}}
+{"event": {"type": "check-repos-error"}}

--- a/tests/logs/clear_repo/test_clear_repo/test_missing_repos.txt
+++ b/tests/logs/clear_repo/test_clear_repo/test_missing_repos.txt
@@ -1,0 +1,4 @@
+[    INFO] Check repos: started
+[   ERROR] Requested repo(s) don't exist: repo1, repo2, repo3
+[   ERROR] Check repos: failed
+# Raised: 30

--- a/tests/shared/test_pulp_task.py
+++ b/tests/shared/test_pulp_task.py
@@ -5,6 +5,11 @@ from mock import Mock, patch
 
 from pubtools.pulplib import Client
 from pubtools._pulp.task import PulpTask
+from pubtools._pulp.services import PulpClientService
+
+
+class TaskWithPulpClient(PulpTask, PulpClientService):
+    pass
 
 
 def test_task_run():
@@ -16,7 +21,7 @@ def test_task_run():
 
 def test_init_args():
     """Checks whether the args from cli are available for the task"""
-    task = PulpTask()
+    task = TaskWithPulpClient()
     arg = ["", "--pulp-url", "http://some.url", "--verbose", "--debug"]
     with patch("sys.argv", arg):
         task_args = task.args
@@ -28,7 +33,7 @@ def test_init_args():
 
 def test_pulp_client():
     """Checks that the client in the task is an instance of pubtools.pulplib.Client"""
-    task = PulpTask()
+    task = TaskWithPulpClient()
     arg = ["", "--pulp-url", "http://some.url", "--pulp-user", "user"]
     with patch("sys.argv", arg):
         client = task.pulp_client
@@ -40,7 +45,7 @@ def test_main():
     """Checks main returns without exception when invoked with minimal args
         assuming run() and add_args() are implemented
     """
-    task = PulpTask()
+    task = TaskWithPulpClient()
     arg = ["", "--pulp-url", "http://some.url", "--verbose", "--debug"]
     with patch("sys.argv", arg):
         with patch("pubtools._pulp.task.PulpTask.run"):

--- a/tests/shared/test_task_interface.py
+++ b/tests/shared/test_task_interface.py
@@ -4,7 +4,9 @@ import sys
 import pytest
 
 
-@pytest.fixture(params=["pubtools._pulp.tasks.garbage_collect"])
+@pytest.fixture(
+    params=["pubtools._pulp.tasks.garbage_collect", "pubtools._pulp.tasks.clear_repo"]
+)
 def task_module(request):
     __import__(request.param)
     return sys.modules[request.param]

--- a/tests/step/test_step_logging.py
+++ b/tests/step/test_step_logging.py
@@ -1,0 +1,183 @@
+from concurrent.futures import Future
+import logging
+import sys
+
+import pytest
+
+from pubtools._pulp.task import PulpTask
+
+step = PulpTask.step
+
+
+class SimulatedError(RuntimeError):
+    pass
+
+
+class FakeTask(object):
+    @property
+    def args(self):
+        # Not a real task, no args from user
+        return object()
+
+    @step("fail if neq")
+    def fail_if_neq(self, x, y):
+        if x != y:
+            raise SimulatedError()
+
+    @step("future in-out")
+    def future_in_out(self, f, fail=False):
+        if fail:
+            raise SimulatedError()
+        return Future()
+
+    @step("exit with code")
+    def exit_with_code(self, code):
+        sys.exit(code)
+
+    @step("future in-out list")
+    def future_in_out_list(self, f):
+        return [Future(), Future()]
+
+
+def test_success(caplog):
+    """Plain blocking step should log when entered/exited"""
+
+    caplog.set_level(logging.INFO)
+    task = FakeTask()
+    task.fail_if_neq(1, 1)
+
+    assert caplog.messages == ["fail if neq: started", "fail if neq: finished"]
+
+
+def test_fail(caplog):
+    """Plain blocking step should log when entered/failed"""
+
+    caplog.set_level(logging.INFO)
+    task = FakeTask()
+
+    with pytest.raises(SimulatedError):
+        task.fail_if_neq(1, 2)
+
+    assert caplog.messages == ["fail if neq: started", "fail if neq: failed"]
+
+
+def test_future_logging(caplog):
+    """Step taking/returning future should log when futures progress"""
+
+    caplog.set_level(logging.INFO)
+
+    task = FakeTask()
+
+    in_fs = [Future(), Future()]
+    out_f = task.future_in_out(in_fs)
+
+    # The step shouldn't be counted as entered yet.
+    assert caplog.messages == []
+
+    # If *any* input future is resolved, then the step counts as started,
+    # but not yet finished.
+    in_fs[0].set_result(None)
+    assert caplog.messages == ["future in-out: started"]
+
+    # There should not be duplicate logs when other input futures resolve.
+    in_fs[1].set_result(None)
+    assert caplog.messages == ["future in-out: started"]
+
+    # If the output future is resolved, then the step counts as finished.
+    out_f.set_result(None)
+    assert caplog.messages == ["future in-out: started", "future in-out: finished"]
+
+
+def test_future_output_failed(caplog):
+    """Step returning future should log when output fails"""
+
+    caplog.set_level(logging.INFO)
+
+    task = FakeTask()
+
+    in_f = Future()
+    in_f.set_result("abc")
+
+    out_f = task.future_in_out(in_f)
+
+    # It's now in progress.
+    assert caplog.messages == ["future in-out: started"]
+
+    # If the output future is failed, then step is considered failed
+    out_f.set_exception(SimulatedError())
+    assert caplog.messages == ["future in-out: started", "future in-out: failed"]
+
+
+def test_future_list_failed(caplog):
+    """Step returning list of futures should log when any fails"""
+
+    caplog.set_level(logging.INFO)
+
+    task = FakeTask()
+
+    in_f = Future()
+    out_fs = task.future_in_out_list(in_f)
+
+    # No logs yet.
+    assert caplog.messages == []
+
+    # If the output future is failed, then step is immediately considered failed
+    out_fs[0].set_exception(SimulatedError())
+    assert caplog.messages == [
+        "future in-out list: started",
+        "future in-out list: failed",
+    ]
+
+    # Nothing changes if another future completes.
+    out_fs[1].set_result(None)
+    assert caplog.messages == [
+        "future in-out list: started",
+        "future in-out list: failed",
+    ]
+
+
+def test_future_fails_not_started(caplog):
+    """Step which immediately fails given incomplete futures should have coherent logs"""
+
+    caplog.set_level(logging.INFO)
+
+    task = FakeTask()
+
+    in_f = Future()
+    with pytest.raises(SimulatedError):
+        task.future_in_out(in_f, fail=True)
+
+    # Although it takes a future which is not resolved yet,
+    # it's immediately marked as both started & failed due
+    # to the exception being raised
+    assert caplog.messages == ["future in-out: started", "future in-out: failed"]
+
+    # Input future being resolved doesn't change the logs at all.
+    in_f.set_result(None)
+    assert caplog.messages == ["future in-out: started", "future in-out: failed"]
+
+
+def test_exit_success(caplog):
+    """Step exiting successfully is considered finished"""
+
+    caplog.set_level(logging.INFO)
+
+    task = FakeTask()
+
+    with pytest.raises(SystemExit):
+        task.exit_with_code(0)
+
+    assert caplog.messages == ["exit with code: started", "exit with code: finished"]
+
+
+def test_exit_fail(caplog):
+    """Step exiting unsuccessfully is considered failed"""
+
+    caplog.set_level(logging.INFO)
+
+    task = FakeTask()
+
+    with pytest.raises(SystemExit):
+        task.exit_with_code(123)
+
+    assert caplog.messages == ["exit with code: started", "exit with code: failed"]

--- a/tests/ud/test_ud_cache_client.py
+++ b/tests/ud/test_ud_cache_client.py
@@ -1,0 +1,78 @@
+import logging
+
+
+from pubtools._pulp.ud import UdCacheClient
+
+
+def test_flush(requests_mock):
+    """Client flushes by hitting expected URLs."""
+
+    client = UdCacheClient("https://ud.example.com/", auth=("user", "pass"))
+
+    urls = [
+        "https://ud.example.com/internal/rcm/flush-cache/eng-product/some-product",
+        "https://ud.example.com/internal/rcm/flush-cache/repo/some-repo",
+    ]
+
+    for url in urls:
+        requests_mock.register_uri("GET", url)
+
+    # It should succeed
+    client.flush_product("some-product").result()
+    client.flush_repo("some-repo").result()
+
+    # It should have called above two URLs
+    fetched_urls = [req.url for req in requests_mock.request_history]
+    assert fetched_urls == urls
+
+
+def test_retries(requests_mock):
+    """Client retries automatically on error."""
+
+    client = UdCacheClient(
+        "https://ud.example.com/", auth=("user", "pass"), max_retry_sleep=0.001
+    )
+
+    url = "https://ud.example.com/internal/rcm/flush-cache/repo/some-repo"
+
+    requests_mock.register_uri(
+        "GET",
+        url,
+        [
+            # Fails on first try
+            {"status_code": 500},
+            # Then succeeds
+            {"status_code": 200},
+        ],
+    )
+
+    # It should succeed due to retrying
+    client.flush_repo("some-repo").result()
+
+    # It should have called above URL twice
+    fetched_urls = [req.url for req in requests_mock.request_history]
+    assert fetched_urls == [url] * 2
+
+
+def test_logs(requests_mock, caplog):
+    """Client produces logs before/after requests."""
+
+    caplog.set_level(logging.INFO)
+
+    client = UdCacheClient(
+        "https://ud.example.com/", auth=("user", "pass"), max_retry_sleep=0.001
+    )
+
+    url = "https://ud.example.com/internal/rcm/flush-cache/repo/some-repo"
+
+    requests_mock.register_uri("GET", url, status_code=500)
+
+    # It should eventually fail with the HTTP error
+    exception = client.flush_repo("some-repo").exception()
+    assert "500 Server Error" in str(exception)
+
+    # It should have logged what it was doing and what failed
+    assert caplog.messages == [
+        "Invalidating repo some-repo",
+        "Invalidating repo some-repo failed: %s" % exception,
+    ]


### PR DESCRIPTION
Implements the clear-repo workflow, which is:

- delete all content of selected type(s) from selected Pulp repo(s)
- record info on deleted push items
- publish the repos
- do UD cache flushing
- do CDN cache flushing

A few refactors were made and (internal) features added to support
this new task:

- `@step` decorator applies standard plaintext and machine-readable
  logs around discrete workflow steps.  Supports blocking and
  non-blocking coding styles.

- Service classes were introduced to encapsulate the creation of
  a particular service based on command-line arguments. Tasks should
  inherit from the Services they want to use. For example, if a task
  needs to use fast purge, it should inherit FastPurgeClientService
  to add all needed command line arguments and properties.

- Simple UD cache flushing client was added

- CommandTester helper class was added to make it easy to write
  log-based tests (see test/logs included in this commit).