### PR TITLE
Add progress tracking onto push phases [RHELDST-8331]

### DIFF
--- a/pubtools/_pulp/tasks/push/command.py
+++ b/pubtools/_pulp/tasks/push/command.py
@@ -135,7 +135,7 @@ class Push(
         # start them all.
         #
         # This will start all the phases...
-        with exitstack(phases):
+        with exitstack([ctx.progress_logger()] + phases):
             LOG.debug("All push phases are now running.")
             # ...and exiting the 'with' block here will wait for them to
             # complete.

--- a/pubtools/_pulp/tasks/push/phase/collect.py
+++ b/pubtools/_pulp/tasks/push/phase/collect.py
@@ -17,7 +17,7 @@ class Collect(Phase):
     def __init__(self, context, collector, **_):
         super(Collect, self).__init__(
             context,
-            in_queue=context.new_queue(),
+            in_queue=context.new_queue(counting=False),
             out_queue=False,
             name="Collect push item metadata",
         )

--- a/pubtools/_pulp/tasks/push/phase/context.py
+++ b/pubtools/_pulp/tasks/push/phase/context.py
@@ -1,6 +1,81 @@
+# -*- coding: utf-8 -*-
+
+import os
+import logging
+import shutil
+from collections import namedtuple
+
+from contextlib import contextmanager
+
+from threading import Lock, Thread, Event
+
 from six.moves.queue import Queue
 
 from .base import Phase
+
+# u here is not redundant since we still support py2...
+# pylint: disable=redundant-u-string-prefix
+
+LOG = logging.getLogger("pubtools.pulp")
+
+# How long, in seconds, between our logging of current phase progress.
+PROGRESS_INTERVAL = int(os.getenv("PUBTOOLS_PULP_PROGRESS_INTERVAL") or "600")
+
+
+QueueCounts = namedtuple("QueueCounts", ["put", "get", "done"])
+
+
+class CountingQueue(object):
+    """A Queue wrapper adding some counting & progress reporting features."""
+
+    def __init__(self, **kwargs):
+        # Name is expected to be set after construction, as phases are wired together.
+        self.name = "<unknown queue>"
+        self._get_count = 0
+        self._put_count = 0
+        self._done_count = 0
+        self._lock = Lock()
+        self._delegate = Queue(**kwargs)
+
+    def _incr_get(self):
+        with self._lock:
+            self._get_count += 1
+
+    def _incr_put(self):
+        with self._lock:
+            self._put_count += 1
+
+    def _incr_done(self):
+        with self._lock:
+            self._done_count += 1
+
+    @property
+    def counts(self):
+        """Returns a QueueCounts tuple for the current state of this queue.
+
+        Can be used to estimate the progress of a phase reading from this
+        queue.
+        """
+        with self._lock:
+            return QueueCounts(self._put_count, self._get_count, self._done_count)
+
+    # The following methods are API-compatible with the standard Queue
+    # methods, but simultaneously update our counts.
+
+    def put(self, item, *args, **kwargs):
+        self._delegate.put(item, *args, **kwargs)
+        if item not in (Phase.ERROR, Phase.FINISHED):
+            self._incr_put()
+
+    def get(self, *args, **kwargs):
+        out = self._delegate.get(*args, **kwargs)
+        if out not in (Phase.ERROR, Phase.FINISHED):
+            self._incr_get()
+        return out
+
+    def task_done(self):
+        self._delegate.task_done()
+        self._incr_done()
 
 
 class Context(object):
@@ -32,12 +107,143 @@ class Context(object):
         for queue in self._queues:
             queue.put(Phase.ERROR)
 
-    def new_queue(self, *args, **kwargs):
+    def new_queue(self, counting=True, **kwargs):
         """Create and return a new Queue.
 
         The Queue is associated with this context such that, if the context
         enters the error state, the queue will receive an ERROR object.
+
+        If counting is True, get/put counts will be recorded for the queue
+        and the queue will participate in progress logging. This should be
+        disabled for unusual cases.
         """
-        out = Queue(*args, **kwargs)
+        if counting:
+            out = CountingQueue(**kwargs)
+        else:
+            out = Queue(**kwargs)
         self._queues.append(out)
         return out
+
+    def dump_progress(self, width=None):
+        """Output a log with progress info for each queue associated with the
+        context.
+
+        The log has a visual component (progress bars) and also a structured
+        event logged via 'extra'.
+        """
+
+        if width is None:
+            width = 80
+
+            # Conditional due to py2
+            if hasattr(shutil, "get_terminal_size"):
+                (width, _) = shutil.get_terminal_size()
+
+        snapshot = []
+        max_namelen = 0
+        max_count = 1
+
+        for queue in self._queues:
+            if not isinstance(queue, CountingQueue):
+                # A queue which does not make sense for counting/progress,
+                # such as the one used by Collect phase.
+                continue
+
+            max_namelen = max(max_namelen, len(queue.name))
+            counts = queue.counts
+            snapshot.append((queue.name, counts))
+            max_count = max(max_count, *counts)
+
+        template_str = "[ %%%ds | %%s%%s%%s%%s ]" % max_namelen
+        bar_width = width - max_namelen - 10
+
+        # We will create both human-oriented strings and machine-oriented
+        # structured metrics (logged via 'extra'). In practice this can be
+        # gathered into JSONL logs.
+        formatted_strs = []
+        event = {"type": "progress-report", "phases": []}
+
+        for (name, counts) in snapshot:
+            # We want to draw a progress bar like this:
+            #
+            # "▇▇▇▇▄▄▄▄▄▁▁▁▁              "
+            #
+            # The bar fills in from left to right.
+            #
+            # '▇' => done processing
+            # '▄' => currently in progress
+            # '▁' => waiting in queue
+            # ' ' => items not yet arrived in queue (estimated)
+            #
+
+            # Proportions of the bar from left to right
+            part1 = float(counts.done) / max_count
+            part2 = float(counts.get - counts.done) / max_count
+            part3 = float(counts.put - counts.get) / max_count
+            part4 = 1.0 - part3 - part2 - part1
+
+            # How much is that in character count?
+            part1 = int(part1 * bar_width)
+            part2 = int(part2 * bar_width)
+            part3 = int(part3 * bar_width)
+            part4 = int(part4 * bar_width)
+
+            # FIXME: code below uses fmt off/on to allow u string literals
+            # with black. Drop this when python2 support goes away!
+            # fmt: off
+            bar1 = u"▇" * part1
+            bar2 = u"▄" * part2
+            bar3 = u"▁" * part3
+            bar4 = u" " * part4
+            # fmt: on
+
+            # Seeing as we've truncated downwards to get integers, we may
+            # need to pad a few more spaces to fill out the bar
+            while len(bar1 + bar2 + bar3 + bar4) < bar_width:
+                bar4 = bar4 + " "
+
+            formatted_strs.append(template_str % (name, bar1, bar2, bar3, bar4))
+
+            # Add counts to the structured event as well.
+            event["phases"].append(
+                {
+                    "name": name,
+                    "in-queue": counts.put - counts.get,
+                    "in-progress": counts.get - counts.done,
+                    "done": counts.done,
+                    "total": max_count,
+                }
+            )
+
+        LOG.info("Progress:\n  %s", "\n  ".join(formatted_strs), extra={"event": event})
+
+    @contextmanager
+    def progress_logger(self, interval=PROGRESS_INTERVAL):
+        """A context manager for periodically logging the progress of all queues.
+
+        While the context is open, progress will be logged periodically via
+        dump_progress. This logging ends once the context is closed.
+        """
+
+        if interval <= 0:
+            # Allows the feature to be entirely disabled.
+            yield
+            return
+
+        stop_logging = Event()
+
+        def loop():
+            while not stop_logging.is_set():
+                self.dump_progress()
+                stop_logging.wait(timeout=interval)
+
+        thread = Thread(name="progress-logger", target=loop)
+        thread.daemon = True
+
+        thread.start()
+        try:
+            yield
+        finally:
+            stop_logging.set()
+            thread.join()
+            self.dump_progress()

--- a/pubtools/_pulp/tasks/push/phase/end_pre_push.py
+++ b/pubtools/_pulp/tasks/push/phase/end_pre_push.py
@@ -44,6 +44,7 @@ class EndPrePush(Phase):
                 count_other += 1
             # Notify of final push item state.
             self.update_push_items([item])
+            self.in_queue.task_done()
 
         # Notify that there are no more push item updates coming.
         self.update_push_items([self.FINISHED])

--- a/pubtools/_pulp/tasks/push/phase/publish.py
+++ b/pubtools/_pulp/tasks/push/phase/publish.py
@@ -95,6 +95,13 @@ class Publish(Phase):
         ]
         self.update_push_items(pushed_items)
 
+        # Mark as done for accurate progress logs.
+        # Note we don't keep track of exactly which items got published through each
+        # repo, so this will simply show that everything moved from in progress to done
+        # at once.
+        for _ in pushed_items:
+            self.in_queue.task_done()
+
         # And we know nothing more happens to the push items, so we can tell
         # collector that we're finished.
         self.update_push_items([self.FINISHED])

--- a/tests/push/test_context_counts.py
+++ b/tests/push/test_context_counts.py
@@ -1,0 +1,179 @@
+# -*- coding: utf-8 -*-
+
+import logging
+import textwrap
+import threading
+
+from threading import Semaphore
+
+from pubtools._pulp.tasks.push.phase import Context, Phase
+from pubtools._pulp.tasks.push.contextlib_compat import exitstack
+
+
+class SynchronizedPhase(Phase):
+    # A Phase implementation which processes items in batches
+    # of a specified size, and which only makes progress when
+    # we increment a semaphore so that the test has fine-grained
+    # control over the progress.
+    def __init__(self, in_sem, out_sem, batch_size, *args, **kwargs):
+        self.in_sem = in_sem
+        self.out_sem = out_sem
+        self.batch_size = batch_size
+        super(SynchronizedPhase, self).__init__(*args, **kwargs)
+
+    def run(self):
+        for items in self.iter_input_batched(
+            batch_size=self.batch_size,
+        ):
+            for item in items:
+                self.in_sem.acquire()
+                self.put_output(item)
+                self.out_sem.release()
+
+
+def test_context_counts(caplog):
+    """Context object counts events on queues, which can be logged
+    by dump_progress."""
+
+    ctx = Context()
+    queues = ctx._queues
+
+    in_sem1 = Semaphore(0)
+    in_sem2 = Semaphore(0)
+    in_sem3 = Semaphore(0)
+    out_sem1 = Semaphore(0)
+    out_sem2 = Semaphore(0)
+    out_sem3 = Semaphore(0)
+
+    q1 = ctx.new_queue()
+    q2 = ctx.new_queue()
+    q3 = ctx.new_queue()
+    # last queue does not use counting since nothing consumes from it.
+    q4 = ctx.new_queue(counting=False)
+
+    p1 = SynchronizedPhase(
+        in_sem1, out_sem1, 10, context=ctx, in_queue=q1, out_queue=q2, name="phase 1"
+    )
+    p2 = SynchronizedPhase(
+        in_sem2, out_sem2, 10, context=ctx, in_queue=q2, out_queue=q3, name="phase 2"
+    )
+    p3 = SynchronizedPhase(
+        in_sem3, out_sem3, 10, context=ctx, in_queue=q3, out_queue=q4, name="phase 3"
+    )
+
+    # Nothing has started yet, so all queues should have zero counts.
+    # Note: there are 4 queues since the last phase also has an output queue, but
+    # since counting is not enabled for that one, we ignore it when checking counts.
+    assert len(queues) == 4
+    for q in queues[:3]:
+        assert q.counts == (0, 0, 0)
+
+    # Now allow all the phases to start.
+    with exitstack([p1, p2, p3]):
+        # Fill up the first queue with 35 items (3.5 batches) and then an item
+        # informing that we're done.
+        for i in range(0, 35):
+            q1.put(i)
+        q1.put(Phase.FINISHED)
+
+        # Allow phases to make progress:
+        # - p1 send 20 items
+        # - p2 send 15 items
+        # - p3 send 5 items
+        for _ in range(0, 20):
+            in_sem1.release()
+            out_sem1.acquire()
+        for _ in range(0, 15):
+            in_sem2.release()
+            out_sem2.acquire()
+        for _ in range(0, 5):
+            in_sem3.release()
+            out_sem3.acquire()
+
+        # We know exactly how much progress has been made, so check the queues now.
+        try:
+            assert queues[0].name == "phase 1"
+            c1 = queues[0].counts
+
+            assert queues[1].name == "phase 2"
+            c2 = queues[1].counts
+
+            assert queues[2].name == "phase 3"
+            c3 = queues[2].counts
+
+            # (put, get, done) counts should match exactly the progress
+            # that we've allowed. Keep in mind that gets always happen
+            # in multiples of 10 since that's our batch size.
+            assert c1 == (35, 30, 20)
+            assert c2 == (20, 20, 15)
+            assert c3 == (15, 10, 5)
+
+            caplog.set_level(logging.INFO)
+            ctx.dump_progress(width=70)
+
+            # When visualized, this is what it should look like.
+            assert (
+                caplog.messages[-1].strip()
+                # to allow u string literal... (FIXME: remove when py2 dropped)
+                # fmt: off
+                == textwrap.dedent(
+                    u"""
+                    Progress:
+                      [ phase 1 | ▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▁▁▁▁▁▁▁  ]
+                      [ phase 2 | ▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▄▄▄▄▄▄▄                         ]
+                      [ phase 3 | ▇▇▇▇▇▇▇▄▄▄▄▄▄▄▁▁▁▁▁▁▁                                 ]
+                    """
+                ).strip()
+                # fmt: on
+            )
+
+            # Similar info should be available in structured form (so it can go
+            # into JSONL logs)
+            rec = caplog.records[-1]
+            assert rec.event == {
+                "type": "progress-report",
+                "phases": [
+                    {
+                        "name": "phase 1",
+                        "in-queue": 5,
+                        "in-progress": 10,
+                        "done": 20,
+                        "total": 35,
+                    },
+                    {
+                        "name": "phase 2",
+                        "in-queue": 0,
+                        "in-progress": 5,
+                        "done": 15,
+                        "total": 35,
+                    },
+                    {
+                        "name": "phase 3",
+                        "in-queue": 5,
+                        "in-progress": 5,
+                        "done": 5,
+                        "total": 35,
+                    },
+                ],
+            }
+
+        finally:
+            # Whether test passes or fails, release all the semaphores to avoid deadlock.
+            for _ in range(0, 1000):
+                in_sem1.release()
+                in_sem2.release()
+                in_sem3.release()
+
+
+def test_context_progress_logger_disabled():
+    """An interval of 0 disables the progress logger."""
+
+    ctx = Context()
+
+    # The progress logger is implemented by a thread, so we can verify that
+    # nothing happens by checking that the thread count is stable.
+    threadcount = len(threading.enumerate())
+
+    with ctx.progress_logger(interval=0):
+        # Should not have spawned a new thread.
+        assert len(threading.enumerate()) == threadcount


### PR DESCRIPTION
Track queue events to get an idea of the progress of each phase.
For each phase, by looking at how many items have been put onto the
queue and how many have been taken out, we can figure out the overall
progress of the phase.

This progress info will be logged at a configurable interval as push runs
(every 5 minutes by default). The logging includes both a visual
component (progress bars) and structured metrics which can be gathered
into JSONL logs.

The primary goal of this logging is to make it clear which of the phases
acts as a bottleneck and could benefit from performance improvements or
tuning.