### PR TITLE
Constraints from dependencies are included for Python 2.7

### DIFF
--- a/constraints-legacy.txt
+++ b/constraints-legacy.txt
@@ -1,0 +1,6 @@
+# Oldest supported versions of major libraries can be added to this
+# file. They'll be tested with Python 2.7.
+
+# constraints from pubtools-pulplib 
+attrs==17.4.0
+jsonschema==2.3.0

--- a/tests/set_maintenance/test_set_maintenance.py
+++ b/tests/set_maintenance/test_set_maintenance.py
@@ -34,9 +34,9 @@ class FakeSetMaintenanceOff(SetMaintenanceOff):
     @property
     def pulp_client(self):
         """Doesn't check if super gives a Pulp client or not:
-            1. it's been checked in maintenance on, which has the same client
-            2. we need to pre-set maintenance mode before test, check would
-               break that since there's no service args passed.
+        1. it's been checked in maintenance on, which has the same client
+        2. we need to pre-set maintenance mode before test, check would
+           break that since there's no service args passed.
         """
         return self.pulp_client_controller.client
 

--- a/tests/shared/test_pulp_task.py
+++ b/tests/shared/test_pulp_task.py
@@ -43,7 +43,7 @@ def test_pulp_client():
 
 def test_main():
     """Checks main returns without exception when invoked with minimal args
-        assuming run() and add_args() are implemented
+    assuming run() and add_args() are implemented
     """
     task = TaskWithPulpClient()
     arg = ["", "--pulp-url", "http://some.url", "-d"]

--- a/tox.ini
+++ b/tox.ini
@@ -11,6 +11,7 @@ deps=
 	# Note: we need to explicitly list requirements.txt here
 	# so it's processed at the same time as the constraints file
 	-rrequirements.txt
+	-cconstraints-legacy.txt
 	-rtest-requirements.txt
 
 [testenv:static]


### PR DESCRIPTION
There are some constraints applied on the dependencies of dependecnies
e.g. jsonschema in pubtools-pulplib via constraints.txt. However, those
constraints are not followed here and the installation for Python 2.7
fails. Hence, addind a constraints.txt file to include the constraints
form the dependencies and using that file in tox.ini for Python 2.7
installation.