### PR TITLE
push: support the remainder of File mutable fields

### DIFF
--- a/pubtools/_pulp/tasks/push/items/file.py
+++ b/pubtools/_pulp/tasks/push/items/file.py
@@ -36,8 +36,9 @@ class PulpFilePushItem(PulpPushItem):
     def unit_for_update(self):
         return attr.evolve(
             self.pulp_unit,
-            # TODO: support other mutable fields too (e.g. content ISO fields)
             description=self.pushsource_item.description,
+            version=self.pushsource_item.version,
+            display_order=self.pushsource_item.display_order,
             # Note: cdn_path is intentionally omitted here as it would not be safe
             # to change that value if the unit was already published, so we only
             # support setting it on upload.
@@ -65,8 +66,9 @@ class PulpFilePushItem(PulpPushItem):
         return repo.upload_file(
             self.pushsource_item.src,
             relative_url=self.pushsource_item.name,
-            # TODO: support other mutable fields too
             description=self.pushsource_item.description,
+            version=self.pushsource_item.version,
+            display_order=self.pushsource_item.display_order,
             cdn_path=self.cdn_path,
             # If there's an existing pulp unit which has already been published to
             # CDN, then cdn_publish is copied across.

--- a/requirements.in
+++ b/requirements.in
@@ -1,7 +1,7 @@
 six
 pubtools>=0.3.0
-pubtools-pulplib>=2.22.0
+pubtools-pulplib>=2.23.0
 fastpurge
 more_executors>=2.7.0
 pushcollector>=1.2.0
-pushsource
+pushsource>=2.14.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -203,18 +203,18 @@ pubtools==1.2.1 \
     # via
     #   -r requirements.in
     #   pubtools-pulplib
-pubtools-pulplib==2.22.0 \
-    --hash=sha256:d1d52d969eab1132b7bbe19882fb519d9d10e2204e037e4fad12f60ee3942ca6 \
-    --hash=sha256:ff6851ad43094cef90c2aa643b3778f2b1cbf1f1238c42bf585e4bfb49b78fc4
+pubtools-pulplib==2.23.0 \
+    --hash=sha256:36de71079620b0724393f0d304773b2c2704201a1ca407ee37407e1b78126168 \
+    --hash=sha256:645b9a8cbc7e893a331da124d16a86556c59c8a7ba306654b487fa7172965ae7
     # via -r requirements.in
 pushcollector==1.2.0 \
     --hash=sha256:cd53036c7880957577bc9a2a3b1431e81a5aea10f4b4cbcbf98c3ee40c6f2ea3
     # via
     #   -r requirements.in
     #   pushsource
-pushsource==2.13.4 \
-    --hash=sha256:a90245f8b377ea03e535ea92d5b3811fe54dec6f98792302073b3d5910b20384 \
-    --hash=sha256:ada6a276466da812652e4568602df3789d56981b6f54bec230fa240bc658fa41
+pushsource==2.14.0 \
+    --hash=sha256:18a3f18e9ca4e444eb97abf3fced0c3ba58b1ea1e0d1717512df43a097893c41 \
+    --hash=sha256:5619f3039f456794b38abd0564803d4015457ae4fb49a1a97da31a37f8439eaf
     # via -r requirements.in
 pyasn1==0.4.8 \
     --hash=sha256:39c7e2ec30515947ff4e87fb6f456dfc6e84857d34be479c9d4a4ba4bf46aa5d \

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -491,18 +491,18 @@ pubtools==1.2.1 \
     # via
     #   -r requirements.in
     #   pubtools-pulplib
-pubtools-pulplib==2.22.0 \
-    --hash=sha256:d1d52d969eab1132b7bbe19882fb519d9d10e2204e037e4fad12f60ee3942ca6 \
-    --hash=sha256:ff6851ad43094cef90c2aa643b3778f2b1cbf1f1238c42bf585e4bfb49b78fc4
+pubtools-pulplib==2.23.0 \
+    --hash=sha256:36de71079620b0724393f0d304773b2c2704201a1ca407ee37407e1b78126168 \
+    --hash=sha256:645b9a8cbc7e893a331da124d16a86556c59c8a7ba306654b487fa7172965ae7
     # via -r requirements.in
 pushcollector==1.2.0 \
     --hash=sha256:cd53036c7880957577bc9a2a3b1431e81a5aea10f4b4cbcbf98c3ee40c6f2ea3
     # via
     #   -r requirements.in
     #   pushsource
-pushsource==2.13.4 \
-    --hash=sha256:a90245f8b377ea03e535ea92d5b3811fe54dec6f98792302073b3d5910b20384 \
-    --hash=sha256:ada6a276466da812652e4568602df3789d56981b6f54bec230fa240bc658fa41
+pushsource==2.14.0 \
+    --hash=sha256:18a3f18e9ca4e444eb97abf3fced0c3ba58b1ea1e0d1717512df43a097893c41 \
+    --hash=sha256:5619f3039f456794b38abd0564803d4015457ae4fb49a1a97da31a37f8439eaf
     # via -r requirements.in
 py==1.11.0 \
     --hash=sha256:51c75c4126074b472f746a24399ad32f6053d1b34b68d2fa41e558e6f4a98719 \

--- a/tests/data/staged-mixed/staged.yaml
+++ b/tests/data/staged-mixed/staged.yaml
@@ -23,5 +23,6 @@ payload:
     - filename: some-iso
       relative_path: iso-dest2/ISOS/some-iso
       sha256sum: db68c8a70f8383de71c107dca5fcfe53b1132186d1a6681d9ee3f4eea724fabb
+      order: 3.0
       attributes:
         description: My wonderful ISO

--- a/tests/logs/push/test_push/test_typical_push.pulp.yaml
+++ b/tests/logs/push/test_push/test_typical_push.pulp.yaml
@@ -2915,6 +2915,7 @@ units:
   sha256sum: 315f5bdb76d078c43b8ac0064e4a0164612b1fce77c869345bfc94c75894edd3
   size: 13
   unit_id: (hidden)
+  version: 1.2.3
 - _class: FileUnit
   cdn_path: /content/origin/files/sha256/d8/d8301c5f72f16455dbc300f3d1bef8972424255caad103cc6c7ba7dc92d90ca8/test.txt
   cdn_published: *id001
@@ -2928,6 +2929,7 @@ units:
   cdn_path: /content/origin/files/sha256/db/db68c8a70f8383de71c107dca5fcfe53b1132186d1a6681d9ee3f4eea724fabb/some-iso
   cdn_published: *id001
   description: My wonderful ISO
+  display_order: 3.0
   path: some-iso
   repository_memberships:
   - iso-dest2

--- a/tests/logs/push/test_push/test_update_push.pulp.yaml
+++ b/tests/logs/push/test_push/test_update_push.pulp.yaml
@@ -2915,6 +2915,7 @@ units:
   sha256sum: 315f5bdb76d078c43b8ac0064e4a0164612b1fce77c869345bfc94c75894edd3
   size: 13
   unit_id: (hidden)
+  version: 1.2.3
 - _class: FileUnit
   cdn_path: /content/origin/files/sha256/d8/d8301c5f72f16455dbc300f3d1bef8972424255caad103cc6c7ba7dc92d90ca8/test.txt
   cdn_published: 2021-12-14 09:59:00
@@ -2928,6 +2929,7 @@ units:
   cdn_path: /content/origin/files/sha256/db/db68c8a70f8383de71c107dca5fcfe53b1132186d1a6681d9ee3f4eea724fabb/some-iso
   cdn_published: 2021-12-14 09:59:00
   description: My wonderful ISO
+  display_order: 3.0
   path: some-iso
   repository_memberships:
   - iso-dest1

--- a/tests/logs/push/test_push_copy_fails/test_push_copy_fails.txt
+++ b/tests/logs/push/test_push_copy_fails/test_push_copy_fails.txt
@@ -21,4 +21,4 @@
 [    INFO] Doing Pulp search: ((content_type_id IN ['iso']) AND (sha256sum=='db68c8a70f8383de71c107dca5fcfe53b1132186d1a6681d9ee3f4eea724fabb' AND path=='some-file'))
 [   ERROR] Associate items in Pulp: failed
 [    INFO] Fake pulp state persisted to <tmpdir>/fake-pulp-state.yaml
-# Raised: Fatal error: Pulp unit not present in repo(s) iso-dest2 after copy: FileUnit(path='some-file', size=46, sha256sum='db68c8a70f8383de71c107dca5fcfe53b1132186d1a6681d9ee3f4eea724fabb', description=None, cdn_path=None, cdn_published=None, content_type_id='iso', repository_memberships=['iso-dest1'], unit_id='e3e70682-c209-4cac-629f-6fbed82c07cd')
+# Raised: Fatal error: Pulp unit not present in repo(s) iso-dest2 after copy: FileUnit(path='some-file', size=46, sha256sum='db68c8a70f8383de71c107dca5fcfe53b1132186d1a6681d9ee3f4eea724fabb', description=None, version=None, display_order=None, cdn_path=None, cdn_published=None, content_type_id='iso', repository_memberships=['iso-dest1'], unit_id='e3e70682-c209-4cac-629f-6fbed82c07cd')


### PR DESCRIPTION
version, display_order fields can now be passed onto Pulp, fixing
one of the TODOs. With the latest version of pubtools-pulplib, this will
result in the setting of ud_file_release_mappings_2 repo note during
publish.

(note the comment's reference to content ISOs is outdated, as we decided
that content ISOs won't be ported over to this code.)