### PR TITLE
Clear repo content type multi instance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,6 @@ venv.bak/
 
 # mypy
 .mypy_cache/
+
+# JetBrains
+.idea/

--- a/pubtools/_pulp/arguments.py
+++ b/pubtools/_pulp/arguments.py
@@ -124,22 +124,11 @@ class SplitAndExtend(Action):
         items = getattr(namespace, self.dest, None) or []
         # if values isn't a string, don't try to split it
         # just add it to the accumulated list.
-
         # by default, argparse will parse each value as a string,
         # so unless this action is being used in conjunction with
         # parser.add_argument(type=<some non-string type>) this
         # should not be the case.
         split = values.split(self.split_on) if isinstance(values, _STRING) else values
-
-        # it is possible to end up with "" as an entry
-        # after splitting in cases with an extra trailing
-        # delimiter like ``--option value1,`` - remove them.
-
-        # calling filter(None, Iterable) is equivalent to
-        # filter(lambda item: bool(item), Iterable)
-        # i.e. yields items which evaluate to True.
-        split = list(filter(None, split))
-
         items.extend(split)
         setattr(namespace, self.dest, items)
 

--- a/pubtools/_pulp/arguments.py
+++ b/pubtools/_pulp/arguments.py
@@ -116,9 +116,9 @@ class SplitAndExtend(Action):
         https://docs.python.org/3/library/argparse.html#action
     """
 
-    def __init__(self, *args, split_on=",", **kwargs):
+    def __init__(self, *args, **kwargs):
+        self.__split_on = kwargs.pop("split_on", ",")
         super(SplitAndExtend, self).__init__(*args, **kwargs)
-        self.__split_on = split_on
 
     def __call__(self, _, namespace, values, options=None):
         items = getattr(namespace, self.dest, None) or []

--- a/pubtools/_pulp/arguments.py
+++ b/pubtools/_pulp/arguments.py
@@ -1,4 +1,10 @@
 import os
+from argparse import Action
+
+import six
+
+# short alias for version specific base string type
+_STRING = six.string_types[0]
 
 
 def from_environ(key, delegate_converter=lambda x: x):
@@ -43,3 +49,100 @@ class FromEnvironmentConverter(object):
         if not value:
             value = os.environ.get(self.key)
         return self.delegate(value)
+
+
+class SplitAndExtend(Action):
+    """Argparse Action subclass for splitting string-type arguments.
+
+    This action is intended to be similar to the built-in action
+    ``"extend"`` (Added in 3.8), which allows for multiple instances
+    of an option to be present by accumulating each instance's values
+    in to a flattened list.
+
+    Where this action adds functionality is in the ability to split
+    string arguments delimited by the ``split_on`` delimiter in to
+    a list before adding them to the resulting accumulated list.
+
+    This allows each instance that is present to be further broken
+    down in to a ``split_on`` delimited list of values.
+
+    To incorporate this action, set ``action=SplitAndExtend`` in
+    the call to ``ArgumentParser#add_argument``. By default this will
+    handle comma-delimited string args.
+
+    To use a different delimiter, pass ``split_on="your-delimiter"`` in
+    addition to ``action=SplitAndExtend``.
+
+    Examples:
+        >>> # setup the parser
+        >>> import sys
+        >>> from argparse import ArgumentParser
+        >>> parser = ArgumentParser()
+        >>> parser.add_argument("--option", type=str, action=SplitAndExtend, split_on=",")
+
+        Option with multiple instances, some are comma-delimited lists:
+        >>> sys.argv = ["command", "--option", "value1,value2", "--option", "value3"]
+        >>> args = parser.parse_args()
+        >>> print(args)
+        Namespace(option=['value1', 'value2', 'value3'])
+
+        Option with single instance, single value:
+        >>> sys.argv = ["command", "--option", "value1"]
+        >>> args = parser.parse_args()
+        >>> print(args)
+        Namespace(option=["value1"])
+
+        No option present:
+        >>> sys.argv = ["command"]
+        >>> args = parser.parse_args()
+        >>> print(args)
+        Namespace(option=None)
+
+        Option present, value missing
+        >>> sys.argv = ["command", "--option"]
+        >>> args = parser.parse_args()
+        usage: pydevconsole.py [-h] [--option OPTION]
+        pydevconsole.py: error: argument --option: expected one argument
+
+    Attributes:
+        split_on (str): the delimiter on which to split a delimited list
+            of vaules for a single instance of an option.
+
+    See Also:
+        `Built-in Argparse Actions`_
+            The set of built-in argparse Actions.
+
+    .. _Built-in Argparse Actions:
+        https://docs.python.org/3/library/argparse.html#action
+    """
+
+    def __init__(self, *args, split_on=",", **kwargs):
+        super(SplitAndExtend, self).__init__(*args, **kwargs)
+        self.__split_on = split_on
+
+    def __call__(self, _, namespace, values, options=None):
+        items = getattr(namespace, self.dest, None) or []
+        # if values isn't a string, don't try to split it
+        # just add it to the accumulated list.
+
+        # by default, argparse will parse each value as a string,
+        # so unless this action is being used in conjunction with
+        # parser.add_argument(type=<some non-string type>) this
+        # should not be the case.
+        split = values.split(self.split_on) if isinstance(values, _STRING) else values
+
+        # it is possible to end up with "" as an entry
+        # after splitting in cases with an extra trailing
+        # delimiter like ``--option value1,`` - remove them.
+
+        # calling filter(None, Iterable) is equivalent to
+        # filter(lambda item: bool(item), Iterable)
+        # i.e. yields items which evaluate to True.
+        split = list(filter(None, split))
+
+        items.extend(split)
+        setattr(namespace, self.dest, items)
+
+    @property
+    def split_on(self):
+        return self.__split_on

--- a/pubtools/_pulp/tasks/clear_repo.py
+++ b/pubtools/_pulp/tasks/clear_repo.py
@@ -14,6 +14,7 @@ from pubtools.pulplib import (
     RpmUnit,
 )
 
+from pubtools._pulp.arguments import SplitAndExtend
 from pubtools._pulp.services import (
     CollectorService,
     PulpClientService,
@@ -58,10 +59,9 @@ class ClearRepo(
 
     @property
     def content_type(self):
-        type_strs = (self.args.content_type or "").split(",")
         # Only return non-None if there were really any types given.
         # Otherwise, return None to let library defaults apply
-        return [x for x in type_strs if x] or None
+        return self.args.content_type or None
 
     def add_args(self):
         super(ClearRepo, self).add_args()
@@ -73,6 +73,8 @@ class ClearRepo(
             "--content-type",
             help="remove only content of these comma-separated type(s)",
             type=str,
+            action=SplitAndExtend,
+            split_on=",",
         )
         self.parser.add_argument("repo", nargs="+", help="Repositories to be cleared")
 

--- a/tests/clear_repo/test_clear_repo.py
+++ b/tests/clear_repo/test_clear_repo.py
@@ -333,3 +333,75 @@ def test_clear_container_repo(command_tester):
             "some-containerrepo",
         ],
     )
+
+
+def test_clear_repo_multiple_content_types(command_tester, fake_collector, monkeypatch):
+    """Test clearing a Yum repo given multiple content type values."""
+    task_instance = FakeClearRepo()
+
+    repo = YumRepository(
+        id="some-yumrepo", relative_url="some/publish/url", mutable_urls=["repomd.xml"]
+    )
+
+    files = [
+        RpmUnit(
+            name="bash",
+            version="1.23",
+            release="1.test8",
+            arch="x86_64",
+            sha256sum="a" * 64,
+            md5sum="b" * 32,
+            signing_key="aabbcc",
+        ),
+        ModulemdUnit(
+            name="mymod", stream="s1", version=123, context="a1c2", arch="s390x"
+        ),
+    ]
+
+    task_instance.pulp_client_controller.insert_repository(repo)
+    task_instance.pulp_client_controller.insert_units(repo, files)
+
+    # It should run with expected output.
+    command_tester.test(
+        task_instance.main,
+        [
+            "test-clear-repo",
+            "--pulp-url",
+            "https://pulp.example.com/",
+            "--content-type",
+            "rpm",
+            "--content-type",
+            "modulemd",
+            "--content-type",
+            "iso",
+            "some-yumrepo",
+        ],
+    )
+
+    # test the new ClearRepo argument handling for --content-type
+    # produces the expected output
+    assert task_instance.args.content_type == ["rpm", "modulemd", "iso"]
+
+    # It should record that it removed these push items:
+    assert sorted(fake_collector.items, key=lambda pi: pi["filename"]) == [
+        {
+            "state": "DELETED",
+            "origin": "pulp",
+            "src": None,
+            "dest": None,
+            "filename": "bash-1.23-1.test8.x86_64.rpm",
+            "checksums": {"sha256": "a" * 64, "md5": "b" * 32},
+            "signing_key": "AABBCC",
+            "build": None,
+        },
+        {
+            "state": "DELETED",
+            "origin": "pulp",
+            "src": None,
+            "dest": None,
+            "filename": "mymod:s1:123:a1c2:s390x",
+            "checksums": None,
+            "signing_key": None,
+            "build": None,
+        },
+    ]

--- a/tests/logs/clear_repo/test_clear_repo/test_clear_repo_multiple_content_types.jsonl
+++ b/tests/logs/clear_repo/test_clear_repo/test_clear_repo_multiple_content_types.jsonl
@@ -1,0 +1,12 @@
+{"event": {"type": "check-repos-start"}}
+{"event": {"type": "check-repos-end"}}
+{"event": {"type": "clear-content-start"}}
+{"event": {"type": "clear-content-end"}}
+{"event": {"type": "record-push-items-start"}}
+{"event": {"type": "record-push-items-end"}}
+{"event": {"type": "publish-start"}}
+{"event": {"type": "publish-end"}}
+{"event": {"type": "flush-ud-cache-start"}}
+{"event": {"type": "flush-ud-cache-end"}}
+{"event": {"type": "flush-cdn-cache-start"}}
+{"event": {"type": "flush-cdn-cache-end"}}

--- a/tests/logs/clear_repo/test_clear_repo/test_clear_repo_multiple_content_types.txt
+++ b/tests/logs/clear_repo/test_clear_repo/test_clear_repo_multiple_content_types.txt
@@ -1,0 +1,15 @@
+[    INFO] Check repos: started
+[    INFO] Check repos: finished
+[    INFO] Clear content: started
+[    INFO] some-yumrepo: removed 1 modulemd(s), 1 rpm(s), tasks: e3e70682-c209-4cac-629f-6fbed82c07cd
+[    INFO] Clear content: finished
+[    INFO] Record push items: started
+[    INFO] Record push items: finished
+[    INFO] Publish: started
+[    INFO] Publish: finished
+[    INFO] Flush UD cache: started
+[    INFO] UD cache flush is not enabled.
+[    INFO] Flush UD cache: finished
+[    INFO] Flush CDN cache: started
+[    INFO] CDN cache flush is not enabled.
+[    INFO] Flush CDN cache: finished

--- a/tests/shared/test_arguments.py
+++ b/tests/shared/test_arguments.py
@@ -1,0 +1,76 @@
+import sys
+from argparse import ArgumentParser
+
+import pytest
+
+from pubtools._pulp.arguments import SplitAndExtend
+
+FAKE_OPTION_VALUES = ["value1", "value2", "value3"]
+
+
+@pytest.fixture
+def parser():
+    return ArgumentParser()
+
+
+def test_split_and_extend_single_delimited_instance():
+    """Test a single option instance, with all values in a delimited list."""
+    # test one instance, all delimited using different delimiters
+    for delimiter in ",.-/":
+        parser = ArgumentParser()
+        parser.add_argument(
+            "--option", type=str, action=SplitAndExtend, split_on=delimiter
+        )
+
+        sys.argv = ["fake-command", "--option", delimiter.join(FAKE_OPTION_VALUES)]
+
+        args = parser.parse_args()
+        assert args.option == FAKE_OPTION_VALUES
+
+
+def test_split_and_extend_multiple_option_instances(parser):
+    """Test multiple option instances."""
+    parser.add_argument("--option", type=str, action=SplitAndExtend)
+
+    # test multiple, individual instances
+    sys.argv = ["command"]
+    for value in FAKE_OPTION_VALUES:
+        sys.argv.extend(["--option", value])
+
+    args = parser.parse_args()
+    assert args.option == FAKE_OPTION_VALUES
+
+
+def test_split_and_extend_multiple_mix_and_match_instance():
+    """Test multiple option instances, some with delimited lists."""
+    # test mix-and-match, delimited-and-not, using different delimiters
+    for delimiter in ",.-/":
+        parser = ArgumentParser()
+        parser.add_argument(
+            "--option", type=str, action=SplitAndExtend, split_on=delimiter
+        )
+
+        sys.argv = [
+            "fake-command",
+            "--option",
+            delimiter.join(FAKE_OPTION_VALUES[:-1]),
+            "--option",
+            FAKE_OPTION_VALUES[-1],
+        ]
+
+        args = parser.parse_args()
+        assert args.option == FAKE_OPTION_VALUES
+
+
+def test_split_and_extend_multiple_instances_with_trailing_delimiters(parser):
+    """Test multiple instances, each with an extra trailing delimiter."""
+    parser.add_argument("--option", type=str, action=SplitAndExtend)
+
+    # test multiple, individual instances with extra
+    # trailing delimiters e.g. --option value1, --option value2,
+    sys.argv = ["command"]
+    for value in FAKE_OPTION_VALUES:
+        sys.argv.extend(["--option", "{},".format(value)])
+
+    args = parser.parse_args()
+    assert args.option == FAKE_OPTION_VALUES

--- a/tests/shared/test_arguments.py
+++ b/tests/shared/test_arguments.py
@@ -13,19 +13,21 @@ def parser():
     return ArgumentParser()
 
 
-def test_split_and_extend_single_delimited_instance():
+@pytest.fixture(params=[",", ".", "-", "/"])
+def delimiter(request):
+    """Provide parameterization for testing different delimiters."""
+    return request.param
+
+
+def test_split_and_extend_single_delimited_instance(parser, delimiter):
     """Test a single option instance, with all values in a delimited list."""
     # test one instance, all delimited using different delimiters
-    for delimiter in ",.-/":
-        parser = ArgumentParser()
-        parser.add_argument(
-            "--option", type=str, action=SplitAndExtend, split_on=delimiter
-        )
+    parser.add_argument("--option", type=str, action=SplitAndExtend, split_on=delimiter)
 
-        sys.argv = ["fake-command", "--option", delimiter.join(FAKE_OPTION_VALUES)]
+    sys.argv = ["command", "--option", delimiter.join(FAKE_OPTION_VALUES)]
 
-        args = parser.parse_args()
-        assert args.option == FAKE_OPTION_VALUES
+    args = parser.parse_args()
+    assert args.option == FAKE_OPTION_VALUES
 
 
 def test_split_and_extend_multiple_option_instances(parser):
@@ -41,36 +43,43 @@ def test_split_and_extend_multiple_option_instances(parser):
     assert args.option == FAKE_OPTION_VALUES
 
 
-def test_split_and_extend_multiple_mix_and_match_instance():
+def test_split_and_extend_multiple_mix_and_match_instance(parser, delimiter):
     """Test multiple option instances, some with delimited lists."""
     # test mix-and-match, delimited-and-not, using different delimiters
-    for delimiter in ",.-/":
-        parser = ArgumentParser()
-        parser.add_argument(
-            "--option", type=str, action=SplitAndExtend, split_on=delimiter
-        )
+    parser.add_argument("--option", type=str, action=SplitAndExtend, split_on=delimiter)
 
-        sys.argv = [
-            "fake-command",
-            "--option",
-            delimiter.join(FAKE_OPTION_VALUES[:-1]),
-            "--option",
-            FAKE_OPTION_VALUES[-1],
-        ]
+    sys.argv = [
+        "command",
+        "--option",
+        delimiter.join(FAKE_OPTION_VALUES[:-1]),
+        "--option",
+        FAKE_OPTION_VALUES[-1],
+    ]
 
-        args = parser.parse_args()
-        assert args.option == FAKE_OPTION_VALUES
+    args = parser.parse_args()
+    assert args.option == FAKE_OPTION_VALUES
 
 
 def test_split_and_extend_multiple_instances_with_trailing_delimiters(parser):
     """Test multiple instances, each with an extra trailing delimiter."""
+
     parser.add_argument("--option", type=str, action=SplitAndExtend)
 
     # test multiple, individual instances with extra
-    # trailing delimiters e.g. --option value1, --option value2,
-    sys.argv = ["command"]
-    for value in FAKE_OPTION_VALUES:
-        sys.argv.extend(["--option", "{},".format(value)])
+    # delimiters e.g. `--option value1,` or `--option value1,,value2`
+    sys.argv = [
+        "command",
+        "--option",
+        "value0,",
+        "--option",
+        ",value1,value2,,",
+        "--option",
+        "value3,,value4",
+        "--option",
+        ",,,value5",
+    ]
+
+    expected = ["value{}".format(i) for i in range(6)]
 
     args = parser.parse_args()
-    assert args.option == FAKE_OPTION_VALUES
+    assert args.option == expected

--- a/tests/shared/test_arguments.py
+++ b/tests/shared/test_arguments.py
@@ -5,81 +5,40 @@ import pytest
 
 from pubtools._pulp.arguments import SplitAndExtend
 
-FAKE_OPTION_VALUES = ["value1", "value2", "value3"]
-
 
 @pytest.fixture
 def parser():
     return ArgumentParser()
 
 
-@pytest.fixture(params=[",", ".", "-", "/"])
-def delimiter(request):
-    """Provide parameterization for testing different delimiters."""
-    return request.param
-
-
-def test_split_and_extend_single_delimited_instance(parser, delimiter):
-    """Test a single option instance, with all values in a delimited list."""
-    # test one instance, all delimited using different delimiters
-    parser.add_argument("--option", type=str, action=SplitAndExtend, split_on=delimiter)
-
-    sys.argv = ["command", "--option", delimiter.join(FAKE_OPTION_VALUES)]
-
-    args = parser.parse_args()
-    assert args.option == FAKE_OPTION_VALUES
-
-
-def test_split_and_extend_multiple_option_instances(parser):
-    """Test multiple option instances."""
+@pytest.mark.parametrize(
+    "argv, expected",
+    [
+        (["--option", "a"], ["a"]),
+        (["--option", "a,"], ["a", ""]),
+        (["--option", "a,b"], ["a", "b"]),
+        (["--option", "a,b,"], ["a", "b", ""]),
+        (["--option", ",a,b"], ["", "a", "b"]),
+        (["--option", "a,,b"], ["a", "", "b"]),
+        (["--option", "a", "--option", "b"], ["a", "b"]),
+        (["--option", "a,b", "--option", "c"], ["a", "b", "c"]),
+        (["--option", "a", "--option", "b,c"], ["a", "b", "c"]),
+        (["--option", "a,,b", "--option", ",c,"], ["a", "", "b", "", "c", ""]),
+    ],
+)
+def test_split_and_extend(parser, argv, expected):
+    """Test SplitAndExtend argparse Action."""
     parser.add_argument("--option", type=str, action=SplitAndExtend)
-
-    # test multiple, individual instances
-    sys.argv = ["command"]
-    for value in FAKE_OPTION_VALUES:
-        sys.argv.extend(["--option", value])
-
+    sys.argv = ["command"] + argv
     args = parser.parse_args()
-    assert args.option == FAKE_OPTION_VALUES
+    assert args.option == expected
 
 
-def test_split_and_extend_multiple_mix_and_match_instance(parser, delimiter):
-    """Test multiple option instances, some with delimited lists."""
-    # test mix-and-match, delimited-and-not, using different delimiters
+@pytest.mark.parametrize("delimiter", [",", ".", "-", "/"])
+def test_split_and_extend_varying_delimiters(parser, delimiter):
+    """Test using different delimiters using a single option instance."""
+    expected = ["a", "b", "x", "y"]
     parser.add_argument("--option", type=str, action=SplitAndExtend, split_on=delimiter)
-
-    sys.argv = [
-        "command",
-        "--option",
-        delimiter.join(FAKE_OPTION_VALUES[:-1]),
-        "--option",
-        FAKE_OPTION_VALUES[-1],
-    ]
-
-    args = parser.parse_args()
-    assert args.option == FAKE_OPTION_VALUES
-
-
-def test_split_and_extend_multiple_instances_with_trailing_delimiters(parser):
-    """Test multiple instances, each with an extra trailing delimiter."""
-
-    parser.add_argument("--option", type=str, action=SplitAndExtend)
-
-    # test multiple, individual instances with extra
-    # delimiters e.g. `--option value1,` or `--option value1,,value2`
-    sys.argv = [
-        "command",
-        "--option",
-        "value0,",
-        "--option",
-        ",value1,value2,,",
-        "--option",
-        "value3,,value4",
-        "--option",
-        ",,,value5",
-    ]
-
-    expected = ["value{}".format(i) for i in range(6)]
-
+    sys.argv = ["command", "--option", delimiter.join(expected)]
     args = parser.parse_args()
     assert args.option == expected


### PR DESCRIPTION
Overview
=======
Allow the `--content-type` option to `clear-repo` to be specified multiple times. Each instance of `--content-type` still conforms to the current behavior of being a comma-separated list of content types.

Approach
-------------
Add a new [argparse.Action](https://docs.python.org/3/library/argparse.html#argparse.Action) subclass called `SplitAndExtend` that can be re-used for any situation like this and allows for delimiters other than `","` to be used (though `","` is the default). This Action class is now used in `ClearRepo#add_args` to configure the parser to accept multiple instances of `--content-type`

The `ClearRepo#content_type` property accessor has been updated so that it no longer has to do string splitting and instead just returns the accumulated list parsed from the command-line.

Multiple new test cases are added to cover some different situations that could arise when using the new Action, especially if the options list is being built programmatically. 

One additional test case is added specifically for the `clear-repo` command to ensure it behaves as expected with multiple content types.

Closes #25.



