### PR TITLE
Make repo-ids option accept comma separated argument

### DIFF
--- a/docs/publish.rst
+++ b/docs/publish.rst
@@ -18,7 +18,7 @@ A typical invocation of publish would look like this:
     --pulp-url https://pulp.example.com/ \
     --pulp-user admin \
     --pulp-password XXXXX \
-    --repo-ids my-repo1 my-repo2 ...
+    --repo-ids my-repo1,my-repo2 ...
 
 Mentioned repositories will be published to the defined
 endpoints in the distributors.
@@ -51,7 +51,7 @@ only the repos matching those filters are published.
     --pulp-password XXXXX \
     --published-before 2019-09-10
     --repo-url-regex /some/url/to/match
-    --repo-ids my-repo1 my-repo2 ...
+    --repo-ids my-repo1,my-repo2 ...
 
 
 Example: with cache flush
@@ -74,4 +74,4 @@ file for authentication.
     --pulp-user admin \
     --pulp-password XXXXX \
     --fastpurge-root-url https://cdn.example.com/ \
-    --repo-ids my-repo1 my-repo2 ...
+    --repo-ids my-repo1,my-repo2 ...

--- a/pubtools/_pulp/tasks/publish.py
+++ b/pubtools/_pulp/tasks/publish.py
@@ -32,7 +32,9 @@ class Publish(PulpClientService, UdCacheClientService, PulpTask, CDNCache):
         super(Publish, self).add_args()
 
         self.parser.add_argument(
-            "--repo-ids", help="list of repos to be published", nargs="+"
+            "--repo-ids",
+            help="comma separated repos to be published",
+            type=lambda x: x.split(","),
         )
         self.parser.add_argument(
             "--clean",

--- a/pubtools/_pulp/tasks/set_maintenance/base.py
+++ b/pubtools/_pulp/tasks/set_maintenance/base.py
@@ -23,8 +23,8 @@ class SetMaintenance(PulpClientService, PulpTask):
 
         self.parser.add_argument(
             "--repo-ids",
-            nargs="+",
-            help="repository to be set/unset to maintenance mode",
+            help="comma separated repositories to be set/unset to maintenance mode",
+            type=lambda x: x.split(","),
         )
 
     @step("Get maintenance report")

--- a/tests/publish/test_publish.py
+++ b/tests/publish/test_publish.py
@@ -139,8 +139,7 @@ def test_nonexist_repos(command_tester):
             "--pulp-url",
             "https://pulp.example.com",
             "--repo-ids",
-            "repo1",
-            "repo2",
+            "repo1,repo2",
         ],
     )
 
@@ -296,9 +295,7 @@ def test_publish_filtered_input_repos(command_tester):
             "--repo-url-regex",
             "/unit/3/",
             "--repo-ids",
-            "repo1",
-            "repo2",
-            "repo3",
+            "repo1,repo2,repo3",
         ],
     )
 

--- a/tests/set_maintenance/test_set_maintenance.py
+++ b/tests/set_maintenance/test_set_maintenance.py
@@ -98,8 +98,7 @@ def test_maintenance_on(command_tester):
             "--pulp-url",
             "http://some.url",
             "--repo-ids",
-            "repo1",
-            "repo2",
+            "repo1,repo2",
             "--message",
             "Now in Maintenance",
         ],
@@ -161,8 +160,7 @@ def test_maintenance_on_with_repo_not_exists(command_tester):
             "--pulp-url",
             "http://some.url",
             "--repo-ids",
-            "repo1",
-            "repo2",
+            "repo1,repo2",
         ],
     )
 
@@ -225,8 +223,7 @@ def test_maintenance_off_with_repo_not_in_maintenance(command_tester):
             "--pulp-url",
             "http://some.url",
             "--repo-ids",
-            "repo1",
-            "repo2",
+            "repo1,repo2",
         ],
     )
 


### PR DESCRIPTION
The advantage of accepting comma separated argument is, the command
fails immediately if space is used. In the opposite, if space is used
as the separator and if user wrongly used comma, then the command won't fail
until certain stage, or even succeeds with wrong results.