### PR TITLE
logging: add -d alias for --debug

### DIFF
--- a/pubtools/_pulp/task.py
+++ b/pubtools/_pulp/task.py
@@ -90,6 +90,7 @@ class PulpTask(object):
         # minimum args required for a pulp CLI task
         self.parser.add_argument(
             "--debug",
+            "-d",
             action="count",
             default=0,
             help=(

--- a/tests/shared/test_pulp_task.py
+++ b/tests/shared/test_pulp_task.py
@@ -46,7 +46,7 @@ def test_main():
         assuming run() and add_args() are implemented
     """
     task = TaskWithPulpClient()
-    arg = ["", "--pulp-url", "http://some.url", "--debug"]
+    arg = ["", "--pulp-url", "http://some.url", "-d"]
     with patch("sys.argv", arg):
         with patch("pubtools._pulp.task.PulpTask.run"):
             assert task.main() == 0

--- a/tests/shared/test_pulp_task_logging.py
+++ b/tests/shared/test_pulp_task_logging.py
@@ -97,7 +97,7 @@ def test_debug2_logs(tier1_logger, tier2_logger, tier3_logger):
     """Tier 1 & 2 loggers use DEBUG if --debug is provided twice."""
 
     task = MyTask()
-    sys.argv = ["my-task", "--debug", "--debug"]
+    sys.argv = ["my-task", "-dd"]
     task.main()
 
     assert tier1_logger.getEffectiveLevel() == logging.DEBUG
@@ -109,7 +109,7 @@ def test_debug3_logs(tier1_logger, tier2_logger, tier3_logger):
     """All loggers use DEBUG if --debug is provided thrice."""
 
     task = MyTask()
-    sys.argv = ["my-task", "--debug", "--debug", "--debug"]
+    sys.argv = ["my-task", "--debug", "-d", "--debug"]
     task.main()
 
     assert tier1_logger.getEffectiveLevel() == logging.DEBUG


### PR DESCRIPTION
Because "--debug --debug --debug" is annoying to write.
Giving a short alias allows e.g. "-ddd" to work.