### PR TITLE
push: make batch timing smarter, more self-tuning

### DIFF
--- a/pubtools/_pulp/tasks/push/phase/context.py
+++ b/pubtools/_pulp/tasks/push/phase/context.py
@@ -11,7 +11,7 @@ from threading import Lock, Thread, Event
 
 from six.moves.queue import Queue
 
-from .base import Phase
+from .base import Phase, QUEUE_SIZE
 
 # u here is not redundant since we still support py2...
 # pylint: disable=redundant-u-string-prefix
@@ -20,14 +20,6 @@ LOG = logging.getLogger("pubtools.pulp")
 
 # How long, in seconds, between our logging of current phase progress.
 PROGRESS_INTERVAL = int(os.getenv("PUBTOOLS_PULP_PROGRESS_INTERVAL") or "600")
-
-# The default max size of each phase's item queue.
-#
-# This value may need tuning per the following:
-# - if too small, pushes will slow down as phases won't be pipelined as much
-# - if too large, memory usage may be too high on pushes with large numbers
-#   of items as queues fill up
-QUEUE_SIZE = int(os.getenv("PUBTOOLS_PULP_QUEUE_SIZE") or "10000")
 
 QueueCounts = namedtuple("QueueCounts", ["put", "get", "done"])
 
@@ -43,6 +35,7 @@ class CountingQueue(object):
         self._done_count = 0
         self._lock = Lock()
         self._delegate = Queue(**kwargs)
+        self.qsize = self._delegate.qsize
 
     def _incr_get(self):
         with self._lock:

--- a/tests/push/test_phase_batching.py
+++ b/tests/push/test_phase_batching.py
@@ -1,0 +1,30 @@
+from pubtools._pulp.tasks.push.phase import Context, Phase, context, base
+
+
+def test_batch_timeout(monkeypatch):
+
+    # Set all these to known values so we don't get affected by the relevant env vars.
+    monkeypatch.setattr(base, "QUEUE_SIZE", 100)
+    monkeypatch.setattr(context, "QUEUE_SIZE", base.QUEUE_SIZE)
+    monkeypatch.setattr(base, "BATCH_TIMEOUT", 0.1)
+    monkeypatch.setattr(base, "BATCH_MAX_TIMEOUT", 60.0)
+
+    ctx = Context()
+    phase = Phase(ctx)
+
+    # It should initially calculate a timeout equal to BATCH_TIMEOUT.
+    assert phase._Phase__batch_timeout == 0.1
+
+    # Let's say the output queue becomes about 2/3rds full.
+    for _ in range(0, 66):
+        phase.out_queue.put(object())
+
+    # Now it should wait up until 2/3rds of the max timeout.
+    assert 39.0 < phase._Phase__batch_timeout < 41.0
+
+    # Fill the output entirely.
+    for _ in range(66, 100):
+        phase.out_queue.put(object())
+
+    # That should make it use the max timeout.
+    assert phase._Phase__batch_timeout == 60.0


### PR DESCRIPTION
In testing of a large push I noted that the "query pulp" phase was often
querying a very small batch, or even a single file at a time.
That would be because the small batch timeout of 0.1 didn't make sense
any more after refactoring the phases to use put_future_outputs.

With that refactor, each iteration of iter_input_batched would tend to
be very fast since the real work is done asynchronously. It would also
not be blocked by a full output queue. This meant it would be too easy
for the phase to always keep up with the input queue and process only
0.1 seconds worth of items at a time, leading to Pulp searches of only a
couple of items.

Make it smarter by using the output queue size to generate some
backpressure. We will apply a small timeout if the output queue is
empty, and a large timeout if it's full. This ensures that the beginning
of the push, when queues are empty, can start working on items as fast
as possible; but as output queues fill up then we become more likely to
wait for a full batch and do more efficient searches (and copies, etc).