### PR TITLE
Bump pubtools-pulplib requirement

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -1,5 +1,5 @@
 six
-pubtools-pulplib>=2.8.0
+pubtools-pulplib>=2.16.0
 fastpurge
 more_executors>=2.7.0
 pushcollector>=1.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -163,9 +163,9 @@ pubtools==1.2.1 \
     --hash=sha256:1e882d0bf622617563aa779049cf6513410b599c971240f614415142979c36a8 \
     --hash=sha256:f630cb91b437c69909bbf8a4c797d2afc9b56ad280b07d912f65e702622f6d60
     # via pubtools-pulplib
-pubtools-pulplib==2.15.0 \
-    --hash=sha256:3d9e47c9654a1183753bcb298b3b2a16cb888bf6b8beb5bc99640b673a316392 \
-    --hash=sha256:c466dcb00359500283dc250aaec5db2ec709fcd6d1d8f85eb0ef089f61487518
+pubtools-pulplib==2.16.0 \
+    --hash=sha256:5abd50f2c35b5abcd73fdea1be396b7d7571a8c09c04dc909f0fbf04dbc79dc1 \
+    --hash=sha256:68876514043a17f9fd899e15f7cc8ab318f32f89acd80c527b3359036c59872b
     # via -r requirements.in
 pushcollector==1.2.0 \
     --hash=sha256:cd53036c7880957577bc9a2a3b1431e81a5aea10f4b4cbcbf98c3ee40c6f2ea3

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -408,9 +408,9 @@ pubtools==1.2.1 \
     --hash=sha256:1e882d0bf622617563aa779049cf6513410b599c971240f614415142979c36a8 \
     --hash=sha256:f630cb91b437c69909bbf8a4c797d2afc9b56ad280b07d912f65e702622f6d60
     # via pubtools-pulplib
-pubtools-pulplib==2.15.0 \
-    --hash=sha256:3d9e47c9654a1183753bcb298b3b2a16cb888bf6b8beb5bc99640b673a316392 \
-    --hash=sha256:c466dcb00359500283dc250aaec5db2ec709fcd6d1d8f85eb0ef089f61487518
+pubtools-pulplib==2.16.0 \
+    --hash=sha256:5abd50f2c35b5abcd73fdea1be396b7d7571a8c09c04dc909f0fbf04dbc79dc1 \
+    --hash=sha256:68876514043a17f9fd899e15f7cc8ab318f32f89acd80c527b3359036c59872b
     # via -r requirements.in
 pushcollector==1.2.0 \
     --hash=sha256:cd53036c7880957577bc9a2a3b1431e81a5aea10f4b4cbcbf98c3ee40c6f2ea3

--- a/tests/logs/set_maintenance/test_set_maintenance/test_maintenance_off.txt
+++ b/tests/logs/set_maintenance/test_set_maintenance/test_maintenance_off.txt
@@ -5,4 +5,5 @@
 [    INFO]  - repo2
 [    INFO] Adjust maintenance report: finished
 [    INFO] Set maintenance report: started
+[    INFO] Uploading repos.json to redhat-maintenance [85776e9a-dd84-f39e-7154-5a137a1d5006]
 [    INFO] Set maintenance report: finished

--- a/tests/logs/set_maintenance/test_set_maintenance/test_maintenance_off_with_regex.txt
+++ b/tests/logs/set_maintenance/test_set_maintenance/test_maintenance_off_with_regex.txt
@@ -5,4 +5,5 @@
 [    INFO]  - repo2
 [    INFO] Adjust maintenance report: finished
 [    INFO] Set maintenance report: started
+[    INFO] Uploading repos.json to redhat-maintenance [85776e9a-dd84-f39e-7154-5a137a1d5006]
 [    INFO] Set maintenance report: finished

--- a/tests/logs/set_maintenance/test_set_maintenance/test_maintenance_off_with_repo_not_in_maintenance.txt
+++ b/tests/logs/set_maintenance/test_set_maintenance/test_maintenance_off_with_repo_not_in_maintenance.txt
@@ -6,4 +6,5 @@
 [    INFO]  - repo1
 [    INFO] Adjust maintenance report: finished
 [    INFO] Set maintenance report: started
+[    INFO] Uploading repos.json to redhat-maintenance [85776e9a-dd84-f39e-7154-5a137a1d5006]
 [    INFO] Set maintenance report: finished

--- a/tests/logs/set_maintenance/test_set_maintenance/test_maintenance_on.txt
+++ b/tests/logs/set_maintenance/test_set_maintenance/test_maintenance_on.txt
@@ -6,4 +6,5 @@
 [    INFO]  - repo2
 [    INFO] Adjust maintenance report: finished
 [    INFO] Set maintenance report: started
+[    INFO] Uploading repos.json to redhat-maintenance [82e2e662-f728-b4fa-4248-5e3a0a5d2f34]
 [    INFO] Set maintenance report: finished

--- a/tests/logs/set_maintenance/test_set_maintenance/test_maintenance_on_with_regex.txt
+++ b/tests/logs/set_maintenance/test_set_maintenance/test_maintenance_on_with_regex.txt
@@ -5,4 +5,5 @@
 [    INFO]  - repo2
 [    INFO] Adjust maintenance report: finished
 [    INFO] Set maintenance report: started
+[    INFO] Uploading repos.json to redhat-maintenance [82e2e662-f728-b4fa-4248-5e3a0a5d2f34]
 [    INFO] Set maintenance report: finished

--- a/tests/logs/set_maintenance/test_set_maintenance/test_maintenance_on_with_repo_not_exists.txt
+++ b/tests/logs/set_maintenance/test_set_maintenance/test_maintenance_on_with_repo_not_exists.txt
@@ -7,4 +7,5 @@
 [    INFO]  - repo1
 [    INFO] Adjust maintenance report: finished
 [    INFO] Set maintenance report: started
+[    INFO] Uploading repos.json to redhat-maintenance [82e2e662-f728-b4fa-4248-5e3a0a5d2f34]
 [    INFO] Set maintenance report: finished


### PR DESCRIPTION
This pulplib update is best combined with some test updates because:

- some log-based tests need testdata updates due to logging changes in
  pulplib

- on the fake client, upload_history was deprecated, so let's remove its
  use from the couple of related tests. It arguably shouldn't have been
  there in the first place anyway, as it is an implementation detail of
  the client that calling set_maintenance involves an upload.