### PR TITLE
Clear-repo sends pushitem objects to the pushcollector

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 sudo: false
 language: python
+before_install:
+  # for rpm-py-installer
+  - sudo apt-get install -y rpm
 install: pip install tox
 matrix:
   include:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- N/A
+- Updated clear-repo to send pushitem objects to the collector
 
 ## 1.0.2 - 2020-04-02
 

--- a/pubtools/_pulp/tasks/clear_repo.py
+++ b/pubtools/_pulp/tasks/clear_repo.py
@@ -12,6 +12,7 @@ from pubtools.pulplib import (
     RpmUnit,
     ModulemdUnit,
 )
+from pushsource import FilePushItem, ModuleMdPushItem, RpmPushItem
 
 from pubtools._pulp.task import PulpTask
 from pubtools._pulp.services import (
@@ -190,9 +191,9 @@ class ClearRepo(
             [unit.name, unit.stream, str(unit.version), unit.context, unit.arch]
         )
 
-        out["filename"] = nsvca
+        out["name"] = nsvca
 
-        return out
+        return ModuleMdPushItem(**out)
 
     def push_item_for_rpm(self, unit):
         out = {}
@@ -210,25 +211,26 @@ class ClearRepo(
             unit.arch,
             ".rpm",
         ]
-        out["filename"] = "".join(filename_parts)
+        out["name"] = "".join(filename_parts)
 
-        out["checksums"] = {}
         if unit.sha256sum:
-            out["checksums"]["sha256"] = unit.sha256sum
+            out["sha256sum"] = unit.sha256sum
         if unit.md5sum:
-            out["checksums"]["md5"] = unit.md5sum
+            out["md5sum"] = unit.md5sum
 
         out["signing_key"] = unit.signing_key
 
-        return out
+        return RpmPushItem(**out)
 
     def push_item_for_file(self, unit):
-        return {
-            "state": "DELETED",
-            "origin": "pulp",
-            "filename": unit.path,
-            "checksums": {"sha256": unit.sha256sum},
-        }
+        out = {}
+
+        out["state"] = "DELETED"
+        out["origin"] = "pulp"
+        out["name"] = unit.path
+        out["sha256sum"] = unit.sha256sum
+
+        return FilePushItem(**out)
 
     @step("Publish")
     def publish(self, repo_fs):

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ pubtools-pulplib>=2.3.1
 fastpurge
 more_executors>=2.2.0
 pushcollector
+pushsource

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,3 +1,4 @@
 pytest
 mock
 requests_mock
+rpm-py-installer

--- a/tests/clear_repo/test_clear_repo.py
+++ b/tests/clear_repo/test_clear_repo.py
@@ -166,14 +166,22 @@ def test_clear_file_repo(command_tester, fake_collector):
         {
             "state": "DELETED",
             "origin": "pulp",
+            "src": None,
+            "dest": None,
             "filename": "hello.txt",
             "checksums": {"sha256": "a" * 64},
+            "build": None,
+            "signing_key": None,
         },
         {
             "state": "DELETED",
             "origin": "pulp",
+            "src": None,
+            "dest": None,
             "filename": "with/subdir.json",
             "checksums": {"sha256": "b" * 64},
+            "build": None,
+            "signing_key": None,
         },
     ]
 
@@ -281,11 +289,23 @@ def test_clear_yum_repo(command_tester, fake_collector, monkeypatch):
         {
             "state": "DELETED",
             "origin": "pulp",
+            "src": None,
+            "dest": None,
             "filename": "bash-1.23-1.test8.x86_64.rpm",
             "checksums": {"sha256": "a" * 64, "md5": "b" * 32},
-            "signing_key": "aabbcc",
+            "signing_key": "AABBCC",
+            "build": None,
         },
-        {"state": "DELETED", "origin": "pulp", "filename": "mymod:s1:123:a1c2:s390x"},
+        {
+            "state": "DELETED",
+            "origin": "pulp",
+            "src": None,
+            "dest": None,
+            "filename": "mymod:s1:123:a1c2:s390x",
+            "checksums": None,
+            "signing_key": None,
+            "build": None,
+        },
     ]
 
     # It should have flushed these URLs


### PR DESCRIPTION
Clear-repo currently sends raw dicts to pushcollector.
This patch updates to send pushitem objects defined in the
pushsource library to send it to push collector instead of
raw dicts.