### PR TITLE
push: fix phase start logs out of order in edge cases

### DIFF
--- a/pubtools/_pulp/tasks/push/phase/base.py
+++ b/pubtools/_pulp/tasks/push/phase/base.py
@@ -298,7 +298,6 @@ class Phase(object):
             target=self.__thread_target, name="phase-%s" % self.__machine_name
         )
         self.__thread.daemon = True
-        self.__thread.start()
 
         # If there's no in queue then we treat the phase as immediately started
         # for logging purposes. Otherwise, we'll wait until we see at least one
@@ -306,6 +305,8 @@ class Phase(object):
         if self.in_queue is None:
             self.__started = True
             self.__log_start()
+
+        self.__thread.start()
 
     def __exit__(self, *_):
         LOG.debug("%s: joining", self.name)


### PR DESCRIPTION
Theoretically, if a phase executes very quickly, thread.start() here
could run the entire phase to completion and log the "finished" message
before the very next call to log_start which logs the "started" message.
Make sure we log_start before starting the thread to prevent this.

This probably only affects tests, where trivial phase implementations
with a near-empty run() method might be used.