### PR TITLE
refactor: give executor a meaningful name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- n/a
+### Changed
+
+- Internally created executors are now named for improved metrics and debuggability.
 
 ## [1.1.0] - 2021-03-22
 

--- a/pubtools/_pulp/ud.py
+++ b/pubtools/_pulp/ud.py
@@ -38,7 +38,7 @@ class UdCacheClient(object):
 
         self._session_attrs = kwargs
         self._executor = (
-            Executors.thread_pool(max_workers=self._REQUEST_THREADS)
+            Executors.thread_pool(name="ud-client", max_workers=self._REQUEST_THREADS)
             .with_map(self._check_http_response)
             .with_retry(**retry_args)
         )

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 six
 pubtools-pulplib>=2.8.0
 fastpurge
-more_executors>=2.2.0
+more_executors>=2.7.0
 pushcollector>=1.2.0
 pushsource


### PR DESCRIPTION
This is a good idea because:

- the name will be reused in any created threads, so we can
  figure out which code created which thread

- the name will appear in prometheus metrics