### PR TITLE
Introduce set maintenance commands

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -12,3 +12,4 @@ content via `Pulp <https://pulpproject.org/>`_.
 
    clear-repo
    garbage-collect
+   set-maintenance

--- a/docs/set-maintenance.rst
+++ b/docs/set-maintenance.rst
@@ -20,7 +20,7 @@ A typical invocation of set maintenance would look like this:
     --pulp-url https://pulp.example.com/ \
     --pulp-user admin \
     --pulp-password XXXXX \
-    --repo-id example-repo
+    --repo-ids example-repo
 
 In this example, the repository with id 'example-repo' will be set to
 maintenance mode.
@@ -45,7 +45,7 @@ A typical invocation of unset maintenance would look like this:
     --pulp-url https://pulp.example.com/ \
     --pulp-user admin \
     --pulp-password XXXXX \
-    --repo-id example-repo
+    --repo-ids example-repo
 
 In this example, the repository with id 'example-repo' will be removed
 from maintenance mode.

--- a/docs/set-maintenance.rst
+++ b/docs/set-maintenance.rst
@@ -1,0 +1,51 @@
+set-maintenance
+===============
+
+Set Maintenance On
+-------------------
+
+.. argparse::
+   :module: pubtools._pulp.tasks.set_maintenance.set_maintenance_on
+   :func: doc_parser
+   :prog: pubtools-pulp-maintenance-on
+
+Example
+.......
+
+A typical invocation of set maintenance would look like this:
+
+.. code-block::
+
+  pubtools-pulp-maintenance-on \
+    --pulp-url https://pulp.example.com/ \
+    --pulp-user admin \
+    --pulp-password XXXXX \
+    --repo-id example-repo
+
+In this example, the repository with id 'example-repo' will be set to
+maintenance mode.
+
+Set Maintenance Off
+-------------------
+
+.. argparse::
+   :module: pubtools._pulp.tasks.set_maintenance.set_maintenance_off
+   :func: doc_parser
+   :prog: pubtools-pulp-maintenance-off
+
+
+Example
+.......
+
+A typical invocation of unset maintenance would look like this:
+
+.. code-block::
+
+  pubtools-pulp-maintenance-off \
+    --pulp-url https://pulp.example.com/ \
+    --pulp-user admin \
+    --pulp-password XXXXX \
+    --repo-id example-repo
+
+In this example, the repository with id 'example-repo' will be removed
+from maintenance mode.

--- a/pubtools/_pulp/tasks/set_maintenance/__init__.py
+++ b/pubtools/_pulp/tasks/set_maintenance/__init__.py
@@ -1,0 +1,2 @@
+from .set_maintenance_off import SetMaintenanceOff
+from .set_maintenance_on import SetMaintenanceOn

--- a/pubtools/_pulp/tasks/set_maintenance/base.py
+++ b/pubtools/_pulp/tasks/set_maintenance/base.py
@@ -15,8 +15,8 @@ class SetMaintenance(PulpClientService, PulpTask):
         self.parser.add_argument("--owner", help="who sets/unsets maintenance mode")
 
         self.parser.add_argument(
-            "--repo-regex",
-            help="only set repositories matched this regex to maintenance mode",
+            "--repo-url-regex",
+            help="set repositories whose relative_url matches to this regex to maintenance mode",
         )
 
         self.parser.add_argument(

--- a/pubtools/_pulp/tasks/set_maintenance/base.py
+++ b/pubtools/_pulp/tasks/set_maintenance/base.py
@@ -1,4 +1,5 @@
 import logging
+import re
 
 from pubtools._pulp.task import PulpTask
 from pubtools._pulp.services import PulpClientService
@@ -16,7 +17,8 @@ class SetMaintenance(PulpClientService, PulpTask):
 
         self.parser.add_argument(
             "--repo-url-regex",
-            help="set repositories whose relative_url matches to this regex to maintenance mode",
+            help="adjust maintenance mode for repositories with a publish URL matching this pattern",
+            type=re.compile,
         )
 
         self.parser.add_argument(
@@ -42,6 +44,4 @@ class SetMaintenance(PulpClientService, PulpTask):
 
         report = self.adjust_maintenance_report(report)
 
-        tasks = self.set_maintenance(report).result()
-        task_ids = ", ".join([t.id for t in tasks])
-        LOG.info("Completed adjusting maintenance mode: %s", task_ids)
+        self.set_maintenance(report).result()

--- a/pubtools/_pulp/tasks/set_maintenance/base.py
+++ b/pubtools/_pulp/tasks/set_maintenance/base.py
@@ -1,0 +1,20 @@
+from pubtools._pulp.task import PulpTask
+from pubtools._pulp.services import PulpClientService
+
+
+class SetMaintenance(PulpClientService, PulpTask):
+    def add_args(self):
+        super(SetMaintenance, self).add_args()
+
+        self.parser.add_argument("--owner", help="who sets/unsets maintenance mode")
+
+        self.parser.add_argument(
+            "--repo-regex",
+            help="only set repositories matched this regex to maintenance mode",
+        )
+
+        self.parser.add_argument(
+            "--repo-ids",
+            nargs="+",
+            help="repository to be set/unset to maintenance mode",
+        )

--- a/pubtools/_pulp/tasks/set_maintenance/base.py
+++ b/pubtools/_pulp/tasks/set_maintenance/base.py
@@ -1,5 +1,11 @@
+import logging
+
 from pubtools._pulp.task import PulpTask
 from pubtools._pulp.services import PulpClientService
+
+
+step = PulpTask.step
+LOG = logging.getLogger("set-maintenance")
 
 
 class SetMaintenance(PulpClientService, PulpTask):
@@ -18,3 +24,24 @@ class SetMaintenance(PulpClientService, PulpTask):
             nargs="+",
             help="repository to be set/unset to maintenance mode",
         )
+
+    @step("Get maintenance report")
+    def get_maintenance_report(self):
+        return self.pulp_client.get_maintenance_report()
+
+    @step("Adjust maintenance report")
+    def adjust_maintenance_report(self, report):
+        raise NotImplementedError
+
+    @step("Set maintenance report")
+    def set_maintenance(self, report):
+        return self.pulp_client.set_maintenance(report)
+
+    def run(self):
+        report = self.get_maintenance_report().result()
+
+        report = self.adjust_maintenance_report(report)
+
+        tasks = self.set_maintenance(report).result()
+        task_ids = ", ".join([t.id for t in tasks])
+        LOG.info("Completed adjusting maintenance mode: %s", task_ids)

--- a/pubtools/_pulp/tasks/set_maintenance/set_maintenance_off.py
+++ b/pubtools/_pulp/tasks/set_maintenance/set_maintenance_off.py
@@ -1,0 +1,48 @@
+import logging
+import re
+
+from .base import SetMaintenance
+
+
+LOG = logging.getLogger("set-maintenance")
+
+
+class SetMaintenanceOff(SetMaintenance):
+    """Unset repositories maintenance mode.
+
+    See "pub maintenance-on --help" for more information on maintenance mode.
+    """
+
+    def run(self):
+        report = self.pulp_client.get_maintenance_report().result()
+
+        to_remove = []
+        if self.args.repo_regex:
+            for entry in report.entries:
+                if re.match(self.args.repo_regex, entry.repo_id):
+                    to_remove.append(entry.repo_id)
+        if self.args.repo_ids:
+            existed_repo_ids = [entry.repo_id for entry in report.entries]
+            for repo_id in self.args.repo_ids:
+
+                if repo_id in existed_repo_ids:
+                    to_remove.append(repo_id)
+                else:
+                    LOG.warn("Repository %s is not in Maintenance Mode", repo_id)
+
+        LOG.info(
+            "Following repositories will be removed from Maintenance Mode: \n%s",
+            "\n".join(to_remove),
+        )
+
+        report = report.remove(to_remove, owner=self.args.owner)
+
+        self.pulp_client.set_maintenance(report).result()
+
+
+def entry_point():
+    SetMaintenanceOff().main()
+
+
+def doc_parser():
+    return SetMaintenanceOff().parser

--- a/pubtools/_pulp/tasks/set_maintenance/set_maintenance_off.py
+++ b/pubtools/_pulp/tasks/set_maintenance/set_maintenance_off.py
@@ -2,20 +2,18 @@ import logging
 import re
 
 from .base import SetMaintenance
+from pubtools._pulp.task import PulpTask
 
 
+step = PulpTask.step
 LOG = logging.getLogger("set-maintenance")
 
 
 class SetMaintenanceOff(SetMaintenance):
-    """Unset repositories maintenance mode.
+    """Unset repositories maintenance mode."""
 
-    See "pub maintenance-on --help" for more information on maintenance mode.
-    """
-
-    def run(self):
-        report = self.pulp_client.get_maintenance_report().result()
-
+    @step("Adjust maintenance report")
+    def adjust_maintenance_report(self, report):
         to_remove = []
         if self.args.repo_regex:
             for entry in report.entries:
@@ -28,20 +26,18 @@ class SetMaintenanceOff(SetMaintenance):
                 if repo_id in existed_repo_ids:
                     to_remove.append(repo_id)
                 else:
-                    LOG.warn("Repository %s is not in Maintenance Mode", repo_id)
-
+                    LOG.warning("Repository %s is not in maintenance mode", repo_id)
         LOG.info(
-            "Following repositories will be removed from Maintenance Mode: \n%s",
+            "Following repositories will be removed from maintenance mode: \n%s",
             "\n".join(to_remove),
         )
-
         report = report.remove(to_remove, owner=self.args.owner)
 
-        self.pulp_client.set_maintenance(report).result()
+        return report
 
 
-def entry_point():
-    SetMaintenanceOff().main()
+def entry_point(cls=SetMaintenanceOff):
+    cls().main()  # pragma: no cover
 
 
 def doc_parser():

--- a/pubtools/_pulp/tasks/set_maintenance/set_maintenance_off.py
+++ b/pubtools/_pulp/tasks/set_maintenance/set_maintenance_off.py
@@ -1,6 +1,8 @@
 import logging
 import re
 
+from pubtools.pulplib import Criteria
+
 from .base import SetMaintenance
 from pubtools._pulp.task import PulpTask
 
@@ -14,30 +16,39 @@ class SetMaintenanceOff(SetMaintenance):
 
     @step("Adjust maintenance report")
     def adjust_maintenance_report(self, report):
+        """Remove entries from maintenance report by repo ids or repo url regex or both"""
         to_remove = []
-        if self.args.repo_regex:
-            for entry in report.entries:
-                if re.match(self.args.repo_regex, entry.repo_id):
-                    to_remove.append(entry.repo_id)
-        if self.args.repo_ids:
-            existed_repo_ids = [entry.repo_id for entry in report.entries]
-            for repo_id in self.args.repo_ids:
+        existed_repo_ids = [entry.repo_id for entry in report.entries]
 
+        if self.args.repo_url_regex:
+            # search all repos with id existed in the report
+            existed_repos = self.pulp_client.search_repository(
+                Criteria.with_id(existed_repo_ids)
+            ).result()
+            for repo in existed_repos:
+                if repo.relative_url and re.search(
+                    self.args.repo_url_regex, repo.relative_url
+                ):
+                    to_remove.append(repo.id)
+        if self.args.repo_ids:
+            for repo_id in self.args.repo_ids:
                 if repo_id in existed_repo_ids:
                     to_remove.append(repo_id)
                 else:
                     LOG.warning("Repository %s is not in maintenance mode", repo_id)
-        LOG.info(
-            "Following repositories will be removed from maintenance mode: \n%s",
-            "\n".join(to_remove),
-        )
-        report = report.remove(to_remove, owner=self.args.owner)
+
+        if to_remove:
+            LOG.info("Following repositories will be removed from maintenance mode:")
+            for repo_id in to_remove:
+                LOG.info(" - %s", repo_id)
+
+            report = report.remove(to_remove, owner=self.args.owner)
 
         return report
 
 
 def entry_point(cls=SetMaintenanceOff):
-    cls().main()  # pragma: no cover
+    cls().main()
 
 
 def doc_parser():

--- a/pubtools/_pulp/tasks/set_maintenance/set_maintenance_on.py
+++ b/pubtools/_pulp/tasks/set_maintenance/set_maintenance_on.py
@@ -1,21 +1,20 @@
 import logging
 
 from pubtools.pulplib import Criteria, Matcher
-
+from pubtools._pulp.task import PulpTask
 from .base import SetMaintenance
 
+
+step = PulpTask.step
 
 LOG = logging.getLogger("set-maintenance")
 
 
 class SetMaintenanceOn(SetMaintenance):
     """Sets repositories into 'maintenance mode'.
+
     When a repository is in maintenance mode, publishing onto customer-visible locations
     should be forbidden.
-
-    Requires 'maintenance_mode' permission.
-
-    NOTE: Publishing is blocked both from Pub and from other commands when it's enabled.
     """
 
     def add_args(self):
@@ -25,41 +24,45 @@ class SetMaintenanceOn(SetMaintenance):
             "--message", help="Describes why set to maintenance mode"
         )
 
-    def run(self):
-        """Set repositories matched repo_ids and repo_regex to maintenance mode"""
-        report = self.pulp_client.get_maintenance_report().result()
+    @step("Adjust maintenance report")
+    def adjust_maintenance_report(self, report):
         repo_ids = []
         if self.args.repo_ids:
-            self._ensure_repos_exist(self.args.repo_ids)
-            repo_ids.extend(self.args.repo_ids)
+            found_ids = self._ensure_repos_exist(self.args.repo_ids)
+            repo_ids.extend(found_ids)
 
         if self.args.repo_regex:
             crit = Criteria.with_field("id", Matcher.regex(self.args.repo_regex))
             repos = self.pulp_client.search_repository(crit).result()
-            repo_ids.extend([repo.id for repo in repos.as_iter()])
+            repo_ids.extend([repo.id for repo in repos])
 
         report = report.add(repo_ids, owner=self.args.owner, message=self.args.message)
-
         LOG.info(
-            "Setting following repos to Maintenance Mode: \n%s", "\n".join(repo_ids)
+            "Setting following repos to maintenance mode: \n%s", "\n".join(repo_ids)
         )
 
-        self.pulp_client.set_maintenance(report).result()
+        return report
 
     def _ensure_repos_exist(self, repo_ids):
-        """Check if repositories are existed in Pulp server, if not, PulpException will
-        be raised.
+        """Checks if repositories are existed in Pulp server, if not, users will be warned and
+        corresponding ids will be removed.
         """
-        repo_ft = []
-        for repo in repo_ids:
-            repo_ft.append(self.pulp_client.get_repository(repo))
+        found_repos = self.pulp_client.search_repository(
+            Criteria.with_id(repo_ids)
+        ).result()
+        found_ids = [r.id for r in found_repos]
+        missing_ids = set(repo_ids) - set(found_ids)
 
-        for ft in repo_ft:
-            ft.result()
+        if missing_ids:
+            LOG.warning(
+                "Didn't find following repositories: \n%s", "\n".join(missing_ids)
+            )
+
+        return sorted(found_ids)
 
 
-def entry_point():
-    SetMaintenanceOn().main()
+def entry_point(cls=SetMaintenanceOn):
+    cls().main()  # pragma: no cover
 
 
 def doc_parser():

--- a/pubtools/_pulp/tasks/set_maintenance/set_maintenance_on.py
+++ b/pubtools/_pulp/tasks/set_maintenance/set_maintenance_on.py
@@ -1,0 +1,66 @@
+import logging
+
+from pubtools.pulplib import Criteria, Matcher
+
+from .base import SetMaintenance
+
+
+LOG = logging.getLogger("set-maintenance")
+
+
+class SetMaintenanceOn(SetMaintenance):
+    """Sets repositories into 'maintenance mode'.
+    When a repository is in maintenance mode, publishing onto customer-visible locations
+    should be forbidden.
+
+    Requires 'maintenance_mode' permission.
+
+    NOTE: Publishing is blocked both from Pub and from other commands when it's enabled.
+    """
+
+    def add_args(self):
+        super(SetMaintenanceOn, self).add_args()
+
+        self.parser.add_argument(
+            "--message", help="Describes why set to maintenance mode"
+        )
+
+    def run(self):
+        """Set repositories matched repo_ids and repo_regex to maintenance mode"""
+        report = self.pulp_client.get_maintenance_report().result()
+        repo_ids = []
+        if self.args.repo_ids:
+            self._ensure_repos_exist(self.args.repo_ids)
+            repo_ids.extend(self.args.repo_ids)
+
+        if self.args.repo_regex:
+            crit = Criteria.with_field("id", Matcher.regex(self.args.repo_regex))
+            repos = self.pulp_client.search_repository(crit).result()
+            repo_ids.extend([repo.id for repo in repos.as_iter()])
+
+        report = report.add(repo_ids, owner=self.args.owner, message=self.args.message)
+
+        LOG.info(
+            "Setting following repos to Maintenance Mode: \n%s", "\n".join(repo_ids)
+        )
+
+        self.pulp_client.set_maintenance(report).result()
+
+    def _ensure_repos_exist(self, repo_ids):
+        """Check if repositories are existed in Pulp server, if not, PulpException will
+        be raised.
+        """
+        repo_ft = []
+        for repo in repo_ids:
+            repo_ft.append(self.pulp_client.get_repository(repo))
+
+        for ft in repo_ft:
+            ft.result()
+
+
+def entry_point():
+    SetMaintenanceOn().main()
+
+
+def doc_parser():
+    return SetMaintenanceOn().parser

--- a/setup.py
+++ b/setup.py
@@ -44,6 +44,8 @@ setup(
         "console_scripts": [
             "pubtools-pulp-garbage-collect = pubtools._pulp.tasks.garbage_collect:entry_point",
             "pubtools-pulp-clear-repo = pubtools._pulp.tasks.clear_repo:entry_point",
+            "pubtools-pulp-maintenance-on = pubtools._pulp.tasks.set_maintenance.set_maintenance_on:entry_point",
+            "pubtools-pulp-maintenance-off = pubtools._pulp.tasks.set_maintenance.set_maintenance_off:entry_point",
         ]
     },
     project_urls={

--- a/tests/logs/set_maintenance/test_set_maintenance/test_maintenance_off.jsonl
+++ b/tests/logs/set_maintenance/test_set_maintenance/test_maintenance_off.jsonl
@@ -1,0 +1,6 @@
+{"event": {"type": "get-maintenance-report-start"}}
+{"event": {"type": "get-maintenance-report-end"}}
+{"event": {"type": "adjust-maintenance-report-start"}}
+{"event": {"type": "adjust-maintenance-report-end"}}
+{"event": {"type": "set-maintenance-report-start"}}
+{"event": {"type": "set-maintenance-report-end"}}

--- a/tests/logs/set_maintenance/test_set_maintenance/test_maintenance_off.txt
+++ b/tests/logs/set_maintenance/test_set_maintenance/test_maintenance_off.txt
@@ -6,4 +6,3 @@
 [    INFO] Adjust maintenance report: finished
 [    INFO] Set maintenance report: started
 [    INFO] Set maintenance report: finished
-[    INFO] Completed adjusting maintenance mode: f7b0b7d2-cda8-056c-3d15-eef738c1962e

--- a/tests/logs/set_maintenance/test_set_maintenance/test_maintenance_off.txt
+++ b/tests/logs/set_maintenance/test_set_maintenance/test_maintenance_off.txt
@@ -1,8 +1,8 @@
 [    INFO] Get maintenance report: started
 [    INFO] Get maintenance report: finished
 [    INFO] Adjust maintenance report: started
-[    INFO] Following repositories will be removed from maintenance mode: 
-repo2
+[    INFO] Following repositories will be removed from maintenance mode:
+[    INFO]  - repo2
 [    INFO] Adjust maintenance report: finished
 [    INFO] Set maintenance report: started
 [    INFO] Set maintenance report: finished

--- a/tests/logs/set_maintenance/test_set_maintenance/test_maintenance_off.txt
+++ b/tests/logs/set_maintenance/test_set_maintenance/test_maintenance_off.txt
@@ -1,0 +1,9 @@
+[    INFO] Get maintenance report: started
+[    INFO] Get maintenance report: finished
+[    INFO] Adjust maintenance report: started
+[    INFO] Following repositories will be removed from maintenance mode: 
+repo2
+[    INFO] Adjust maintenance report: finished
+[    INFO] Set maintenance report: started
+[    INFO] Set maintenance report: finished
+[    INFO] Completed adjusting maintenance mode: f7b0b7d2-cda8-056c-3d15-eef738c1962e

--- a/tests/logs/set_maintenance/test_set_maintenance/test_maintenance_off_with_regex.jsonl
+++ b/tests/logs/set_maintenance/test_set_maintenance/test_maintenance_off_with_regex.jsonl
@@ -1,0 +1,6 @@
+{"event": {"type": "get-maintenance-report-start"}}
+{"event": {"type": "get-maintenance-report-end"}}
+{"event": {"type": "adjust-maintenance-report-start"}}
+{"event": {"type": "adjust-maintenance-report-end"}}
+{"event": {"type": "set-maintenance-report-start"}}
+{"event": {"type": "set-maintenance-report-end"}}

--- a/tests/logs/set_maintenance/test_set_maintenance/test_maintenance_off_with_regex.txt
+++ b/tests/logs/set_maintenance/test_set_maintenance/test_maintenance_off_with_regex.txt
@@ -1,0 +1,9 @@
+[    INFO] Get maintenance report: started
+[    INFO] Get maintenance report: finished
+[    INFO] Adjust maintenance report: started
+[    INFO] Following repositories will be removed from maintenance mode: 
+repo1
+[    INFO] Adjust maintenance report: finished
+[    INFO] Set maintenance report: started
+[    INFO] Set maintenance report: finished
+[    INFO] Completed adjusting maintenance mode: f7b0b7d2-cda8-056c-3d15-eef738c1962e

--- a/tests/logs/set_maintenance/test_set_maintenance/test_maintenance_off_with_regex.txt
+++ b/tests/logs/set_maintenance/test_set_maintenance/test_maintenance_off_with_regex.txt
@@ -6,4 +6,3 @@
 [    INFO] Adjust maintenance report: finished
 [    INFO] Set maintenance report: started
 [    INFO] Set maintenance report: finished
-[    INFO] Completed adjusting maintenance mode: f7b0b7d2-cda8-056c-3d15-eef738c1962e

--- a/tests/logs/set_maintenance/test_set_maintenance/test_maintenance_off_with_regex.txt
+++ b/tests/logs/set_maintenance/test_set_maintenance/test_maintenance_off_with_regex.txt
@@ -1,8 +1,8 @@
 [    INFO] Get maintenance report: started
 [    INFO] Get maintenance report: finished
 [    INFO] Adjust maintenance report: started
-[    INFO] Following repositories will be removed from maintenance mode: 
-repo1
+[    INFO] Following repositories will be removed from maintenance mode:
+[    INFO]  - repo2
 [    INFO] Adjust maintenance report: finished
 [    INFO] Set maintenance report: started
 [    INFO] Set maintenance report: finished

--- a/tests/logs/set_maintenance/test_set_maintenance/test_maintenance_off_with_repo_not_in_maintenance.jsonl
+++ b/tests/logs/set_maintenance/test_set_maintenance/test_maintenance_off_with_repo_not_in_maintenance.jsonl
@@ -1,0 +1,6 @@
+{"event": {"type": "get-maintenance-report-start"}}
+{"event": {"type": "get-maintenance-report-end"}}
+{"event": {"type": "adjust-maintenance-report-start"}}
+{"event": {"type": "adjust-maintenance-report-end"}}
+{"event": {"type": "set-maintenance-report-start"}}
+{"event": {"type": "set-maintenance-report-end"}}

--- a/tests/logs/set_maintenance/test_set_maintenance/test_maintenance_off_with_repo_not_in_maintenance.txt
+++ b/tests/logs/set_maintenance/test_set_maintenance/test_maintenance_off_with_repo_not_in_maintenance.txt
@@ -2,8 +2,8 @@
 [    INFO] Get maintenance report: finished
 [    INFO] Adjust maintenance report: started
 [ WARNING] Repository repo2 is not in maintenance mode
-[    INFO] Following repositories will be removed from maintenance mode: 
-repo1
+[    INFO] Following repositories will be removed from maintenance mode:
+[    INFO]  - repo1
 [    INFO] Adjust maintenance report: finished
 [    INFO] Set maintenance report: started
 [    INFO] Set maintenance report: finished

--- a/tests/logs/set_maintenance/test_set_maintenance/test_maintenance_off_with_repo_not_in_maintenance.txt
+++ b/tests/logs/set_maintenance/test_set_maintenance/test_maintenance_off_with_repo_not_in_maintenance.txt
@@ -1,0 +1,10 @@
+[    INFO] Get maintenance report: started
+[    INFO] Get maintenance report: finished
+[    INFO] Adjust maintenance report: started
+[ WARNING] Repository repo2 is not in maintenance mode
+[    INFO] Following repositories will be removed from maintenance mode: 
+repo1
+[    INFO] Adjust maintenance report: finished
+[    INFO] Set maintenance report: started
+[    INFO] Set maintenance report: finished
+[    INFO] Completed adjusting maintenance mode: f7b0b7d2-cda8-056c-3d15-eef738c1962e

--- a/tests/logs/set_maintenance/test_set_maintenance/test_maintenance_off_with_repo_not_in_maintenance.txt
+++ b/tests/logs/set_maintenance/test_set_maintenance/test_maintenance_off_with_repo_not_in_maintenance.txt
@@ -7,4 +7,3 @@
 [    INFO] Adjust maintenance report: finished
 [    INFO] Set maintenance report: started
 [    INFO] Set maintenance report: finished
-[    INFO] Completed adjusting maintenance mode: f7b0b7d2-cda8-056c-3d15-eef738c1962e

--- a/tests/logs/set_maintenance/test_set_maintenance/test_maintenance_on.jsonl
+++ b/tests/logs/set_maintenance/test_set_maintenance/test_maintenance_on.jsonl
@@ -1,0 +1,6 @@
+{"event": {"type": "get-maintenance-report-start"}}
+{"event": {"type": "get-maintenance-report-end"}}
+{"event": {"type": "adjust-maintenance-report-start"}}
+{"event": {"type": "adjust-maintenance-report-end"}}
+{"event": {"type": "set-maintenance-report-start"}}
+{"event": {"type": "set-maintenance-report-end"}}

--- a/tests/logs/set_maintenance/test_set_maintenance/test_maintenance_on.txt
+++ b/tests/logs/set_maintenance/test_set_maintenance/test_maintenance_on.txt
@@ -1,9 +1,9 @@
 [    INFO] Get maintenance report: started
 [    INFO] Get maintenance report: finished
 [    INFO] Adjust maintenance report: started
-[    INFO] Setting following repos to maintenance mode: 
-repo1
-repo2
+[    INFO] Setting following repos to maintenance mode:
+[    INFO]  - repo1
+[    INFO]  - repo2
 [    INFO] Adjust maintenance report: finished
 [    INFO] Set maintenance report: started
 [    INFO] Set maintenance report: finished

--- a/tests/logs/set_maintenance/test_set_maintenance/test_maintenance_on.txt
+++ b/tests/logs/set_maintenance/test_set_maintenance/test_maintenance_on.txt
@@ -1,0 +1,10 @@
+[    INFO] Get maintenance report: started
+[    INFO] Get maintenance report: finished
+[    INFO] Adjust maintenance report: started
+[    INFO] Setting following repos to maintenance mode: 
+repo1
+repo2
+[    INFO] Adjust maintenance report: finished
+[    INFO] Set maintenance report: started
+[    INFO] Set maintenance report: finished
+[    INFO] Completed adjusting maintenance mode: 23a7711a-8133-2876-37eb-dcd9e87a1613

--- a/tests/logs/set_maintenance/test_set_maintenance/test_maintenance_on.txt
+++ b/tests/logs/set_maintenance/test_set_maintenance/test_maintenance_on.txt
@@ -7,4 +7,3 @@
 [    INFO] Adjust maintenance report: finished
 [    INFO] Set maintenance report: started
 [    INFO] Set maintenance report: finished
-[    INFO] Completed adjusting maintenance mode: 23a7711a-8133-2876-37eb-dcd9e87a1613

--- a/tests/logs/set_maintenance/test_set_maintenance/test_maintenance_on_with_regex.jsonl
+++ b/tests/logs/set_maintenance/test_set_maintenance/test_maintenance_on_with_regex.jsonl
@@ -1,0 +1,6 @@
+{"event": {"type": "get-maintenance-report-start"}}
+{"event": {"type": "get-maintenance-report-end"}}
+{"event": {"type": "adjust-maintenance-report-start"}}
+{"event": {"type": "adjust-maintenance-report-end"}}
+{"event": {"type": "set-maintenance-report-start"}}
+{"event": {"type": "set-maintenance-report-end"}}

--- a/tests/logs/set_maintenance/test_set_maintenance/test_maintenance_on_with_regex.txt
+++ b/tests/logs/set_maintenance/test_set_maintenance/test_maintenance_on_with_regex.txt
@@ -1,8 +1,8 @@
 [    INFO] Get maintenance report: started
 [    INFO] Get maintenance report: finished
 [    INFO] Adjust maintenance report: started
-[    INFO] Setting following repos to maintenance mode: 
-repo1
+[    INFO] Setting following repos to maintenance mode:
+[    INFO]  - repo2
 [    INFO] Adjust maintenance report: finished
 [    INFO] Set maintenance report: started
 [    INFO] Set maintenance report: finished

--- a/tests/logs/set_maintenance/test_set_maintenance/test_maintenance_on_with_regex.txt
+++ b/tests/logs/set_maintenance/test_set_maintenance/test_maintenance_on_with_regex.txt
@@ -6,4 +6,3 @@
 [    INFO] Adjust maintenance report: finished
 [    INFO] Set maintenance report: started
 [    INFO] Set maintenance report: finished
-[    INFO] Completed adjusting maintenance mode: 23a7711a-8133-2876-37eb-dcd9e87a1613

--- a/tests/logs/set_maintenance/test_set_maintenance/test_maintenance_on_with_regex.txt
+++ b/tests/logs/set_maintenance/test_set_maintenance/test_maintenance_on_with_regex.txt
@@ -1,0 +1,9 @@
+[    INFO] Get maintenance report: started
+[    INFO] Get maintenance report: finished
+[    INFO] Adjust maintenance report: started
+[    INFO] Setting following repos to maintenance mode: 
+repo1
+[    INFO] Adjust maintenance report: finished
+[    INFO] Set maintenance report: started
+[    INFO] Set maintenance report: finished
+[    INFO] Completed adjusting maintenance mode: 23a7711a-8133-2876-37eb-dcd9e87a1613

--- a/tests/logs/set_maintenance/test_set_maintenance/test_maintenance_on_with_repo_not_exists.jsonl
+++ b/tests/logs/set_maintenance/test_set_maintenance/test_maintenance_on_with_repo_not_exists.jsonl
@@ -1,0 +1,6 @@
+{"event": {"type": "get-maintenance-report-start"}}
+{"event": {"type": "get-maintenance-report-end"}}
+{"event": {"type": "adjust-maintenance-report-start"}}
+{"event": {"type": "adjust-maintenance-report-end"}}
+{"event": {"type": "set-maintenance-report-start"}}
+{"event": {"type": "set-maintenance-report-end"}}

--- a/tests/logs/set_maintenance/test_set_maintenance/test_maintenance_on_with_repo_not_exists.txt
+++ b/tests/logs/set_maintenance/test_set_maintenance/test_maintenance_on_with_repo_not_exists.txt
@@ -8,4 +8,3 @@
 [    INFO] Adjust maintenance report: finished
 [    INFO] Set maintenance report: started
 [    INFO] Set maintenance report: finished
-[    INFO] Completed adjusting maintenance mode: 23a7711a-8133-2876-37eb-dcd9e87a1613

--- a/tests/logs/set_maintenance/test_set_maintenance/test_maintenance_on_with_repo_not_exists.txt
+++ b/tests/logs/set_maintenance/test_set_maintenance/test_maintenance_on_with_repo_not_exists.txt
@@ -1,0 +1,11 @@
+[    INFO] Get maintenance report: started
+[    INFO] Get maintenance report: finished
+[    INFO] Adjust maintenance report: started
+[ WARNING] Didn't find following repositories: 
+repo2
+[    INFO] Setting following repos to maintenance mode: 
+
+[    INFO] Adjust maintenance report: finished
+[    INFO] Set maintenance report: started
+[    INFO] Set maintenance report: finished
+[    INFO] Completed adjusting maintenance mode: 23a7711a-8133-2876-37eb-dcd9e87a1613

--- a/tests/logs/set_maintenance/test_set_maintenance/test_maintenance_on_with_repo_not_exists.txt
+++ b/tests/logs/set_maintenance/test_set_maintenance/test_maintenance_on_with_repo_not_exists.txt
@@ -1,10 +1,10 @@
 [    INFO] Get maintenance report: started
 [    INFO] Get maintenance report: finished
 [    INFO] Adjust maintenance report: started
-[ WARNING] Didn't find following repositories: 
-repo2
-[    INFO] Setting following repos to maintenance mode: 
-
+[ WARNING] Didn't find following repositories:
+[ WARNING]  - repo2
+[    INFO] Setting following repos to maintenance mode:
+[    INFO]  - repo1
 [    INFO] Adjust maintenance report: finished
 [    INFO] Set maintenance report: started
 [    INFO] Set maintenance report: finished

--- a/tests/set_maintenance/test_base.py
+++ b/tests/set_maintenance/test_base.py
@@ -1,0 +1,34 @@
+import pytest
+from mock import patch
+
+from pubtools.pulplib import (
+    Client,
+    FakeController,
+    Distributor,
+    Repository,
+    FileRepository,
+)
+
+from pubtools._pulp.tasks.set_maintenance.base import SetMaintenance
+
+
+def test_no_implemented(command_tester):
+    task_instance = SetMaintenance()
+
+    controller = FakeController()
+    controller.insert_repository(FileRepository(id="redhat-maintenance"))
+    client = controller.client
+
+    arg = [
+        "test-maintenance",
+        "--pulp-url",
+        "http://some.url",
+        "--verbose",
+        "--repo-ids",
+        "repo1",
+    ]
+
+    with patch("pubtools._pulp.services.PulpClientService.pulp_client", client):
+        with pytest.raises(NotImplementedError):
+            with patch("sys.argv", arg):
+                task_instance.main()

--- a/tests/set_maintenance/test_set_maintenance.py
+++ b/tests/set_maintenance/test_set_maintenance.py
@@ -1,0 +1,178 @@
+import pytest
+from mock import patch
+
+from pubtools.pulplib import (
+    FakeController,
+    Distributor,
+    Repository,
+    FileRepository,
+    Task,
+    PulpException,
+)
+
+from pubtools._pulp.tasks.set_maintenance import SetMaintenanceOn, SetMaintenanceOff
+
+
+@pytest.fixture
+def mock_on_logger():
+    with patch(
+        "pubtools._pulp.tasks.set_maintenance.set_maintenance_on.LOG"
+    ) as mocked_info:
+        yield mocked_info
+
+
+@pytest.fixture
+def mock_off_logger():
+    with patch(
+        "pubtools._pulp.tasks.set_maintenance.set_maintenance_off.LOG"
+    ) as mocked_info:
+        yield mocked_info
+
+
+def maintenance_repo():
+    iso_distributor = Distributor(id="iso_distributor", type_id="iso_distributor")
+    repo = FileRepository(id="redhat-maintenance", distributors=[iso_distributor])
+
+    return repo
+
+
+def _get_fake_controller(*args):
+    controller = FakeController()
+    for repo in args:
+        controller.insert_repository(repo)
+    controller.insert_repository(maintenance_repo())
+    return controller
+
+
+def _patch_pulp_client(client):
+    return patch("pubtools._pulp.services.PulpClientService.pulp_client", client)
+
+
+def _run_test(cmd_args, on, *repos):
+    controller = _get_fake_controller(*repos)
+    if on:
+        s_m = SetMaintenanceOn()
+    else:
+        s_m = SetMaintenanceOff()
+    arg = ["", "--pulp-url", "http://some.url", "--verbose"]
+    arg.extend(cmd_args)
+
+    with patch("sys.argv", arg):
+        with _patch_pulp_client(controller.client):
+            s_m.main()
+    return controller
+
+
+def test_maintenance_on(mock_on_logger):
+    """Test set maintenance by passing repo ids."""
+    repo1 = Repository(id="repo1")
+    repo2 = Repository(id="repo2")
+
+    cmd_args = ["--repo-id", "repo1", "repo2", "--message", "Now in Miantenance"]
+
+    controller = _run_test(cmd_args, True, repo1, repo2)
+
+    # upload and publish should be called once each
+    assert len(controller.upload_history) == 1
+    assert controller.upload_history[0].repository.id == "redhat-maintenance"
+    assert len(controller.publish_history) == 1
+    assert controller.publish_history[0].repository.id == "redhat-maintenance"
+
+    # logged message should indicate both repos are set to maintenance
+    mock_on_logger.info.assert_called_with(
+        "Setting following repos to Maintenance Mode: \n%s", "repo1\nrepo2"
+    )
+
+
+def test_maintenance_on_with_regex(mock_on_logger):
+    """Test set maintenance by using regex"""
+    repo1 = Repository(id="repo1")
+    repo2 = Repository(id="repo2")
+
+    cmd_args = ["--repo-regex", "repo1"]
+
+    controller = _run_test(cmd_args, True, repo1, repo2)
+
+    # only repo1 should be set to maintenance
+    mock_on_logger.info.assert_called_with(
+        "Setting following repos to Maintenance Mode: \n%s", "repo1"
+    )
+
+
+def test_maintenance_on_with_repo_not_exists():
+    """Set maintenance to non-existed repo in server will fail"""
+    repo1 = Repository(id="repo1")
+    cmd_args = ["--repo-id", "repo2"]
+
+    with pytest.raises(PulpException):
+        _run_test(cmd_args, True, repo1)
+
+
+def test_maintenance_off(mock_off_logger):
+    repo1 = Repository(id="repo1")
+    repo2 = Repository(id="repo2")
+
+    # set maintenance first, get the controller
+    cmd_args = ["--repo-id", "repo1", "repo2"]
+    controller = _run_test(cmd_args, True, repo1, repo2)
+
+    args = [
+        "",
+        "--pulp-url",
+        "http://some.url",
+        "--verbose",
+        "--repo-id",
+        "repo1",
+        "repo2",
+    ]
+    s_m = SetMaintenanceOff()
+
+    # remove repos from maintenance mode by id
+    with patch("sys.argv", args):
+        with _patch_pulp_client(controller.client):
+            s_m.main()
+
+    mock_off_logger.info.assert_called_with(
+        "Following repositories will be removed from Maintenance Mode: \n%s",
+        "repo1\nrepo2",
+    )
+
+    # upload and publish should be called twice eachassert len(controller.upload_history) == 1
+    assert len(controller.upload_history) == 2
+    assert len(controller.publish_history) == 2
+
+
+def test_maintenance_off_with_regex(mock_off_logger):
+    repo1 = Repository(id="repo1")
+    repo2 = Repository(id="repo2")
+
+    # set maintenance first, get the controller
+    cmd_args = ["--repo-id", "repo1", "repo2"]
+    controller = _run_test(cmd_args, True, repo1, repo2)
+
+    args = ["", "--pulp-url", "http://some.url", "--verbose", "--repo-regex", "repo1"]
+    s_m = SetMaintenanceOff()
+
+    # remove repos from maintenance mode by id
+    with patch("sys.argv", args):
+        with _patch_pulp_client(controller.client):
+            s_m.main()
+
+    mock_off_logger.info.assert_called_with(
+        "Following repositories will be removed from Maintenance Mode: \n%s", "repo1"
+    )
+
+
+def test_maintenance_off_with_repo_not_in_maintenance(mock_off_logger):
+    controller = _get_fake_controller()
+    args = ["", "--pulp-url", "http://some.url", "--verbose", "--repo-id", "repo1"]
+    s_m = SetMaintenanceOff()
+
+    # remove repos from maintenance mode by id
+    with patch("sys.argv", args):
+        with _patch_pulp_client(controller.client):
+            s_m.main()
+
+    mock_off_logger.warn.assert_called_with(
+        "Repository %s is not in Maintenance Mode", "repo1"
+    )

--- a/tests/set_maintenance/test_set_maintenance.py
+++ b/tests/set_maintenance/test_set_maintenance.py
@@ -10,6 +10,7 @@ from pubtools.pulplib import (
 
 from pubtools._pulp.tasks.set_maintenance import SetMaintenanceOn, SetMaintenanceOff
 import pubtools._pulp.tasks.set_maintenance.set_maintenance_on
+import pubtools._pulp.tasks.set_maintenance.set_maintenance_off
 
 
 class FakeSetMaintenanceOn(SetMaintenanceOn):
@@ -154,7 +155,9 @@ def test_maintenance_off(command_tester):
     task_instance = get_task_instance(False, repo1, repo2)
 
     command_tester.test(
-        task_instance.main,
+        lambda: pubtools._pulp.tasks.set_maintenance.set_maintenance_off.entry_point(
+            lambda: task_instance
+        ),
         [
             "test-maintenance-off",
             "--pulp-url",

--- a/tests/shared/test_task_interface.py
+++ b/tests/shared/test_task_interface.py
@@ -5,7 +5,12 @@ import pytest
 
 
 @pytest.fixture(
-    params=["pubtools._pulp.tasks.garbage_collect", "pubtools._pulp.tasks.clear_repo"]
+    params=[
+        "pubtools._pulp.tasks.garbage_collect",
+        "pubtools._pulp.tasks.clear_repo",
+        "pubtools._pulp.tasks.set_maintenance.set_maintenance_on",
+        "pubtools._pulp.tasks.set_maintenance.set_maintenance_off",
+    ]
 )
 def task_module(request):
     __import__(request.param)


### PR DESCRIPTION
Two commands are included:
 1. pubtools-pulp-maintenance-on: enable maintenance mode
 2. pubtools-pulp-maintenance-off: disale maintenance mode

Both commands accepts repo ids and repo regex pattern as input. For enable
maintenance mode, if repo ids are passed, then it first checks if the repo
exists or not by querying pulp server with repo ids.

The general workflow for set maintenance is:
 1. get maintenance report from pulp server
 2. make changes to report according to enable/disable
 3. upload result report to pulp and publish