### PR TITLE
push: make queue size adjustable

### DIFF
--- a/pubtools/_pulp/tasks/push/phase/context.py
+++ b/pubtools/_pulp/tasks/push/phase/context.py
@@ -21,6 +21,13 @@ LOG = logging.getLogger("pubtools.pulp")
 # How long, in seconds, between our logging of current phase progress.
 PROGRESS_INTERVAL = int(os.getenv("PUBTOOLS_PULP_PROGRESS_INTERVAL") or "600")
 
+# The default max size of each phase's item queue.
+#
+# This value may need tuning per the following:
+# - if too small, pushes will slow down as phases won't be pipelined as much
+# - if too large, memory usage may be too high on pushes with large numbers
+#   of items as queues fill up
+QUEUE_SIZE = int(os.getenv("PUBTOOLS_PULP_QUEUE_SIZE") or "10000")
 
 QueueCounts = namedtuple("QueueCounts", ["put", "get", "done"])
 
@@ -130,6 +137,9 @@ class Context(object):
         and the queue will participate in progress logging. This should be
         disabled for unusual cases.
         """
+        if "maxsize" not in kwargs:
+            kwargs["maxsize"] = QUEUE_SIZE
+
         if counting:
             out = CountingQueue(**kwargs)
         else:

--- a/tests/push/test_push.py
+++ b/tests/push/test_push.py
@@ -17,6 +17,7 @@ from pubtools.pulplib import (
 from pubtools.pluggy import pm
 
 from pubtools._pulp.tasks.push import entry_point
+from pubtools._pulp.tasks.push.phase import context
 
 from .util import hide_unit_ids
 
@@ -187,11 +188,16 @@ def test_typical_push(
 
 
 def test_update_push(
-    fake_controller, data_path, fake_push, fake_state_path, command_tester
+    fake_controller, data_path, fake_push, fake_state_path, command_tester, monkeypatch
 ):
     """Test a more complex push where items already exist in Pulp in a variety of
     different states.
     """
+
+    # For this test we'll force an abnormally small queue size.
+    # This will verify that nothing breaks in edge cases such as the queue size
+    # being smaller than the batch size.
+    monkeypatch.setattr(context, "QUEUE_SIZE", 2)
 
     # Sanity check that the Pulp server is, initially, empty.
     client = fake_controller.client


### PR DESCRIPTION
Add a tunable for the max size of queues used to pass items between
phases. The intent is to provide a way of reducing memory usage.