### PR TITLE
README: fix outdated CI badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A command-line interface to [Pulp](https://pulpproject.org/) tasks,
 used by [release-engineering](https://github.com/release-engineering) publishing tools.
 
 [![PyPI version](https://badge.fury.io/py/pubtools-pulp.svg)](https://badge.fury.io/py/pubtools-pulp)
-[![Build Status](https://travis-ci.org/release-engineering/pubtools-pulp.svg?branch=master)](https://travis-ci.org/release-engineering/pubtools-pulp)
+[![Build Status](https://travis-ci.com/release-engineering/pubtools-pulp.svg?branch=master)](https://travis-ci.com/release-engineering/pubtools-pulp)
 [![Coverage Status](https://coveralls.io/repos/github/release-engineering/pubtools-pulp/badge.svg?branch=master)](https://coveralls.io/github/release-engineering/pubtools-pulp?branch=master)
 
 - [Source](https://github.com/release-engineering/pubtools-pulp)


### PR DESCRIPTION
This repo moved to travis-ci.com but badge still pointed at .org,
fix it.

(Note the repo is expected to move to github-actions soon, but it'd be
nice to fix the README meanwhile regardless.)