### PR TITLE
Add pulp flush  hook [RHELDST-7309]

### DIFF
--- a/pubtools/_pulp/hooks.py
+++ b/pubtools/_pulp/hooks.py
@@ -1,0 +1,17 @@
+import sys
+
+from pubtools.pluggy import hookspec, pm
+
+
+@hookspec
+def task_pulp_flush():
+    """Invoked during task execution after successful completion of all Pulp
+    publishes.
+
+    This hook is invoked a maximum of once per task, to indicate that all Pulp
+    content associated with the task is considered fully up-to-date. The
+    intended usage is to flush Pulp-derived caches or to notify systems that
+    Pulp content may have recently changed."""
+
+
+pm.add_hookspecs(sys.modules[__name__])

--- a/pubtools/_pulp/tasks/common.py
+++ b/pubtools/_pulp/tasks/common.py
@@ -10,6 +10,8 @@ from pubtools.pulplib import PublishOptions
 from pubtools._pulp.task import PulpTask
 from pubtools._pulp.services import FastPurgeClientService, UdCacheClientService
 
+from ..hooks import pm
+
 LOG = logging.getLogger("pubtools.pulp")
 
 step = PulpTask.step
@@ -141,6 +143,9 @@ class Publisher(CDNCache, UdCache):
         # wait for the publish to complete before
         # flushing caches.
         f_sequence(publish_fs).result()
+
+        # hook implementation(s) may now flush pulp-derived caches and datastores
+        pm.hook.task_pulp_flush()
 
         # flush CDN cache
         out = self.flush_cdn(repos)

--- a/requirements.in
+++ b/requirements.in
@@ -1,4 +1,5 @@
 six
+pubtools>=0.3.0
 pubtools-pulplib>=2.21.0
 fastpurge
 more_executors>=2.7.0

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ setup(
             "pubtools-pulp-maintenance-off = pubtools._pulp.tasks.set_maintenance.set_maintenance_off:entry_point",
             "pubtools-pulp-publish = pubtools._pulp.tasks.publish:entry_point",
             "pubtools-pulp-push = pubtools._pulp.tasks.push:entry_point",
-        ]
+        ],
     },
     project_urls={
         "Documentation": "https://release-engineering.github.io/pubtools-pulp/",


### PR DESCRIPTION
A hook, "task_pulp_flush", is now specified and called when
pubtools-pulp-push completes publishing all repositories. Hook
implementations may now subscribe to these events to flush pulp-derived
caches and datastores.