### PR TITLE
Enable throttling for publish command

### DIFF
--- a/pubtools/_pulp/tasks/publish.py
+++ b/pubtools/_pulp/tasks/publish.py
@@ -111,7 +111,7 @@ class Publish(PulpClientService, UdCacheClientService, PulpTask, CDNCache):
 
         start_index = 0
 
-        LOG.info("Publish throttled to publish %s repo at time", throttle_limit)
+        LOG.info("Publish throttled to publish %s repos at time", throttle_limit)
         # finish the loop when we submitted all repos for publish
         while start_index < len(repos):
             next_batch_len = throttle_limit - len(publish_fs)

--- a/tests/logs/publish/test_publish/test_throttled_publish.jsonl
+++ b/tests/logs/publish/test_publish/test_throttled_publish.jsonl
@@ -1,0 +1,8 @@
+{"event": {"type": "check-repos-start"}}
+{"event": {"type": "check-repos-end"}}
+{"event": {"type": "publish-start"}}
+{"event": {"type": "publish-end"}}
+{"event": {"type": "flush-cdn-cache-start"}}
+{"event": {"type": "flush-cdn-cache-end"}}
+{"event": {"type": "flush-ud-cache-start"}}
+{"event": {"type": "flush-ud-cache-end"}}

--- a/tests/logs/publish/test_publish/test_throttled_publish.txt
+++ b/tests/logs/publish/test_publish/test_throttled_publish.txt
@@ -1,0 +1,15 @@
+[    INFO] Check repos: started
+[    INFO] Check repos: finished
+[    INFO] Publish: started
+[    INFO] Publish throttled to publish 2 repo at time
+[    INFO] Publishing repo1
+[    INFO] Publishing repo2
+[    INFO] Publishing repo3
+[    INFO] Publish: finished
+[    INFO] Flush CDN cache: started
+[    INFO] CDN cache flush is not enabled.
+[    INFO] Flush CDN cache: finished
+[    INFO] Flush UD cache: started
+[    INFO] UD cache flush is not enabled.
+[    INFO] Flush UD cache: finished
+[    INFO] Publishing repositories completed

--- a/tests/logs/publish/test_publish/test_throttled_publish.txt
+++ b/tests/logs/publish/test_publish/test_throttled_publish.txt
@@ -1,7 +1,7 @@
 [    INFO] Check repos: started
 [    INFO] Check repos: finished
 [    INFO] Publish: started
-[    INFO] Publish throttled to publish 2 repo at time
+[    INFO] Publish throttled to publish 2 repos at time
 [    INFO] Publishing repo1
 [    INFO] Publishing repo2
 [    INFO] Publishing repo3

--- a/tests/publish/test_publish.py
+++ b/tests/publish/test_publish.py
@@ -302,3 +302,29 @@ def test_publish_filtered_input_repos(command_tester):
     # provided repos that were published before 2019-08-11 and
     # has relative url matching '/unit/3/'is published
     assert [hist.repository.id for hist in fake_pulp.publish_history] == ["repo3"]
+
+
+def test_throttled_publish(command_tester):
+    """publishes all provided repos with throttling enabled"""
+    fake_publish = FakePublish()
+    fake_pulp = fake_publish.pulp_client_controller
+    _add_repo(fake_pulp)
+
+    command_tester.test(
+        fake_publish.main,
+        [
+            "test-publish",
+            "--pulp-url",
+            "https://pulp.example.com",
+            "--repo-ids",
+            "repo1,repo2,repo3",
+            "--throttle",
+            "2",
+        ],
+    )
+
+    assert [hist.repository.id for hist in fake_pulp.publish_history] == [
+        "repo1",
+        "repo2",
+        "repo3",
+    ]


### PR DESCRIPTION
This change introduces --throttle option that
is usable for publish command.

This option allows to specify a number of repositories
that can be publish at one time. This may help
with not overloading pulp server with mass publishes
and leave some capacity of workers to do another tasks.