### PR TITLE
fix couldn't search distributors while setting maintenance mode on

### DIFF
--- a/pubtools/_pulp/tasks/set_maintenance/set_maintenance_on.py
+++ b/pubtools/_pulp/tasks/set_maintenance/set_maintenance_on.py
@@ -34,7 +34,7 @@ class SetMaintenanceOn(SetMaintenance):
         if self.args.repo_url_regex:
             # search distributors with relative_url, get the repo id from distributors
             crit = Criteria.with_field(
-                "relative_url", Matcher.regex(self.args.repo_url_regex)
+                "relative_url", Matcher.regex(self.args.repo_url_regex.pattern)
             )
             dists = self.pulp_client.search_distributor(crit).result()
             to_add.extend(set([dist.repo_id for dist in dists]))


### PR DESCRIPTION
The reason why --repo-url-regex option isn't working is because,
for validation purpose, we add type=re.compile to that option, make
sure it's a valid pattern and passed it to make Criteria object directly,
which isn't supported.
Now passes RE.Pattern object's pattern to it.