### PR TITLE
Use slots for all attr.s classes

### DIFF
--- a/pubtools/_pulp/tasks/clear_repo.py
+++ b/pubtools/_pulp/tasks/clear_repo.py
@@ -36,7 +36,7 @@ LOG = logging.getLogger("pubtools.pulp")
 # pylint: disable=no-member
 
 
-@attr.s
+@attr.s(slots=True)
 class ClearedRepo(object):
     """Represents a single repo which has been cleared."""
 

--- a/pubtools/_pulp/tasks/push/copy.py
+++ b/pubtools/_pulp/tasks/push/copy.py
@@ -9,7 +9,7 @@ import attr
 LOG = logging.getLogger("pubtools.pulp")
 
 
-@attr.s(frozen=True)
+@attr.s(frozen=True, slots=True)
 class CopyOperation(object):
     # Represents a single copy operation between one repo and another.
     src_repo_id = attr.ib(type=str)

--- a/pubtools/_pulp/tasks/push/items/base.py
+++ b/pubtools/_pulp/tasks/push/items/base.py
@@ -67,12 +67,12 @@ class State(object):
     IN_REPOS = "IN_REPOS"
 
 
-@attr.s(frozen=True)
+@attr.s(frozen=True, slots=True)
 class UploadContext(object):
     client = attr.ib(default=None)
 
 
-@attr.s(frozen=True)
+@attr.s(frozen=True, slots=True)
 class PulpPushItem(object):
     """Wraps a pushitem with additional info for Pulp push.
 

--- a/pubtools/_pulp/tasks/push/items/comps.py
+++ b/pubtools/_pulp/tasks/push/items/comps.py
@@ -6,7 +6,7 @@ from .direct import PulpDirectUploadPushItem
 
 
 @supports_type(CompsXmlPushItem)
-@attr.s(frozen=True)
+@attr.s(frozen=True, slots=True)
 class PulpCompsXmlPushItem(PulpDirectUploadPushItem):
     """Handler for comps.xml files which are uploaded directly to each dest repo."""
 

--- a/pubtools/_pulp/tasks/push/items/direct.py
+++ b/pubtools/_pulp/tasks/push/items/direct.py
@@ -10,7 +10,7 @@ from .base import PulpPushItem, State
 # pylint:disable=abstract-method
 
 
-@attr.s(frozen=True)
+@attr.s(frozen=True, slots=True)
 class PulpDirectUploadPushItem(PulpPushItem):
     """A specialization of PulpPushItems for content types with the following behavior:
 

--- a/pubtools/_pulp/tasks/push/items/erratum.py
+++ b/pubtools/_pulp/tasks/push/items/erratum.py
@@ -15,7 +15,7 @@ LOG = logging.getLogger("pubtools.pulp")
 
 
 @supports_type(ErratumPushItem)
-@attr.s(frozen=True)
+@attr.s(frozen=True, slots=True)
 class PulpErratumPushItem(PulpPushItem):
     """Handler for errata."""
 

--- a/pubtools/_pulp/tasks/push/items/file.py
+++ b/pubtools/_pulp/tasks/push/items/file.py
@@ -8,7 +8,7 @@ from .base import supports_type, PulpPushItem
 
 
 @supports_type(FilePushItem)
-@attr.s(frozen=True)
+@attr.s(frozen=True, slots=True)
 class PulpFilePushItem(PulpPushItem):
     """Handler for generic files (in Pulp2 terms, "iso" units)."""
 

--- a/pubtools/_pulp/tasks/push/items/modulemd.py
+++ b/pubtools/_pulp/tasks/push/items/modulemd.py
@@ -6,7 +6,7 @@ from .direct import PulpDirectUploadPushItem
 
 
 @supports_type(ModuleMdPushItem)
-@attr.s(frozen=True)
+@attr.s(frozen=True, slots=True)
 class PulpModuleMdPushItem(PulpDirectUploadPushItem):
     """Handler for modulemd YAML files which are uploaded directly to each dest repo."""
 

--- a/pubtools/_pulp/tasks/push/items/productid.py
+++ b/pubtools/_pulp/tasks/push/items/productid.py
@@ -6,7 +6,7 @@ from .direct import PulpDirectUploadPushItem
 
 
 @supports_type(ProductIdPushItem)
-@attr.s(frozen=True)
+@attr.s(frozen=True, slots=True)
 class PulpProductIdPushItem(PulpDirectUploadPushItem):
     """Handler for productids which are uploaded directly to each dest repo."""
 

--- a/pubtools/_pulp/tasks/push/items/rpm.py
+++ b/pubtools/_pulp/tasks/push/items/rpm.py
@@ -7,7 +7,7 @@ import attr
 from .base import supports_type, PulpPushItem
 
 
-@attr.s(frozen=True)
+@attr.s(frozen=True, slots=True)
 class RpmUploader(object):
     """A custom context for RPM uploads.
 
@@ -19,7 +19,7 @@ class RpmUploader(object):
 
 
 @supports_type(RpmPushItem)
-@attr.s(frozen=True)
+@attr.s(frozen=True, slots=True)
 class PulpRpmPushItem(PulpPushItem):
     """Handler for RPMs."""
 


### PR DESCRIPTION
Tasks dealing with many items have been running into some memory usage
issues. Slots-based classes are expected to reduce memory pressure, and
we don't seem to be impacted by the caveats about this in the attrs
docs, so let's use them.