### PR TITLE
Add PULP_THROTTLE env variable for task throttle in Pulp client

### DIFF
--- a/pubtools/_pulp/services/pulp.py
+++ b/pubtools/_pulp/services/pulp.py
@@ -47,7 +47,8 @@ class PulpClientService(Service):
         )
         group.add_argument(
             "--pulp-throttle",
-            help="Allows to enqueue or run only specified number of Pulp tasks at one moment",
+            help="Allows to enqueue or run only specified number of Pulp tasks at one moment "
+            + "(or set PULP_THROTTLE environment variable)",
             default=None,
             type=pulp_throttle,
         )
@@ -92,7 +93,9 @@ class PulpClientService(Service):
             # Thank you, but we don't need to hear about this for every single request
             warnings.filterwarnings("once", r"Unverified HTTPS request is being made")
 
-        if args.pulp_throttle:
-            kwargs["task_throttle"] = args.pulp_throttle
+        if args.pulp_throttle or os.environ.get("PULP_THROTTLE"):
+            kwargs["task_throttle"] = args.pulp_throttle or pulp_throttle(
+                os.environ.get("PULP_THROTTLE")
+            )
 
         return pulplib.Client(args.pulp_url, **kwargs)


### PR DESCRIPTION
Task throttle in Pulp client is modified with the --pulp-throttle
option in the PulpClientService. This throttle value will now be
modified with the PULP_THROTTLE environment variable as well. It
should be defined before invoking the task and the client service
will pick the throttle value from the env if it's not specified
as the --pulp-throttle option.