### PR TITLE
ci: update black version, drop from 'static', move to pre-commit-ci

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,6 @@
 repos:
 -   repo: https://github.com/ambv/black
-    rev: 026c81b83454f176a9f9253cbfb70be2c159d822
+    rev: 21.8b0
     hooks:
     - id: black
-      language_version: python3.6
-
+      language_version: python3.8

--- a/tests/garbage_collect/test_garbage_collect.py
+++ b/tests/garbage_collect/test_garbage_collect.py
@@ -47,7 +47,7 @@ def _run_test(*repos):
 
 
 def test_add_args():
-    """adds the arg to the PulpTask parser """
+    """adds the arg to the PulpTask parser"""
     gc = GarbageCollect()
     arg = ["", "--pulp-url", "http://some.url", "--gc-threshold", "7"]
 

--- a/tests/shared/test_pulp_task.py
+++ b/tests/shared/test_pulp_task.py
@@ -13,7 +13,7 @@ class TaskWithPulpClient(PulpTask, PulpClientService):
 
 
 def test_task_run():
-    """ raises if run() is not implemeted"""
+    """raises if run() is not implemeted"""
     task = PulpTask()
     with pytest.raises(NotImplementedError):
         task.run()

--- a/tox.ini
+++ b/tox.ini
@@ -17,10 +17,8 @@ deps=
 [testenv:static]
 deps=
 	-rtest-requirements.txt
-	black==20.8b1
 	pylint==2.7.2
 commands=
-	black --check .
 	sh -c 'pylint pubtools; test $(( $? & (1|2|4|32) )) = 0'
 
 [testenv:cov]


### PR DESCRIPTION
This commit drops the black code formatting tool from "tox -e static" as
well as refreshing the black version used by pre-commit (and letting
black fix a couple of files).  Instead of running black within tox,
let's have the pre-commit-ci service take care of it.

The motivation here is that I want to pin all dependencies used by tox.
But if that includes black, then updating the pins might need to include
reformatting files, and our CI doesn't implement anything like that.
However, pre-commit-ci itself already implements everything needed here,
so if we shift responsibility to that service then we don't need
anything more.