### PR TITLE
Add some caching onto Pulp repo lookups

### DIFF
--- a/pubtools/_pulp/services/__init__.py
+++ b/pubtools/_pulp/services/__init__.py
@@ -1,4 +1,5 @@
 from .collector import CollectorService
 from .fastpurge_ import FastPurgeClientService
 from .pulp import PulpClientService
+from .cachingpulp import CachingPulpClientService
 from .udcache import UdCacheClientService

--- a/pubtools/_pulp/services/cachingpulp.py
+++ b/pubtools/_pulp/services/cachingpulp.py
@@ -1,0 +1,62 @@
+import threading
+import logging
+
+from .pulp import PulpClientService
+
+LOG = logging.getLogger("pubtools.pulp")
+
+
+class CachingPulpClient(object):
+    """A Pulp client wrapper adding some modest caching."""
+
+    def __init__(self, delegate):
+        # Most methods work as usual, so just copy some references across.
+        self.search_repository = delegate.search_repository
+        self.search_content = delegate.search_content
+        self.copy_content = delegate.copy_content
+        self.update_content = delegate.update_content
+
+        self._delegate = delegate
+        self._repo_cache = {}
+        self._lock = threading.Lock()
+
+    def get_repository(self, repo_id):
+        with self._lock:
+            # Use cached object if we have one - but not if it was
+            # unsuccessful.
+            out = self._repo_cache.get(repo_id)
+            if out and (not out.done() or not out.exception()):
+                return out
+
+        out = self._delegate.get_repository(repo_id)
+        with self._lock:
+            self._repo_cache[repo_id] = out
+
+        return out
+
+
+# Because class is designed as a mix-in...
+# pylint: disable=no-member
+
+
+class CachingPulpClientService(PulpClientService):
+    """A service providing a caching Pulp client.
+
+    When this service is inherited by a task, that task will have access to
+    both a pulp_client property which is a Pulp client, and a
+    caching_pulp_client property which returns the same client with some caching
+    added.
+    """
+
+    def __init__(self, *args, **kwargs):
+        self.__lock = threading.Lock()
+        self.__instance = None
+        super(CachingPulpClientService, self).__init__(*args, **kwargs)
+
+    @property
+    def caching_pulp_client(self):
+        """A caching Pulp client used during task, instantiated on demand."""
+        with self.__lock:
+            if not self.__instance:
+                self.__instance = CachingPulpClient(self.pulp_client)
+        return self.__instance

--- a/pubtools/_pulp/tasks/push/command.py
+++ b/pubtools/_pulp/tasks/push/command.py
@@ -18,7 +18,7 @@ from .phase import (
 from ..common import Publisher, PulpTask
 from ...services import (
     CollectorService,
-    PulpClientService,
+    CachingPulpClientService,
 )
 
 step = PulpTask.step
@@ -34,7 +34,7 @@ LOG = logging.getLogger("pubtools.pulp")
 
 class Push(
     CollectorService,
-    PulpClientService,
+    CachingPulpClientService,
     Publisher,
     PulpTask,
 ):
@@ -89,7 +89,7 @@ class Push(
             # all used by every phase.
             kwargs.update(
                 context=ctx,
-                pulp_client=self.pulp_client,
+                pulp_client=self.caching_pulp_client,
                 pre_push=self.args.pre_push,
                 update_push_items=collect_phase.update_push_items,
                 publish_with_cache_flush=self.publish_with_cache_flush,

--- a/pubtools/_pulp/tasks/push/items/base.py
+++ b/pubtools/_pulp/tasks/push/items/base.py
@@ -237,7 +237,6 @@ class PulpPushItem(object):
         for key in copy_crit.keys():
             (src_repo_id, dest_repo_id) = key
 
-            # TODO: cache repo lookups?
             src_repo = pulp_client.get_repository(src_repo_id)
             dest_repo = pulp_client.get_repository(dest_repo_id)
 

--- a/tests/push/conftest.py
+++ b/tests/push/conftest.py
@@ -48,8 +48,10 @@ class NoCopyClient(object):
     """
 
     def __init__(self, delegate):
-        self.search_content = delegate.search_content
         self.get_repository = delegate.get_repository
+        self.search_repository = delegate.search_repository
+        self.search_content = delegate.search_content
+        self.update_content = delegate.update_content
 
     def copy_content(self, *_args, **_kwargs):
         return f_return([Task(id="no-copy-123", completed=True, succeeded=True)])

--- a/tests/shared/test_pulp_cache.py
+++ b/tests/shared/test_pulp_cache.py
@@ -1,0 +1,82 @@
+import sys
+from pubtools.pulplib import Client, FakeController, FileRepository
+from pubtools._pulp.task import PulpTask
+from pubtools._pulp.services import CachingPulpClientService
+
+
+class TaskWithPulpClient(CachingPulpClientService, PulpTask):
+    def __init__(self, *args, **kwargs):
+        super(TaskWithPulpClient, self).__init__(*args, **kwargs)
+        self.pulp_ctrl = FakeController()
+
+    @property
+    def pulp_client(self):
+        # Super should give a Pulp client
+        assert isinstance(super(TaskWithPulpClient, self).pulp_client, Client)
+        # But we'll substitute our own
+        return self.pulp_ctrl.client
+
+
+def test_client_caches(monkeypatch):
+    """caching_pulp_client caches the result of calls to get_repository"""
+
+    with TaskWithPulpClient() as task:
+        monkeypatch.setattr(
+            sys,
+            "argv",
+            [
+                "",
+                "--pulp-url",
+                "http://some.url",
+            ],
+        )
+
+        # Add some repo
+        task.pulp_ctrl.insert_repository(FileRepository(id="test-repo"))
+
+        # Let's try getting it via the caching client.
+        repo1 = task.caching_pulp_client.get_repository("test-repo")
+        repo2 = task.caching_pulp_client.get_repository("test-repo")
+
+        # Due to the caching, it should give me back *exactly* the same
+        # object in both cases.
+        assert repo1 is repo2
+
+        # And it should fetch OK
+        assert repo1.result().id == "test-repo"
+
+
+def test_client_no_cache_errors(monkeypatch):
+    """caching_pulp_client does not cache failed get_repository calls"""
+
+    with TaskWithPulpClient() as task:
+        monkeypatch.setattr(
+            sys,
+            "argv",
+            [
+                "",
+                "--pulp-url",
+                "http://some.url",
+            ],
+        )
+
+        # Try getting a repo *before* it's added to the client.
+        repo1 = task.caching_pulp_client.get_repository("test-repo")
+
+        # Now add the repo and get it again.
+        task.pulp_ctrl.insert_repository(FileRepository(id="test-repo"))
+
+        repo2 = task.caching_pulp_client.get_repository("test-repo")
+        repo3 = task.caching_pulp_client.get_repository("test-repo")
+
+        # The first fetch should fail since the repo didn't exist yet.
+        assert repo1.exception()
+
+        # Since it failed, it should not have been cached and returned again.
+        assert repo1 is not repo2
+
+        # But caching worked as usual for the next two calls.
+        assert repo2 is repo3
+
+        # And those calls succeeded.
+        assert repo2.result().id == "test-repo"


### PR DESCRIPTION
Fixes a performance TODO. During copy phase of push, we may be
repeatedly calling get_repository for the same repo. Add a bit of
caching around these calls to reduce redundant calls to Pulp.