### PR TITLE
Arg. repo-ids can be specified multiple times [RHELDST-5455]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- n/a
+- Publish command accepts multiple repo-ids arg
 
 ## [1.0.3] - 2021-02-05
 

--- a/pubtools/_pulp/tasks/publish.py
+++ b/pubtools/_pulp/tasks/publish.py
@@ -33,8 +33,9 @@ class Publish(PulpClientService, UdCacheClientService, PulpTask, CDNCache):
 
         self.parser.add_argument(
             "--repo-ids",
-            help="comma separated repos to be published",
-            type=lambda x: x.split(","),
+            help="comma separated repos to be published, can be specified multiple times",
+            action="append",
+            default=[],
         )
         self.parser.add_argument(
             "--clean",
@@ -56,6 +57,13 @@ class Publish(PulpClientService, UdCacheClientService, PulpTask, CDNCache):
             default=None,
             type=re.compile,
         )
+
+    def _sanitize_repo_ids_args(self):
+        repo_ids = []
+        for item in self.args.repo_ids:
+            repo_ids.extend(item.split(","))
+
+        self.args.repo_ids = repo_ids
 
     def run(self):
         to_await = []
@@ -110,6 +118,7 @@ class Publish(PulpClientService, UdCacheClientService, PulpTask, CDNCache):
 
     @step("Check repos")
     def check_repos(self):
+        self._sanitize_repo_ids_args()
         repo_ids = self.args.repo_ids
         found_repo_ids = []
         out = []

--- a/tests/publish/test_publish.py
+++ b/tests/publish/test_publish.py
@@ -295,7 +295,9 @@ def test_publish_filtered_input_repos(command_tester):
             "--repo-url-regex",
             "/unit/3/",
             "--repo-ids",
-            "repo1,repo2,repo3",
+            "repo1",
+            "--repo-ids",
+            "repo2,repo3",
         ],
     )
 


### PR DESCRIPTION
Arg. repo-ids can be specified multiple times
in publish task. Previous "Comma separated repos"
behavior is retained.

E.g. --repo-ids 'a,b,c' will result in publishing
the same repos as in case --repo-ids 'a' --repo-ids 'b,c'