### PR TITLE
tests: fix one uncovered path for --pulp-fake

### DIFF
--- a/tests/fake/test_fake_persistence.py
+++ b/tests/fake/test_fake_persistence.py
@@ -8,8 +8,8 @@ from pubtools._pulp.services.fakepulp import new_fake_client
 
 def test_state_persisted(tmpdir, data_path):
     """Fake client automatically saves/loads state across tasks."""
-    state_path1 = str(tmpdir.join("pulpfake.yaml"))
-    state_path2 = str(tmpdir.join("pulpfake-other.yaml"))
+    state_path1 = str(tmpdir.join("state/pulpfake.yaml"))
+    state_path2 = str(tmpdir.join("state/pulpfake-other.yaml"))
 
     module_file = os.path.join(data_path, "sample-modules.yaml")
 


### PR DESCRIPTION
The fake is supposed to support automatically creating the directory for
the state file. However, this is not tested if we put the state file
directly in "tmpdir" during tests, since that dir already exists.