### PR TITLE
Tweak progress logger to look at COLUMNS by default

### DIFF
--- a/pubtools/_pulp/tasks/push/phase/context.py
+++ b/pubtools/_pulp/tasks/push/phase/context.py
@@ -133,7 +133,7 @@ class Context(object):
         """
 
         if width is None:
-            width = 80
+            width = int(os.environ.get("COLUMNS") or "80")
 
             # Conditional due to py2
             if hasattr(shutil, "get_terminal_size"):


### PR DESCRIPTION
Without this, when running in Pub there is no way to customize
the width of the progress bar. (shutil.get_terminal_size already
respects COLUMNS, but it's not available for python 2.)