### PR TITLE
Fix crash when flushing UD cache for engproduct

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- n/a
+- Fixed a crash when clear-repo attempts to flush engproduct in UD
 
 ## 1.0.1 - 2020-03-26
 

--- a/pubtools/_pulp/ud.py
+++ b/pubtools/_pulp/ud.py
@@ -64,7 +64,7 @@ class UdCacheClient(object):
 
     def _flush_object(self, object_type, object_id):
         url = os.path.join(
-            self._url, "internal/rcm/flush-cache", object_type, object_id
+            self._url, "internal/rcm/flush-cache", object_type, str(object_id)
         )
 
         LOG.info("Invalidating %s %s", object_type, object_id)

--- a/tests/ud/test_ud_cache_client.py
+++ b/tests/ud/test_ud_cache_client.py
@@ -10,7 +10,7 @@ def test_flush(requests_mock):
     client = UdCacheClient("https://ud.example.com/", auth=("user", "pass"))
 
     urls = [
-        "https://ud.example.com/internal/rcm/flush-cache/eng-product/some-product",
+        "https://ud.example.com/internal/rcm/flush-cache/eng-product/1234",
         "https://ud.example.com/internal/rcm/flush-cache/repo/some-repo",
     ]
 
@@ -18,7 +18,7 @@ def test_flush(requests_mock):
         requests_mock.register_uri("GET", url)
 
     # It should succeed
-    client.flush_product("some-product").result()
+    client.flush_product(1234).result()
     client.flush_repo("some-repo").result()
 
     # It should have called above two URLs


### PR DESCRIPTION
Product IDs are provided as integers.  os.path.join does not accept
integers, so make sure to stringify all IDs while assembling URLs.

Autotests would have caught this, but were inaccurately providing
strings rather than integers as product IDs.