### PR TITLE
push: fix attempting to flush UD cache for all-rpm-content

### DIFF
--- a/pubtools/_pulp/tasks/push/items/erratum.py
+++ b/pubtools/_pulp/tasks/push/items/erratum.py
@@ -35,7 +35,18 @@ class PulpErratumPushItem(PulpPushItem):
         # right now.
         #
         out = set(super(PulpErratumPushItem, self).publish_pulp_repos)
-        out.update(self.in_pulp_repos)
+
+        for repo_id in self.in_pulp_repos:
+            # Though the existing code doesn't push errata to all-rpm-content,
+            # historically advisories have been pushed there. We shouldn't return
+            # this from publish_pulp_repos as there's no point in trying to publish
+            # it, and worse, UD cache flush on this repo gives a fatal error.
+            #
+            # Also note that there's an entire family of these repos, hence the
+            # startswith rather than plain equality check.
+            if not repo_id.startswith("all-rpm-content"):
+                out.add(repo_id)
+
         return sorted(out)
 
     def with_unit(self, unit):

--- a/tests/push/test_pulperratumpushitem.py
+++ b/tests/push/test_pulperratumpushitem.py
@@ -15,7 +15,12 @@ def test_erratum_publishes_all_repos():
             id="abc123",
             # ...and the advisory already exists in some Pulp, repos, maybe with
             # some overlap
-            repository_memberships=["existing1", "existing2"],
+            repository_memberships=[
+                "all-rpm-content",
+                "all-rpm-content-ff",
+                "existing1",
+                "existing2",
+            ],
         ),
     )
 
@@ -23,4 +28,5 @@ def test_erratum_publishes_all_repos():
     # it should always include both the new repo(s) we're pushing to and also the
     # existing repos, as any mutation of the erratum requires metadata to be
     # republished for all of them.
+    # all-rpm-content is an exception given that those repos don't get published.
     assert item.publish_pulp_repos == ["existing1", "existing2", "new1", "new2"]


### PR DESCRIPTION
Due to the errata-specific logic of "if unit changes in any repo,
republish all of them", we could end up trying to publish & cache flush
the all-rpm-content repo here if an erratum unit existed in that repo.
Publish wouldn't be a problem as the pulp client is smart enough to
realize that's a no-op, but cache flush would fail.

Add a condition to avoid doing any publish handling for those repos.