### PR TITLE
CI fix

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -96,4 +96,6 @@ disable=print-statement,
         # we use black code style and don't need additional checks
         bad-continuation,
         line-too-long,
+        # skip linting Python3 features
+        super-with-arguments,
 

--- a/tox.ini
+++ b/tox.ini
@@ -17,8 +17,8 @@ deps=
 [testenv:static]
 deps=
 	-rtest-requirements.txt
-	black
-	pylint
+	black==20.8b1
+	pylint==2.7.2
 commands=
 	black --check .
 	sh -c 'pylint pubtools; test $(( $? & (1|2|4|32) )) = 0'


### PR DESCRIPTION
Pin black and pylint to specific versions.
Update config of pylint to skip linting some
of Python3 features.