### PR TITLE
Move to ubuntu:bionic env. of travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: bionic
 sudo: false
 language: python
 before_install:


### PR DESCRIPTION
Rust compiler isn't a part of the xenial
and is needed for building cryptography wheel
that is dependency of pyOpenSSL via edgegrid-python->fastpurge.