### PR TITLE
Improve pipelining of upload, update, query & associate push phases

### DIFF
--- a/pubtools/_pulp/tasks/push/copy.py
+++ b/pubtools/_pulp/tasks/push/copy.py
@@ -52,3 +52,24 @@ class CopyOperation(object):
         )
 
         log_fn(msg)
+
+
+def asserting_copied_ok(item):
+    """Given an item which has allegedly just been copied to all desired target repos:
+
+    - raises if the item is still missing any repos, or...
+    - returns the item if it's not missing any repos
+    """
+    missing_repos = item.missing_pulp_repos
+    if missing_repos:
+        msg = "Fatal error: Pulp unit not present in repo(s) %s after copy: %s" % (
+            ", ".join(missing_repos),
+            item.pulp_unit,
+        )
+        raise RuntimeError(msg)
+    return item
+
+
+def asserting_all_copied_ok(items):
+    """Like asserting_copied_ok, but for a list of items."""
+    return [asserting_copied_ok(item) for item in items]

--- a/pubtools/_pulp/tasks/push/phase/associate.py
+++ b/pubtools/_pulp/tasks/push/phase/associate.py
@@ -39,10 +39,8 @@ class Associate(Phase):
             batch = remaining[:BATCH_SIZE]
             remaining = remaining[BATCH_SIZE:]
 
-            # TODO: this could be parallelized further.
             for items in PulpPushItem.items_by_type(batch):
-                for item in PulpPushItem.associated_items_single_batch(
+                for associated_f in PulpPushItem.associated_items_single_batch(
                     self.pulp_client, items
                 ):
-                    assert item
-                    self.put_output(item)
+                    self.put_future_outputs(associated_f)

--- a/pubtools/_pulp/tasks/push/phase/query_pulp.py
+++ b/pubtools/_pulp/tasks/push/phase/query_pulp.py
@@ -25,13 +25,9 @@ class QueryPulp(Phase):
         self.pulp_client = pulp_client
 
     def run(self):
-        # TODO: this could be parallelized further. There's no reason we need to
-        # wait for one batch to complete before starting the search for the next
-        # one.
         for batch in self.iter_input_batched():
             for items in PulpPushItem.items_by_type(batch):
-                for item in PulpPushItem.items_with_pulp_state_single_batch(
+                updated_items_f = PulpPushItem.items_with_pulp_state_single_batch(
                     self.pulp_client, items
-                ):
-                    assert item
-                    self.put_output(item)
+                )
+                self.put_future_outputs(updated_items_f)


### PR DESCRIPTION
As a holdover from the older generator-based implementation, the logic
in these phases was written in a way such that no items would be output
until all items had been received on the input. This unnecessarily
blocks later phases.

Rewrite them to remove the unnecessary blocking. In each case a refactor
is done so that the phase is able to make use of put_future_output(s),
similarly as done for the checksum phase in fa8cedbd84.