### PR TITLE
Make --pulp-fake persistence cleaner

### DIFF
--- a/tests/fake/test_fake_persistence.py
+++ b/tests/fake/test_fake_persistence.py
@@ -54,3 +54,30 @@ def test_state_persisted(tmpdir, data_path):
 
         # client2 on the other hand has no content.
         assert [] == list(client2.get_repository("redhat-maintenance").search_content())
+
+
+def test_state_clean(tmpdir):
+    """Persisted state does not include default values."""
+    state_path = str(tmpdir.join("pulpfake.yaml"))
+
+    # Do no-op tasks to trigger a persistence round-trip
+    with task_context():
+        new_fake_client(state_path)
+
+    with task_context():
+        client = new_fake_client(state_path)
+
+    # Now let's have a look at this repo which has gone through a save/load cycle...
+    repo = client.get_repository("all-rpm-content").result()
+
+    # It should have a value for this field
+    assert repo.type == "rpm-repo"
+
+    # But actually that's just the default value, so the fake should
+    # have been smart enough to not persist it.
+    persisted_raw = open(state_path, "rt").read()
+    assert "rpm-repo" not in persisted_raw
+
+    # (And just to sanity check that this kind of test makes sense, see that
+    # other non-default fields are present.)
+    assert "id: all-rpm-content" in persisted_raw


### PR DESCRIPTION
In typical cases, many fields on repo and unit objects will simply be
using their default values.

Don't persist those fields; it keeps the files cleaner, and also works
better in cases where a new version of pubtools-pulplib changes the
default value for a field.