### PR TITLE
tests: fix a non-forwards-compatible test

### DIFF
--- a/tests/fake/test_fake_persistence.py
+++ b/tests/fake/test_fake_persistence.py
@@ -28,76 +28,14 @@ def test_state_persisted(tmpdir, data_path):
         repo = client.get_repository("all-rpm-content")
         repo.upload_modules(module_file).result()
 
-        # And check the resulting units.
-        units = list(repo.search_content())
-        units.sort(key=lambda u: (u.content_type_id, u.name))
-        assert units == [
-            ModulemdUnit(
-                name="avocado-vt",
-                stream="82lts",
-                version=3420210902113311,
-                context="035be0ad",
-                arch="x86_64",
-                content_type_id="modulemd",
-                repository_memberships=["all-rpm-content"],
-                artifacts=[
-                    "avocado-vt-0:82.0-3.module_f34+12808+b491ffc8.src",
-                    "python3-avocado-vt-0:82.0-3.module_f34+12808+b491ffc8.noarch",
-                ],
-                profiles={
-                    "default": {
-                        "description": "Common profile installing the avocado-vt plugin.",
-                        "rpms": ["python3-avocado-vt"],
-                    }
-                },
-            ),
-            ModulemdUnit(
-                name="dwm",
-                stream="6.0",
-                version=3420210201213909,
-                context="058368ca",
-                arch="x86_64",
-                content_type_id="modulemd",
-                repository_memberships=["all-rpm-content"],
-                artifacts=[
-                    "dwm-0:6.0-1.module_f34+11150+aec78cf8.src",
-                    "dwm-0:6.0-1.module_f34+11150+aec78cf8.x86_64",
-                    "dwm-debuginfo-0:6.0-1.module_f34+11150+aec78cf8.x86_64",
-                    "dwm-debugsource-0:6.0-1.module_f34+11150+aec78cf8.x86_64",
-                    "dwm-user-0:6.0-1.module_f34+11150+aec78cf8.x86_64",
-                ],
-                profiles={
-                    "default": {
-                        "description": "The minimal, distribution-compiled dwm binary.",
-                        "rpms": ["dwm"],
-                    },
-                    "user": {
-                        "description": "Includes distribution-compiled dwm as well as a helper script to apply user patches and configuration, dwm-user.",
-                        "rpms": ["dwm", "dwm-user"],
-                    },
-                },
-            ),
-            ModulemdDefaultsUnit(
-                name="ant",
-                repo_id="all-rpm-content",
-                stream="1.10",
-                profiles={"1.10": ["default"]},
-                content_type_id="modulemd_defaults",
-                repository_memberships=["all-rpm-content"],
-            ),
-            ModulemdDefaultsUnit(
-                name="dwm",
-                repo_id="all-rpm-content",
-                stream=None,
-                profiles={
-                    "6.0": ["default"],
-                    "6.1": ["default"],
-                    "6.2": ["default"],
-                    "latest": ["default"],
-                },
-                content_type_id="modulemd_defaults",
-                repository_memberships=["all-rpm-content"],
-            ),
+        # And sanity check the resulting units.
+        units = sorted(repo.search_content(), key=repr)
+        unit_keys = sorted(["%s-%s" % (u.content_type_id, u.name) for u in units])
+        assert unit_keys == [
+            "modulemd-avocado-vt",
+            "modulemd-dwm",
+            "modulemd_defaults-ant",
+            "modulemd_defaults-dwm",
         ]
 
     # Now see if another task can see that same state.
@@ -109,8 +47,9 @@ def test_state_persisted(tmpdir, data_path):
 
         # In client1, the units previously persisted should be available again
         # exactly as before.
-        new_units = list(client1.get_repository("all-rpm-content").search_content())
-        new_units.sort(key=lambda u: (u.content_type_id, u.name))
+        new_units = sorted(
+            client1.get_repository("all-rpm-content").search_content(), key=repr
+        )
         assert units == new_units
 
         # client2 on the other hand has no content.


### PR DESCRIPTION
In tests outside of pubtools-pulplib, it is a bit risky to compare
expected results against precise *Unit instances. The problem is that if
pubtools-pulplib gains support for any new fields, and the fake client
sets those fields to non-default values, then the test would start to
fail as the objects would no longer be precisely equal.

The effect is that such a test may not be forwards-compatible with
newer versions of pubtools-pulplib.

Fix it up by not comparing details we don't care about. In this specific
case, we're only trying to do a sanity check of modulemds we've
uploaded, so we don't need to check every field.