### PR TITLE
push: fix files potentially being uploaded more than once

### DIFF
--- a/pubtools/_pulp/tasks/push/items/file.py
+++ b/pubtools/_pulp/tasks/push/items/file.py
@@ -62,6 +62,14 @@ class PulpFilePushItem(PulpPushItem):
         for item in items:
             yield item.with_unit(units_by_key.get(item.file_key))
 
+    @property
+    def upload_key(self):
+        # We can reuse prior uploads if they use an identical name & content.
+        # (It's a bit weird that you need to upload a file multiple times if you
+        # want it to appear with different names in different repos, but it's
+        # just the way Pulp works.)
+        return (self.pushsource_item.name, self.pushsource_item.sha256sum)
+
     def upload_to_repo(self, repo):
         return repo.upload_file(
             self.pushsource_item.src,

--- a/tests/data/staged-mixed/dest2/RPMS/walrus-5.21-1.noarch.rpm
+++ b/tests/data/staged-mixed/dest2/RPMS/walrus-5.21-1.noarch.rpm
@@ -1,0 +1,1 @@
+../../dest1/RPMS/walrus-5.21-1.noarch.rpm

--- a/tests/data/staged-mixed/iso-dest2/FILES/test.txt
+++ b/tests/data/staged-mixed/iso-dest2/FILES/test.txt
@@ -1,0 +1,1 @@
+Here's a simple file for upload.

--- a/tests/data/staged-mixed/staged.yaml
+++ b/tests/data/staged-mixed/staged.yaml
@@ -9,6 +9,11 @@ payload:
       relative_path: iso-dest1/ISOS/test.txt
       sha256sum: d8301c5f72f16455dbc300f3d1bef8972424255caad103cc6c7ba7dc92d90ca8
 
+    # same file in iso-dest2, will trigger upload de-dupe
+    - filename: test.txt
+      relative_path: iso-dest2/FILES/test.txt
+      sha256sum: d8301c5f72f16455dbc300f3d1bef8972424255caad103cc6c7ba7dc92d90ca8
+
     # example where dest filename does not match filename under staging area
     # (this is not a problem)
     - filename: some-file.txt

--- a/tests/logs/push/test_push/test_typical_push.pulp.yaml
+++ b/tests/logs/push/test_push/test_typical_push.pulp.yaml
@@ -2922,6 +2922,7 @@ units:
   path: test.txt
   repository_memberships:
   - iso-dest1
+  - iso-dest2
   sha256sum: d8301c5f72f16455dbc300f3d1bef8972424255caad103cc6c7ba7dc92d90ca8
   size: 33
   unit_id: (hidden)
@@ -7860,6 +7861,7 @@ units:
   repository_memberships:
   - all-rpm-content
   - dest1
+  - dest2
   requires:
   - _class: RpmDependency
     epoch: '0'

--- a/tests/logs/push/test_push/test_update_push.pulp.yaml
+++ b/tests/logs/push/test_push/test_update_push.pulp.yaml
@@ -2922,6 +2922,7 @@ units:
   path: test.txt
   repository_memberships:
   - iso-dest1
+  - iso-dest2
   sha256sum: d8301c5f72f16455dbc300f3d1bef8972424255caad103cc6c7ba7dc92d90ca8
   size: 33
   unit_id: (hidden)
@@ -7861,6 +7862,7 @@ units:
   repository_memberships:
   - all-rpm-content
   - dest1
+  - dest2
   requires:
   - _class: RpmDependency
     epoch: '0'

--- a/tests/push/test_push.py
+++ b/tests/push/test_push.py
@@ -125,16 +125,16 @@ def test_typical_push(
     )
 
     # It should have invoked hook(s).
-    assert len(hookspy) == 9
+    assert len(hookspy) == 11
     (hook_name, hook_kwargs) = hookspy[0]
     assert hook_name == "task_start"
     (hook_name, hook_kwargs) = hookspy[1]
     assert hook_name == "pulp_repository_pre_publish"
     (hook_name, hook_kwargs) = hookspy[2]
     assert hook_name == "pulp_repository_published"
-    (hook_name, hook_kwargs) = hookspy[7]
+    (hook_name, hook_kwargs) = hookspy[-2]
     assert hook_name == "task_pulp_flush"
-    (hook_name, hook_kwargs) = hookspy[8]
+    (hook_name, hook_kwargs) = hookspy[-1]
     assert hook_name == "task_stop"
 
     # It should have recorded various push items.
@@ -354,7 +354,7 @@ def test_update_push(
     # Orphaned file after push should be as it was before except no longer an orphan.
     assert updated_orphan_file == attr.evolve(
         orphan_file,
-        repository_memberships=["iso-dest1"],
+        repository_memberships=["iso-dest1", "iso-dest2"],
     )
 
     # Erratum after push should be updated. The full update will not be tested here

--- a/tests/push/test_upload_sharing.py
+++ b/tests/push/test_upload_sharing.py
@@ -1,0 +1,116 @@
+import os
+from functools import partial
+
+import attr
+from more_executors.futures import f_map
+
+
+from pubtools.pulplib import FakeController, YumRepository
+from pushsource import RpmPushItem
+from pubtools._pulp.tasks.push.items import (
+    PulpRpmPushItem,
+)
+from pubtools._pulp.tasks.push.phase import Context, Upload, Phase
+
+# Wrap Pulp client/repo objects to spy on uploads.
+class RepoWrapper(object):
+    def __init__(self, delegate, uploads):
+        self.delegate = delegate
+        self.uploads = uploads
+
+    def upload_rpm(self, path, *args, **kwargs):
+        self.uploads.append(("rpm", path))
+        return self.delegate.upload_rpm(path, *args, **kwargs)
+
+
+class ClientWrapper(object):
+    def __init__(self, delegate):
+        self.delegate = delegate
+        self.search_content = delegate.search_content
+        self.uploads = []
+
+    def get_repository(self, *args, **kwargs):
+        wrapper = partial(RepoWrapper, uploads=self.uploads)
+        return f_map(self.delegate.get_repository(*args, **kwargs), wrapper)
+
+
+def test_uploads_shared(data_path):
+    """Upload phase allows for uploads of identical content to be reused."""
+
+    pulp_ctrl = FakeController()
+
+    pulp_ctrl.insert_repository(YumRepository(id="all-rpm-content"))
+    pulp_ctrl.insert_repository(YumRepository(id="repo1"))
+    pulp_ctrl.insert_repository(YumRepository(id="repo2"))
+    pulp_ctrl.insert_repository(YumRepository(id="repo3"))
+
+    client_wrapper = ClientWrapper(pulp_ctrl.client)
+
+    ctx = Context()
+    queue = ctx.new_queue()
+    phase = Upload(
+        context=ctx,
+        pulp_client=client_wrapper,
+        pre_push=None,
+        in_queue=queue,
+        update_push_items=lambda _: None,
+    )
+
+    rpm1 = RpmPushItem(
+        name="walrus-5.21-1.noarch.rpm",
+        sha256sum="e837a635cc99f967a70f34b268baa52e0f412c1502e08e924ff5b09f1f9573f2",
+        src=os.path.join(data_path, "staged-mixed/dest1/RPMS/walrus-5.21-1.noarch.rpm"),
+    )
+    rpm2 = RpmPushItem(
+        name="test-srpm01-1.0-1.src.rpm",
+        sha256sum="54cc4713fe704dfc7a4fd5b398f834ceb6a692f53b0c6aefaf89d88417b4c51d",
+        src=os.path.join(
+            data_path, "staged-mixed/dest1/SRPMS/test-srpm01-1.0-1.src.rpm"
+        ),
+    )
+
+    inputs = [
+        # Some copies of the same RPM to different repos
+        PulpRpmPushItem(pushsource_item=attr.evolve(rpm1, dest=["repo1"])),
+        PulpRpmPushItem(pushsource_item=attr.evolve(rpm1, dest=["repo2", "repo3"])),
+        # A different RPM
+        PulpRpmPushItem(pushsource_item=attr.evolve(rpm2, dest=["repo1"])),
+    ]
+
+    # Shove 'em into the queue
+    for item in inputs:
+        queue.put(item)
+
+    # Put this so that iteration will end
+    queue.put(Phase.FINISHED)
+
+    # Let the phase run
+    with phase:
+        pass
+
+    # It should not have failed
+    assert not ctx.has_error
+
+    # Should have called upload exactly once per file.
+    assert sorted(client_wrapper.uploads) == [
+        ("rpm", rpm1.src),
+        ("rpm", rpm2.src),
+    ]
+
+    # Look at the pulp units created.
+    outputs = {}
+    while True:
+        item = phase.out_queue.get()
+        if item is phase.FINISHED:
+            break
+        outputs.setdefault(item.pushsource_item.name, []).append(item.pulp_unit)
+
+    # Although there were two items dealing with this RPM...
+    assert len(outputs["walrus-5.21-1.noarch.rpm"]) == 2
+
+    # If we de-duplicate, we'll find they're actually the same unit since
+    # upload was shared.
+    assert len(set(outputs["walrus-5.21-1.noarch.rpm"])) == 1
+
+    # And the non-dupe should just work as normal.
+    assert len(outputs["test-srpm01-1.0-1.src.rpm"]) == 1


### PR DESCRIPTION
When we're used with staged source it's possible for the same file or
RPM to be present in multiple destination dirs. If so, we get one push
item per instance of that file.

The code here did not previously have any special handling for this, so
if the same file was in N dirs then we'd potentially upload it to pulp
N times. Fix it by keeping track of uploaded content and reusing
existing upload futures when possible.