### PR TITLE
tests: fix one test being affected by local config

### DIFF
--- a/pubtools/_pulp/services/fakepulp.py
+++ b/pubtools/_pulp/services/fakepulp.py
@@ -182,7 +182,7 @@ class PersistentFake(object):
         self.save()
 
 
-def new_fake_client(state_path=os.path.expanduser("~/.config/pubtools-pulp/fake.yaml")):
+def new_fake_client(state_path=None):
     """Create and return a new fake Pulp client.
 
     On top of the fake built in to pulplib library, this adds persistent state
@@ -191,6 +191,7 @@ def new_fake_client(state_path=os.path.expanduser("~/.config/pubtools-pulp/fake.
     The state is persisted in a somewhat human-accessible form; the idea is that
     you can manually view and edit the YAML to see how the commands behave.
     """
+    state_path = state_path or os.path.expanduser("~/.config/pubtools-pulp/fake.yaml")
     fake = PersistentFake(state_path)
     fake.load()
     return fake.ctrl.client

--- a/tests/shared/test_pulp_task.py
+++ b/tests/shared/test_pulp_task.py
@@ -41,8 +41,13 @@ def test_pulp_client():
     assert isinstance(client, Client)
 
 
-def test_pulp_fake_client():
+def test_pulp_fake_client(monkeypatch, tmpdir):
     """Checks that a fake client is created if --pulp-fake is given"""
+
+    # Ensure we use a clean home dir so the fake can't be affected by
+    # any of the caller's persisted state.
+    monkeypatch.setenv("HOME", str(tmpdir))
+
     with TaskWithPulpClient() as task:
         arg = ["", "--pulp-fake"]
         with patch("sys.argv", arg):


### PR DESCRIPTION
This test involving --fake-pulp would really try to access
`~/.config/pubtools-pulp/fake.yaml`, so it could fail if the caller had
deliberately persisted something weird there. Make sure it uses a clean
environment.