### PR TITLE
Add persistence to --pulp-fake

### DIFF
--- a/pubtools/_pulp/services/fakepulp.py
+++ b/pubtools/_pulp/services/fakepulp.py
@@ -1,0 +1,161 @@
+import os
+import logging
+
+import yaml
+import attr
+from pubtools.pluggy import pm, hookimpl
+
+from pubtools import pulplib
+from pubtools.pulplib import FakeController, FileRepository, YumRepository
+
+LOG = logging.getLogger("pubtools-pulp")
+
+
+def serialize(value):
+    """Serialize pulplib model objects to a form which can be stored
+    in YAML and later deserialized.
+    """
+
+    if isinstance(value, list):
+        return [serialize(elem) for elem in value]
+
+    if isinstance(value, dict):
+        out = {}
+        for key, elem in value.items():
+            out[key] = serialize(elem)
+        return out
+
+    if attr.has(type(value)):
+        # We do not use the recursion feature in asdict because it
+        # doesn't put enough metadata in the output for deserialization
+        # to work (and attr library itself doesn't provide an inverse
+        # of asdict either).
+        out = attr.asdict(value, recurse=False)
+        out["_class"] = type(value).__name__
+
+        # Private attrs field which cannot be (de)serialized
+        if "_client" in out:
+            del out["_client"]
+
+        for key in out.keys():
+            out[key] = serialize(out[key])
+        return out
+
+    return value
+
+
+def deserialize(value):
+    """Inverse of 'serialize'."""
+
+    if isinstance(value, list):
+        return [deserialize(elem) for elem in value]
+
+    if isinstance(value, dict) and "_class" not in value:
+        # Plain old dict
+        out = {}
+        for key, elem in value.items():
+            out[key] = deserialize(elem)
+        return out
+
+    if isinstance(value, dict) and "_class" in value:
+        value = value.copy()
+
+        model_class = getattr(pulplib, value.pop("_class"))
+        assert attr.has(model_class)
+
+        # Deserialize everything inside it first using the plain dict
+        # logic. This is where we recurse into nested attr classes, if any.
+        value = deserialize(value)
+
+        return model_class(**value)
+
+    return value
+
+
+class PersistentFake(object):
+    """Wraps pulplib fake client adding persistence of state."""
+
+    def __init__(self, state_path):
+        self.ctrl = FakeController()
+        self.state_path = state_path
+
+        # Register ourselves with pubtools so we can get the task stop hook,
+        # at which point we will save our current state.
+        pm.register(self)
+
+    def load_initial(self):
+        """Initial load of data into the fake, in the case where no state
+        has previously been persisted.
+
+        This will populate a hardcoded handful of repos which are expected
+        to always be present in a realistically configured rhsm-pulp server.
+        """
+        self.ctrl.insert_repository(FileRepository(id="redhat-maintenance"))
+        self.ctrl.insert_repository(FileRepository(id="all-iso-content"))
+        self.ctrl.insert_repository(YumRepository(id="all-rpm-content"))
+
+    def load(self):
+        """Load data into the fake from previously serialized state (if any).
+
+        If no state has been previously serialized, load_initial will be used
+        to seed the fake with some hardcoded state.
+        """
+
+        if not os.path.exists(self.state_path):
+            return self.load_initial()
+
+        with open(self.state_path, "rt") as f:  # pylint:disable=unspecified-encoding
+            raw = yaml.load(f, Loader=yaml.SafeLoader)
+
+        repos = raw.get("repos") or []
+        for repo in deserialize(repos):
+            self.ctrl.insert_repository(repo)
+
+        units = raw.get("units") or []
+        for unit in deserialize(units):
+            for repo_id in unit.repository_memberships:
+                repo = self.ctrl.client.get_repository(repo_id).result()
+                self.ctrl.insert_units(repo, [unit])
+
+    def save(self):
+        """Serialize the current state of the fake and save it to persistent storage."""
+
+        serialized = {}
+
+        serialized["repos"] = serialize(self.ctrl.repositories)
+        serialized["repos"].sort(key=lambda repo: repo["id"])
+
+        all_units = list(self.ctrl.client.search_content())
+        serialized["units"] = serialize(all_units)
+        serialized["units"].sort(key=repr)
+
+        path = self.state_path
+
+        state_dir = os.path.dirname(path)
+        if not os.path.isdir(state_dir):
+            os.makedirs(state_dir)
+
+        with open(path, "wt") as f:  # pylint:disable=unspecified-encoding
+            yaml.dump(serialized, f, Dumper=yaml.SafeDumper)
+
+        LOG.info("Fake pulp state persisted to %s", path)
+
+    @hookimpl
+    def task_stop(self, failed):  # pylint:disable=unused-argument
+        """Called when a task is ending."""
+        pm.unregister(self)
+        self.save()
+
+
+def new_fake_client(state_path=os.path.expanduser("~/.config/pubtools-pulp/fake.yaml")):
+    """Create and return a new fake Pulp client.
+
+    On top of the fake built in to pulplib library, this adds persistent state
+    stored under ~/.config/pubtools-pulp by default.
+
+    The state is persisted in a somewhat human-accessible form; the idea is that
+    you can manually view and edit the YAML to see how the commands behave.
+    """
+    fake = PersistentFake(state_path)
+    fake.load()
+    return fake.ctrl.client

--- a/pubtools/_pulp/task.py
+++ b/pubtools/_pulp/task.py
@@ -2,6 +2,8 @@ import logging
 import textwrap
 from argparse import ArgumentParser, RawDescriptionHelpFormatter
 
+from pubtools.pluggy import task_context
+
 from .step import StepDecorator
 
 
@@ -138,8 +140,9 @@ class PulpTask(object):
     def main(self):
         """Main method called by the entrypoint of the task."""
 
-        # setup the logging as required
-        self._setup_logging()
+        with task_context():
+            # setup the logging as required
+            self._setup_logging()
 
-        self.run()
-        return 0
+            self.run()
+            return 0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,5 @@
 import sys
+import os
 
 import requests_mock
 import pytest
@@ -27,9 +28,10 @@ def home_tmpdir(tmpdir, monkeypatch):
     for the duration of tests.
 
     This is an autouse fixture because certain used libraries
-    are influenced by files under $HOME, and for tests which
-    actually need it, we should explicitly set up anything
-    needed there instead of inheriting the user's environment.
+    and our own pulp fake are influenced by files under $HOME,
+    and for tests which actually need it, we should explicitly
+    set up anything needed there instead of inheriting the
+    user's environment.
     """
     homedir = str(tmpdir.mkdir("home"))
     monkeypatch.setenv("HOME", homedir)
@@ -62,6 +64,12 @@ def fake_collector():
     yield collector
 
     Collector.set_default_backend(None)
+
+
+@pytest.fixture
+def data_path():
+    """Returns path to the tests/data dir used to store extra files for testing."""
+    return os.path.join(os.path.dirname(__file__), "data")
 
 
 @pytest.fixture

--- a/tests/data/sample-modules.yaml
+++ b/tests/data/sample-modules.yaml
@@ -1,0 +1,138 @@
+# This file has a small selection of modules taken from Fedora and used from
+# tests in this repo. Modules with a small number of packages were chosen to
+# keep test data from being larger than necessary. Other than that, the
+# selected modules are more or less arbitrary.
+---
+document: modulemd-defaults
+version: 1
+data:
+  module: ant
+  modified: 202002242100
+  stream: 1.10
+  profiles:
+    1.10: [default]
+...
+---
+document: some-unknown-type
+comment: >
+  This is a made up document type to demonstrate Pulp's behavior of ignoring
+  unknown document types.
+...
+---
+document: modulemd
+version: 2
+data:
+  name: avocado-vt
+  stream: "82lts"
+  version: 3420210902113311
+  context: 035be0ad
+  arch: x86_64
+  summary: Avocado Virt Test Plugin
+  description: >-
+    Avocado Virt Test is a plugin that lets you execute virt-tests with all the avocado
+    convenience features, such as HTML report, Xunit output, among others. This is
+    the '82lts' rolling stream that tracks with the most recent upstream release.
+  license:
+    module:
+    - MIT
+    content:
+    - GPLv2
+  xmd: {}
+  dependencies:
+  - buildrequires:
+      platform: [f34]
+    requires:
+      avocado: [82lts]
+      platform: [f34]
+  references:
+    community: http://avocado-framework.github.io/
+    documentation: http://avocado-vt.readthedocs.io/
+    tracker: https://pagure.io/avocado-vt/issues
+  profiles:
+    default:
+      description: Common profile installing the avocado-vt plugin.
+      rpms:
+      - python3-avocado-vt
+  api:
+    rpms:
+    - python3-avocado-vt
+  components:
+    rpms:
+      avocado-vt:
+        rationale: Avocado Virt Test Plugin
+        ref: 82lts
+        arches: [aarch64, armv7hl, i686, ppc64le, s390x, x86_64]
+  artifacts:
+    rpms:
+    - avocado-vt-0:82.0-3.module_f34+12808+b491ffc8.src
+    - python3-avocado-vt-0:82.0-3.module_f34+12808+b491ffc8.noarch
+...
+---
+document: modulemd-defaults
+version: 1
+data:
+  module: dwm
+  modified: 202002242100
+  profiles:
+    6.0: [default]
+    6.1: [default]
+    6.2: [default]
+    latest: [default]
+...
+---
+document: modulemd
+version: 2
+data:
+  name: dwm
+  stream: "6.0"
+  version: 3420210201213909
+  context: 058368ca
+  arch: x86_64
+  summary: Dynamic window manager for X
+  description: >-
+    dwm is a dynamic window manager for X.  It manages windows in tiled, monocle,
+    and floating layouts.  All of the layouts can be applied dynamically, optimizing
+    the environment for the application in use and the task performed.
+  license:
+    module:
+    - MIT
+    content:
+    - MIT
+  xmd: {}
+  dependencies:
+  - buildrequires:
+      platform: [f34]
+    requires:
+      platform: [f34]
+  references:
+    community: https://suckless.org/
+    documentation: https://dwm.suckless.org/
+  profiles:
+    default:
+      description: The minimal, distribution-compiled dwm binary.
+      rpms:
+      - dwm
+    user:
+      description: Includes distribution-compiled dwm as well as a helper script to
+        apply user patches and configuration, dwm-user.
+      rpms:
+      - dwm
+      - dwm-user
+  api:
+    rpms:
+    - dwm
+    - dwm-user
+  components:
+    rpms:
+      dwm:
+        rationale: The main component of this module.
+        ref: 6.0
+        arches: [aarch64, armv7hl, i686, ppc64le, s390x, x86_64]
+  artifacts:
+    rpms:
+    - dwm-0:6.0-1.module_f34+11150+aec78cf8.src
+    - dwm-0:6.0-1.module_f34+11150+aec78cf8.x86_64
+    - dwm-debuginfo-0:6.0-1.module_f34+11150+aec78cf8.x86_64
+    - dwm-debugsource-0:6.0-1.module_f34+11150+aec78cf8.x86_64
+    - dwm-user-0:6.0-1.module_f34+11150+aec78cf8.x86_64
+...

--- a/tests/fake/test_fake_persistence.py
+++ b/tests/fake/test_fake_persistence.py
@@ -1,0 +1,117 @@
+import os
+
+from pubtools.pluggy import task_context
+from pubtools.pulplib import ModulemdDefaultsUnit, ModulemdUnit
+
+from pubtools._pulp.services.fakepulp import new_fake_client
+
+
+def test_state_persisted(tmpdir, data_path):
+    """Fake client automatically saves/loads state across tasks."""
+    state_path1 = str(tmpdir.join("pulpfake.yaml"))
+    state_path2 = str(tmpdir.join("pulpfake-other.yaml"))
+
+    module_file = os.path.join(data_path, "sample-modules.yaml")
+
+    # Simulate task 1 creating some state
+    with task_context():
+        client = new_fake_client(state_path1)
+
+        # It should already have a few repos since there is some default
+        # state.
+        repo_ids = sorted([repo.id for repo in client.search_repository()])
+        assert repo_ids == ["all-iso-content", "all-rpm-content", "redhat-maintenance"]
+
+        # Now add a bit more state.
+        # We use modules here because that's one of the more complex types
+        # to serialize.
+        repo = client.get_repository("all-rpm-content")
+        repo.upload_modules(module_file).result()
+
+        # And check the resulting units.
+        units = list(repo.search_content())
+        units.sort(key=lambda u: (u.content_type_id, u.name))
+        assert units == [
+            ModulemdUnit(
+                name="avocado-vt",
+                stream="82lts",
+                version=3420210902113311,
+                context="035be0ad",
+                arch="x86_64",
+                content_type_id="modulemd",
+                repository_memberships=["all-rpm-content"],
+                artifacts=[
+                    "avocado-vt-0:82.0-3.module_f34+12808+b491ffc8.src",
+                    "python3-avocado-vt-0:82.0-3.module_f34+12808+b491ffc8.noarch",
+                ],
+                profiles={
+                    "default": {
+                        "description": "Common profile installing the avocado-vt plugin.",
+                        "rpms": ["python3-avocado-vt"],
+                    }
+                },
+            ),
+            ModulemdUnit(
+                name="dwm",
+                stream="6.0",
+                version=3420210201213909,
+                context="058368ca",
+                arch="x86_64",
+                content_type_id="modulemd",
+                repository_memberships=["all-rpm-content"],
+                artifacts=[
+                    "dwm-0:6.0-1.module_f34+11150+aec78cf8.src",
+                    "dwm-0:6.0-1.module_f34+11150+aec78cf8.x86_64",
+                    "dwm-debuginfo-0:6.0-1.module_f34+11150+aec78cf8.x86_64",
+                    "dwm-debugsource-0:6.0-1.module_f34+11150+aec78cf8.x86_64",
+                    "dwm-user-0:6.0-1.module_f34+11150+aec78cf8.x86_64",
+                ],
+                profiles={
+                    "default": {
+                        "description": "The minimal, distribution-compiled dwm binary.",
+                        "rpms": ["dwm"],
+                    },
+                    "user": {
+                        "description": "Includes distribution-compiled dwm as well as a helper script to apply user patches and configuration, dwm-user.",
+                        "rpms": ["dwm", "dwm-user"],
+                    },
+                },
+            ),
+            ModulemdDefaultsUnit(
+                name="ant",
+                repo_id="all-rpm-content",
+                stream="1.10",
+                profiles={"1.10": ["default"]},
+                content_type_id="modulemd_defaults",
+                repository_memberships=["all-rpm-content"],
+            ),
+            ModulemdDefaultsUnit(
+                name="dwm",
+                repo_id="all-rpm-content",
+                stream=None,
+                profiles={
+                    "6.0": ["default"],
+                    "6.1": ["default"],
+                    "6.2": ["default"],
+                    "latest": ["default"],
+                },
+                content_type_id="modulemd_defaults",
+                repository_memberships=["all-rpm-content"],
+            ),
+        ]
+
+    # Now see if another task can see that same state.
+    with task_context():
+        # We'll look at two different state paths to prove that the path
+        # affects the behavior.
+        client1 = new_fake_client(state_path1)
+        client2 = new_fake_client(state_path2)
+
+        # In client1, the units previously persisted should be available again
+        # exactly as before.
+        new_units = list(client1.get_repository("all-rpm-content").search_content())
+        new_units.sort(key=lambda u: (u.content_type_id, u.name))
+        assert units == new_units
+
+        # client2 on the other hand has no content.
+        assert [] == list(client2.get_repository("redhat-maintenance").search_content())


### PR DESCRIPTION
This change makes the --pulp-fake argument much more useful by:

- having it save and load state as each task is run
- having it seed a bit of common state (e.g. existence of
  all-rpm-content repo) if there is no prior state

The intent is to make running the tasks against a fake usable in
situations where it previously wasn't, and also make it possible to
view the changes made by a task. It's similar in concept to
developing a service against a local sqlite DB while a remote
DB is used in production.

As an example, if I run the maintenance-on command like this:

    $ pubtools-pulp-maintenance-on --pulp-fake --repo-ids myrepo
    [INFO    ] Get maintenance report: started
    [WARNING ] Using a fake Pulp client, no changes will be made to Pulp!
    [INFO    ] Get maintenance report: finished
    [INFO    ] Adjust maintenance report: started
    [WARNING ] Didn't find following repositories:
    [WARNING ]  - myrepo
    [INFO    ] Adjust maintenance report: finished
    [INFO    ] Set maintenance report: started
    [INFO    ] Uploading repos.json to redhat-maintenance [82e2e662-f728-b4fa-4248-5e3a0a5d2f34]
    [INFO    ] Set maintenance report: finished
    [INFO    ] Fake pulp state persisted to /home/rmcgover/.config/pubtools-pulp/fake.yaml

I can check the state file to see that it uploaded a repos.json into
redhat-maintenance as claimed:

    $ tail -n8 /home/rmcgover/.config/pubtools-pulp/fake.yaml
    units:
    - _class: FileUnit
      content_type_id: iso
      path: repos.json
      repository_memberships:
      - redhat-maintenance
      sha256sum: ebd05e2128ae0a929bc7163c0457830d3d89d0b758c9aa3f93d087238e125c96
      size: 126

I can also manually modify the state file to simulate any desired
conditions.