### PR TITLE
push: fix an error handling mistake which could swallow exceptions

### DIFF
--- a/tests/push/test_phase_error_logs.py
+++ b/tests/push/test_phase_error_logs.py
@@ -1,0 +1,64 @@
+import logging
+
+from more_executors.futures import f_return_error
+
+from pubtools._pulp.tasks.push.phase import Context, Phase
+
+
+class ImmediateErrorPhase(Phase):
+    # A Phase implementation which always raises some error directly
+    # from within run().
+
+    def run(self):
+        raise RuntimeError("simulated immediate error")
+
+
+class AsyncErrorPhase(Phase):
+    # A Phase implementation which tries put_future_output with a
+    # future always raising an error.
+
+    def run(self):
+        exc = RuntimeError("simulated async error")
+        self.put_future_output(f_return_error(exc))
+
+
+def test_immediate_raise(caplog):
+    """Immediate raise in phase's run() will be logged as a fatal error."""
+
+    caplog.set_level(logging.INFO)
+
+    ctx = Context()
+
+    phase = ImmediateErrorPhase(ctx, name="test-phase")
+
+    # Let it run
+    with phase:
+        pass
+
+    # It should have flagged an error
+    assert ctx.has_error
+
+    # It should have logged the exception
+    assert "test-phase: fatal error occurred" in caplog.text
+    assert "simulated immediate error" in caplog.text
+
+
+def test_async_raise(caplog):
+    """Async raise via put_future_output will be logged as a fatal error."""
+
+    caplog.set_level(logging.INFO)
+
+    ctx = Context()
+
+    phase = AsyncErrorPhase(ctx, name="test-phase")
+
+    # Let it run
+    with phase:
+        pass
+
+    # It should have flagged an error
+    assert ctx.has_error
+
+    # It should have logged the exception
+    assert "test-phase: fatal error occurred" in caplog.text
+    assert "simulated async error" in caplog.text


### PR DESCRIPTION
Errors can occur asynchronously when put_future_output is used.
A comment here reasoned that this should not be logged in the error
handling callback because re-raising the exception will cause it
to propagate elsewhere and appropriate logging will happen there.

That reasoning was not correct for all cases. When the error was
re-raised, we'd be putting the phase into a state where __get_input
would raise PhaseInterrupted and __future_puts would raise the original
exception. There is no guarantee which one happens first, as it depends
how the phase implements run(). If the former happened first, the
original exception which caused the interruption would be silently lost.

Update the error handling so that the exception will always be logged in
this scenario.