### PR TITLE
README: add badge for PyPI

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ pubtools-pulp
 A command-line interface to [Pulp](https://pulpproject.org/) tasks,
 used by [release-engineering](https://github.com/release-engineering) publishing tools.
 
+[![PyPI version](https://badge.fury.io/py/pubtools-pulp.svg)](https://badge.fury.io/py/pubtools-pulp)
 [![Build Status](https://travis-ci.org/release-engineering/pubtools-pulp.svg?branch=master)](https://travis-ci.org/release-engineering/pubtools-pulp)
 [![Coverage Status](https://coveralls.io/repos/github/release-engineering/pubtools-pulp/badge.svg?branch=master)](https://coveralls.io/github/release-engineering/pubtools-pulp?branch=master)
 


### PR DESCRIPTION
It's convenient to have a link directly to PyPI from the
project's README, to advertise that the project is available there
and also at a glance show the latest released version.