### PR TITLE
Introduce --pulp-fake option for development/testing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- n/a
+- The `--pulp-fake` option was added for development and testing.
 
 ## [1.2.0] - 2021-08-18
 

--- a/pubtools/_pulp/services/pulp.py
+++ b/pubtools/_pulp/services/pulp.py
@@ -51,6 +51,14 @@ class PulpClientService(Service):
             default=None,
             type=pulp_throttle,
         )
+        group.add_argument(
+            "--pulp-fake",
+            help=(
+                "Use a fake in-memory Pulp client rather than interacting with a real server. "
+                + "For development/testing only, may have limited functionality."
+            ),
+            action="store_true",
+        )
 
     @property
     def pulp_client(self):
@@ -63,6 +71,11 @@ class PulpClientService(Service):
     def __get_instance(self):
         auth = None
         args = self._service_args
+
+        if args.pulp_fake:
+            LOG.warning("Using a fake Pulp client, no changes will be made to Pulp!")
+            controller = pulplib.FakeController()
+            return controller.client
 
         # checks if pulp password is available as environment variable
         if args.pulp_user:

--- a/tests/shared/test_pulp_task.py
+++ b/tests/shared/test_pulp_task.py
@@ -41,6 +41,23 @@ def test_pulp_client():
     assert isinstance(client, Client)
 
 
+def test_pulp_fake_client():
+    """Checks that a fake client is created if --pulp-fake is given"""
+    task = TaskWithPulpClient()
+    arg = ["", "--pulp-url", "https://pulp.example.com/", "--pulp-fake"]
+    with patch("sys.argv", arg):
+        client = task.pulp_client
+
+    # Fake client doesn't advertise itself in any obvious way.
+    # Just do some rough checks...
+    assert "Fake" in type(client).__name__
+
+    # Should be able to use the API even though it's obviously not connected
+    # to a real Pulp server
+    assert "rpm" in client.get_content_type_ids().result()
+    assert list(client.search_repository().result()) == []
+
+
 def test_main():
     """Checks main returns without exception when invoked with minimal args
     assuming run() and add_args() are implemented


### PR DESCRIPTION
pubtools-pulplib comes with a full-featured fake client which implements
all the same API as a real client, but with a simple in-memory
implementation instead of calling out to a real server.

Enable the usage of this client for all the tasks in pubtools-pulp.
This is never expected to be used in production, but can be useful for
development as it removes the hard dependency on a real writable
Pulp server in order to realistically exercise the code within this
project.