### PR TITLE
push: reduce modulemd-related blocking in associate

### DIFF
--- a/pubtools/_pulp/tasks/push/phase/associate.py
+++ b/pubtools/_pulp/tasks/push/phase/associate.py
@@ -1,5 +1,5 @@
 from .base import Phase, BATCH_SIZE
-from ..items import PulpPushItem
+from ..items import PulpPushItem, PulpRpmPushItem
 
 
 class Associate(Phase):
@@ -22,23 +22,52 @@ class Associate(Phase):
         self.pulp_client = pulp_client
         self.pre_push = pre_push
 
+    def iter_for_associate(self):
+        """A special batched iterator for this phase which reorders all RPMs
+        to the end of the queue.
+
+        Why: it is strongly encouraged to ensure all modulemds are put into repos
+        before we start putting RPMs into them, to reduce the risk that we could
+        accidentally expose an RPM without the corresponding modulemd as that
+        can break systems consuming the repos. Therefore we need to ensure any
+        module items are processed before we can proceed to associate any RPM
+        items.
+
+        Note this potentially could be made smarter by, for example, tracking
+        the state of modulemds for each repo, or even fully tracking the
+        dependencies between each modulemd and the RPMs referenced by it, but
+        it's unclear whether the additional complexity would be worth it.
+        """
+
+        yield_later = []
+
+        for batch in self.iter_input_batched():
+            yield_now = []
+
+            for item in batch:
+                if isinstance(item, PulpRpmPushItem):
+                    # RPMs are held until later
+                    yield_later.append(item)
+                else:
+                    yield_now.append(item)
+
+            if yield_now:
+                yield yield_now
+
+        # OK, everything other than RPMs have been seen already.
+        # By this point we know that modulemds are all in the right repos (noting
+        # that modulemds are fully handled during upload phase, so by the time
+        # we see a modulemd item in this phase, it's all done).
+        #
+        # That means it's safe to go ahead and yield RPMs, since any corresponding
+        # modulemds must be in place.
+        while yield_later:
+            batch = yield_later[:BATCH_SIZE]
+            yield_later = yield_later[BATCH_SIZE:]
+            yield batch
+
     def run(self):
-        # Synchronization point prior to association.
-        #
-        # Why: it is strongly encouraged to ensure all modulemds are put into repos
-        # before we start putting RPMs into them, to reduce the risk that we could
-        # accidentally expose an RPM without the corresponding modulemd. Therefore we
-        # need to ensure any module items are processed by uploaded_items above,
-        # before we can proceed to associate any RPM items.
-        #
-        # TODO: try to make this smarter so it handles only that modulemd/rpm case
-        # described above without slowing other stuff down?
-        remaining = list(self.iter_input())
-
-        while remaining:
-            batch = remaining[:BATCH_SIZE]
-            remaining = remaining[BATCH_SIZE:]
-
+        for batch in self.iter_for_associate():
             for items in PulpPushItem.items_by_type(batch):
                 for associated_f in PulpPushItem.associated_items_single_batch(
                     self.pulp_client, items

--- a/tests/push/test_associate_item_order.py
+++ b/tests/push/test_associate_item_order.py
@@ -1,0 +1,45 @@
+from pubtools._pulp.tasks.push.items import (
+    PulpFilePushItem,
+    PulpModuleMdPushItem,
+    PulpRpmPushItem,
+)
+from pubtools._pulp.tasks.push.phase import Context, Associate, Phase
+
+
+def test_associate_order():
+    """Associate phase reorders items so that RPMs are processed last."""
+
+    ctx = Context()
+    queue = ctx.new_queue()
+    phase = Associate(context=ctx, pulp_client=None, pre_push=None, in_queue=queue)
+
+    # Arrange for various items coming into the associate phase noting that
+    # RPMs are not last.
+    # Note: items don't have to actually be valid for this test, so we're just
+    # creating a lot of empty objects.
+    # Also, we use awkward numbers so it doesn't line up exactly with
+    # BATCH_SIZE.
+    rpms = [PulpRpmPushItem(pushsource_item=None) for _ in range(0, 1003)]
+    modules = [PulpModuleMdPushItem(pushsource_item=None) for _ in range(0, 2040)]
+    files = [PulpFilePushItem(pushsource_item=None) for _ in range(0, 300)]
+
+    rpm_ids = [id(rpm) for rpm in rpms]
+    module_ids = [id(module) for module in modules]
+    file_ids = [id(file) for file in files]
+
+    # Put everything on the queue...
+    for item in rpms + modules + files:
+        queue.put(item)
+
+    # Put this so that iteration will end
+    queue.put(Phase.FINISHED)
+
+    # Now let's see how iteration over it will work out
+    got_ids = []
+    for batch in phase.iter_for_associate():
+        got_ids.extend([id(item) for item in batch])
+
+    # We should have got all the same items back out as we put in,
+    # but the order is different: RPMs have been shifted to the
+    # end (and the order is otherwise the same as the input)
+    assert got_ids == module_ids + file_ids + rpm_ids


### PR DESCRIPTION
We want to ensure that RPMs are always associated into target repos only
after any corresponding modulemds. Previously, the simplistic solution
to this was simply to not associate *anything* until *all* uploads had
completed, but that causes unnecessary blocking in some cases and
potentially wastes a lot of time for pushes which don't even use RPMs or
modules.

With a minor refactor we can do a little better: make associate process
RPMs last, only after all other items have made it into the phase. Fixes
a TODO.

This could still be improved further by tracking information on which
modules/RPMs correspond to each other and in which repos, but the
performance vs complexity trade-off isn't clear right now.