### PR TITLE
push: make collect phase filter out duplicates

### DIFF
--- a/pubtools/_pulp/tasks/push/phase/collect.py
+++ b/pubtools/_pulp/tasks/push/phase/collect.py
@@ -27,7 +27,47 @@ class Collect(Phase):
         for item in items:
             self.in_queue.put(item)
 
-    def run(self):
+    def item_key(self, item):
+        # Given an item, return a key which should be comparable between items
+        # in order to decide if a pair of items are considered duplicates.
+        pushsource_item = item.pushsource_item
+        return (pushsource_item.name, pushsource_item.dest, pushsource_item.src)
+
+    def iter_for_collect(self):
+        """A special batched iterator for this phase which filters out
+        duplicate items."""
         for item_batch in self.iter_input_batched():
+            # Depending how fast we're running, it's possible for the input
+            # batch to have the "same" item more than once with different
+            # states; for example, an RPM which was initially PENDING, then
+            # updated to EXISTS after it was found to be present in Pulp.
+            #
+            # In that case we only want the latter item to be included here,
+            # because:
+            # - it's pointless to include both
+            # - some backends (Pub's at least) do not expect to receive such
+            #   duplicates and may crash when they do.
+            #
+            out_batch = []
+            out_keys = set()
+            for item in item_batch:
+                key = self.item_key(item)
+                if key not in out_keys:
+                    out_keys.add(key)
+                    out_batch.append(item)
+                else:
+                    idx = None
+                    for idx, out_item in enumerate(out_batch):
+                        if self.item_key(out_item) == key:
+                            break
+
+                    # Current item replaces the last one we saw with the same key.
+                    assert idx is not None
+                    out_batch[idx] = item
+
+            yield out_batch
+
+    def run(self):
+        for item_batch in self.iter_for_collect():
             pushsource_items = [item.pushsource_item for item in item_batch]
             self.collector.update_push_items(pushsource_items).result()

--- a/tests/push/test_collect_duplicates.py
+++ b/tests/push/test_collect_duplicates.py
@@ -1,0 +1,136 @@
+from pushsource import FilePushItem
+import attr
+
+from more_executors.futures import f_return
+from pubtools._pulp.tasks.push.items import (
+    PulpFilePushItem,
+    PulpModuleMdPushItem,
+    PulpRpmPushItem,
+)
+from pubtools._pulp.tasks.push.phase import Context, Collect, Phase
+
+
+def test_collect_dupes():
+    """Collect phase filters out duplicate items during iteration."""
+
+    ctx = Context()
+    phase = Collect(context=ctx, collector=None)
+
+    # Set up some items to put onto the queue.
+    files = [
+        PulpFilePushItem(
+            pushsource_item=FilePushItem(
+                name="file%s" % i,
+                dest=["some-repo"],
+                src="/tmp/file%s" % i,
+                state="PENDING",
+            )
+        )
+        for i in range(0, 10)
+    ]
+
+    # Let's add some duplicates of what's already there, just with an
+    # updated state.
+    files.append(
+        attr.evolve(
+            files[0],
+            pushsource_item=attr.evolve(files[0].pushsource_item, state="EXISTS"),
+        )
+    )
+    files.append(
+        attr.evolve(
+            files[0],
+            pushsource_item=attr.evolve(files[0].pushsource_item, state="PUSHED"),
+        )
+    )
+    files.append(
+        attr.evolve(
+            files[4],
+            pushsource_item=attr.evolve(files[4].pushsource_item, state="WHATEVER"),
+        )
+    )
+
+    # Sanity check: now we have this many files
+    assert len(files) == 13
+
+    # Put everything on the queue...
+    for item in files:
+        phase.in_queue.put(item)
+
+    # Put this so that iteration will end
+    phase.in_queue.put(Phase.FINISHED)
+
+    # Now let's see how iteration over it will work out
+    got_items = []
+    for batch in phase.iter_for_collect():
+        got_items.extend([i.pushsource_item for i in batch])
+
+    # We got this many items - 3 dupes filtered, so only 10
+    assert len(got_items) == 10
+
+    # And let's check exactly what we got:
+    # - order should be the same as the input, but...
+    # - items at index 0 and 4 use their last submitted STATE rather
+    #   than the original
+    assert got_items == [
+        FilePushItem(
+            name="file0",
+            dest=["some-repo"],
+            src="/tmp/file0",
+            state="PUSHED",
+        ),
+        FilePushItem(
+            name="file1",
+            dest=["some-repo"],
+            src="/tmp/file1",
+            state="PENDING",
+        ),
+        FilePushItem(
+            name="file2",
+            dest=["some-repo"],
+            src="/tmp/file2",
+            state="PENDING",
+        ),
+        FilePushItem(
+            name="file3",
+            dest=["some-repo"],
+            src="/tmp/file3",
+            state="PENDING",
+        ),
+        FilePushItem(
+            name="file4",
+            dest=["some-repo"],
+            src="/tmp/file4",
+            state="WHATEVER",
+        ),
+        FilePushItem(
+            name="file5",
+            dest=["some-repo"],
+            src="/tmp/file5",
+            state="PENDING",
+        ),
+        FilePushItem(
+            name="file6",
+            dest=["some-repo"],
+            src="/tmp/file6",
+            state="PENDING",
+        ),
+        FilePushItem(
+            name="file7",
+            dest=["some-repo"],
+            src="/tmp/file7",
+            state="PENDING",
+        ),
+        FilePushItem(
+            name="file8",
+            dest=["some-repo"],
+            src="/tmp/file8",
+            state="PENDING",
+        ),
+        FilePushItem(
+            name="file9",
+            dest=["some-repo"],
+            src="/tmp/file9",
+            state="PENDING",
+        ),
+    ]


### PR DESCRIPTION
If we're running fast enough, we might end up calling update_push_items
with the "same" item at multiple states, e.g. PENDING when we first
discover it and then EXISTS if we were already able to figure out the
item exists in Pulp.

In that case, we should only include the latest version of the item.
It's important because Pub's collector backend will crash otherwise as
it does not expect to see duplicate items like that.