### PR TITLE
Add 'pulp-throttle' option to CLI of commands [RHELDST-441]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 - Publish command accepts multiple repo-ids arg
+- Add throttle arg for all commands that limit number of pulp tasks running simultaneously
 
 ## [1.0.3] - 2021-02-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 - Publish command accepts multiple repo-ids arg
-- Add throttle arg for all commands that limit number of pulp tasks running simultaneously
+- Add pulp-throttle arg for all commands that limit number of pulp tasks running simultaneously
 
 ## [1.0.3] - 2021-02-05
 

--- a/pubtools/_pulp/services/pulp.py
+++ b/pubtools/_pulp/services/pulp.py
@@ -10,6 +10,13 @@ from .base import Service
 LOG = logging.getLogger("pubtools.pulp")
 
 
+def throttle(str_throttle):
+    val = int(str_throttle)
+    if val <= 0:
+        raise ValueError
+    return val
+
+
 class PulpClientService(Service):
     """A service providing a Pulp client.
 
@@ -38,6 +45,12 @@ class PulpClientService(Service):
             action="store_true",
             help="Allow unverified HTTPS connection to Pulp",
         )
+        group.add_argument(
+            "--throttle",
+            help="Allows to enqueue or run only specified number of Pulp tasks at one moment",
+            default=None,
+            type=throttle,
+        )
 
     @property
     def pulp_client(self):
@@ -65,5 +78,8 @@ class PulpClientService(Service):
 
             # Thank you, but we don't need to hear about this for every single request
             warnings.filterwarnings("once", r"Unverified HTTPS request is being made")
+
+        if args.throttle:
+            kwargs["task_throttle"] = args.throttle
 
         return pulplib.Client(args.pulp_url, **kwargs)

--- a/pubtools/_pulp/services/pulp.py
+++ b/pubtools/_pulp/services/pulp.py
@@ -10,8 +10,8 @@ from .base import Service
 LOG = logging.getLogger("pubtools.pulp")
 
 
-def throttle(str_throttle):
-    val = int(str_throttle)
+def pulp_throttle(str_pulp_throttle):
+    val = int(str_pulp_throttle)
     if val <= 0:
         raise ValueError
     return val
@@ -46,10 +46,10 @@ class PulpClientService(Service):
             help="Allow unverified HTTPS connection to Pulp",
         )
         group.add_argument(
-            "--throttle",
+            "--pulp-throttle",
             help="Allows to enqueue or run only specified number of Pulp tasks at one moment",
             default=None,
-            type=throttle,
+            type=pulp_throttle,
         )
 
     @property
@@ -79,7 +79,7 @@ class PulpClientService(Service):
             # Thank you, but we don't need to hear about this for every single request
             warnings.filterwarnings("once", r"Unverified HTTPS request is being made")
 
-        if args.throttle:
-            kwargs["task_throttle"] = args.throttle
+        if args.pulp_throttle:
+            kwargs["task_throttle"] = args.pulp_throttle
 
         return pulplib.Client(args.pulp_url, **kwargs)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 six
-pubtools-pulplib>=2.3.1
+pubtools-pulplib>=2.8.0
 fastpurge
 more_executors>=2.2.0
 pushcollector>=1.2.0

--- a/tests/shared/test_pulp_task.py
+++ b/tests/shared/test_pulp_task.py
@@ -70,32 +70,41 @@ def test_description():
     )
 
 
-def test_throttle():
+def test_pulp_throttle():
     """Checks main returns without exception when invoked with minimal args
     assuming run() and add_args() are implemented
     """
-    throttle = 7
+    pulp_throttle = 7
     task = TaskWithPulpClient()
-    arg = ["", "--pulp-url", "http://some.url", "-d", "--throttle", str(throttle)]
+    arg = [
+        "",
+        "--pulp-url",
+        "http://some.url",
+        "-d",
+        "--pulp-throttle",
+        str(pulp_throttle),
+    ]
     with patch("sys.argv", arg):
         with patch("pubtools._pulp.task.PulpTask.run"):
             assert task.main() == 0
-            assert task.args.throttle == throttle
-            assert task.pulp_client._task_executor._delegate._throttle() == throttle
+            assert task.args.pulp_throttle == pulp_throttle
+            assert (
+                task.pulp_client._task_executor._delegate._throttle() == pulp_throttle
+            )
 
 
-def test_throttle_invalid():
+def test_pulp_throttle_invalid():
     task = TaskWithPulpClient()
-    arg = ["", "--pulp-url", "http://some.url", "-d", "--throttle", "xyz"]
+    arg = ["", "--pulp-url", "http://some.url", "-d", "--pulp-throttle", "xyz"]
     with patch("sys.argv", arg):
         with patch("pubtools._pulp.task.PulpTask.run"):
             with pytest.raises(SystemExit):
                 task.main()
 
 
-def test_throttle_negative():
+def test_pulp_throttle_negative():
     task = TaskWithPulpClient()
-    arg = ["", "--pulp-url", "http://some.url", "-d", "--throttle", "-1"]
+    arg = ["", "--pulp-url", "http://some.url", "-d", "--pulp-throttle", "-1"]
     with patch("sys.argv", arg):
         with patch("pubtools._pulp.task.PulpTask.run"):
             with pytest.raises(SystemExit):

--- a/tests/shared/test_pulp_task.py
+++ b/tests/shared/test_pulp_task.py
@@ -71,8 +71,8 @@ def test_description():
 
 
 def test_pulp_throttle():
-    """Checks main returns without exception when invoked with minimal args
-    assuming run() and add_args() are implemented
+    """Checks main returns without exception when invoked also with --pulp-throttle arg,
+    and checks whether the arg is correctly promoted to pulp_client.
     """
     pulp_throttle = 7
     task = TaskWithPulpClient()
@@ -94,6 +94,7 @@ def test_pulp_throttle():
 
 
 def test_pulp_throttle_invalid():
+    """Checks main raises SystemExit when a non-int string is passed with --pulp-throttle."""
     task = TaskWithPulpClient()
     arg = ["", "--pulp-url", "http://some.url", "-d", "--pulp-throttle", "xyz"]
     with patch("sys.argv", arg):
@@ -103,6 +104,7 @@ def test_pulp_throttle_invalid():
 
 
 def test_pulp_throttle_negative():
+    """Checks main raises SystemExit when a negative int is passed with --pulp-throttle."""
     task = TaskWithPulpClient()
     arg = ["", "--pulp-url", "http://some.url", "-d", "--pulp-throttle", "-1"]
     with patch("sys.argv", arg):

--- a/tests/shared/test_pulp_task.py
+++ b/tests/shared/test_pulp_task.py
@@ -68,3 +68,35 @@ def test_description():
         "It has a realistic multi-line doc string:\n\n"
         "    ...and may have several levels of indent."
     )
+
+
+def test_throttle():
+    """Checks main returns without exception when invoked with minimal args
+    assuming run() and add_args() are implemented
+    """
+    throttle = 7
+    task = TaskWithPulpClient()
+    arg = ["", "--pulp-url", "http://some.url", "-d", "--throttle", str(throttle)]
+    with patch("sys.argv", arg):
+        with patch("pubtools._pulp.task.PulpTask.run"):
+            assert task.main() == 0
+            assert task.args.throttle == throttle
+            assert task.pulp_client._task_executor._delegate._throttle() == throttle
+
+
+def test_throttle_invalid():
+    task = TaskWithPulpClient()
+    arg = ["", "--pulp-url", "http://some.url", "-d", "--throttle", "xyz"]
+    with patch("sys.argv", arg):
+        with patch("pubtools._pulp.task.PulpTask.run"):
+            with pytest.raises(SystemExit):
+                task.main()
+
+
+def test_throttle_negative():
+    task = TaskWithPulpClient()
+    arg = ["", "--pulp-url", "http://some.url", "-d", "--throttle", "-1"]
+    with patch("sys.argv", arg):
+        with patch("pubtools._pulp.task.PulpTask.run"):
+            with pytest.raises(SystemExit):
+                task.main()


### PR DESCRIPTION
All commands now support 'pulp-throttle' option.
This option allows to enqueue or run specified maximum
number of Pulp pask at one moment.