### PR TITLE
cleanup: drop usage of deprecated as_iter

### DIFF
--- a/pubtools/_pulp/tasks/clear_repo.py
+++ b/pubtools/_pulp/tasks/clear_repo.py
@@ -87,7 +87,7 @@ class ClearRepo(
 
         out = []
         search = self.pulp_client.search_repository(Criteria.with_id(repo_ids))
-        for repo in search.result().as_iter():
+        for repo in search.result():
             out.append(repo)
             found_repo_ids.append(repo.id)
 

--- a/pubtools/_pulp/tasks/garbage_collect.py
+++ b/pubtools/_pulp/tasks/garbage_collect.py
@@ -45,7 +45,7 @@ class GarbageCollect(PulpClientService, PulpTask):
         gc_threshold = self.args.gc_threshold
         deleted_repos = []
         # initiate deletion task for the repos
-        for repo in repos.as_iter():
+        for repo in repos:
             repo_age = datetime.utcnow() - repo.created
             if repo_age > timedelta(days=gc_threshold):
                 LOG.info("Deleting %s (created on %s)", repo.id, repo.created)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 six
-pubtools-pulplib>=1.5.0
+pubtools-pulplib>=2.1.0
 fastpurge
 more_executors>=2.2.0
 pushcollector


### PR DESCRIPTION
This is no longer required when iterating over search results.