### PR TITLE
Update product_versions on upload of productid

### DIFF
--- a/pubtools/_pulp/services/cachingpulp.py
+++ b/pubtools/_pulp/services/cachingpulp.py
@@ -34,6 +34,17 @@ class CachingPulpClient(object):
 
         return out
 
+    def _invalidate(self, repo_id):
+        with self._lock:
+            self._repo_cache.pop(repo_id, None)
+
+    def update_repository(self, repo):
+        # update_repository needs a simple wrapper to ensure our
+        # cache becomes invalidated.
+        out = self._delegate.update_repository(repo)
+        out.add_done_callback(lambda _: self._invalidate(repo.id))
+        return out
+
 
 # Because class is designed as a mix-in...
 # pylint: disable=no-member

--- a/pubtools/_pulp/tasks/push/items/productid.py
+++ b/pubtools/_pulp/tasks/push/items/productid.py
@@ -1,8 +1,72 @@
+import logging
+from threading import Lock
+
+from pubtools.pulplib import Criteria
+from more_executors.futures import f_flat_map, f_map, f_sequence
 from pushsource import ProductIdPushItem
 import attr
+import rhsm.certificate
 
 from .base import supports_type
 from .direct import PulpDirectUploadPushItem
+
+LOG = logging.getLogger("pubtools.pulp")
+
+
+@attr.s(slots=True)
+class RepoFinder(object):
+    """A helper for looking up related repos for product_versions update,
+    in a reasonably efficient manner.
+    """
+
+    client = attr.ib()
+    repos = attr.ib(type=list, default=attr.Factory(list))
+    searches = attr.ib(type=dict, default=attr.Factory(dict))
+    lock = attr.ib(default=attr.Factory(Lock))
+
+    def find_related(self, repo):
+        """Start searching for the repos which should have product_versions updated
+        after a productid has been uploaded to 'repo'.
+
+        Returns None, but influences the return value of a later call to all_results.
+        """
+        arch = repo.arch
+        eng_product_id = repo.eng_product_id
+        platform_full_version = repo.platform_full_version
+        search_key = (arch, eng_product_id, platform_full_version)
+
+        with self.lock:
+            self.repos.append(repo)
+            if not self.searches.get(search_key):
+                search_f = self.client.search_repository(
+                    Criteria.and_(
+                        Criteria.with_field("arch", arch),
+                        Criteria.with_field("eng_product_id", eng_product_id),
+                        Criteria.with_field(
+                            "platform_full_version", platform_full_version
+                        ),
+                    )
+                )
+                self.searches[search_key] = search_f
+
+    @property
+    def all_results(self):
+        """Yields repos:
+
+        - all repos passed in to find_related, and:
+        - all repos found to be "related" to those, for the purpose of
+          product_versions update.
+
+        Intended to be called once only after all find_related calls have
+        been performed.
+        """
+        seen_ids = set()
+
+        for repo_iterable in [self.repos] + list(self.searches.values()):
+            for repo in repo_iterable:
+                if repo.id not in seen_ids:
+                    seen_ids.add(repo.id)
+                    yield repo
 
 
 @supports_type(ProductIdPushItem)
@@ -10,5 +74,86 @@ from .direct import PulpDirectUploadPushItem
 class PulpProductIdPushItem(PulpDirectUploadPushItem):
     """Handler for productids which are uploaded directly to each dest repo."""
 
+    product_versions = attr.ib(type=list)
+    """The product versions included in this push item's productid cert."""
+
+    @product_versions.default
+    def _product_versions_from_cert(self):
+        if self.pushsource_item and self.pushsource_item.src:
+            cert = rhsm.certificate.create_from_file(self.pushsource_item.src)
+            versions = [p.version for p in cert.products]
+            return sorted(set(versions))
+        return []
+
     def upload_to_repo(self, repo):
         return repo.upload_metadata(self.pushsource_item.src, metadata_type="productid")
+
+    def ensure_uploaded(self, ctx, repo_f=None):
+        # Overridden to add the post-upload step of product_versions update.
+        uploaded_item = super(PulpProductIdPushItem, self).ensure_uploaded(ctx, repo_f)
+
+        return f_flat_map(
+            uploaded_item, lambda item: item.ensure_product_versions_uptodate(ctx)
+        )
+
+    def ensure_product_versions_uptodate(self, ctx):
+        # Ensures that the product_versions field contains all the product
+        # versions from this cert, in all repos containing this productid as well
+        # as any repos sharing a certain relationship.
+
+        # First we need to figure out the repos to handle.
+        # We start from the repos we're contained in.
+        repo_ids = self.in_pulp_repos
+        repo_fs = [ctx.client.get_repository(repo_id) for repo_id in repo_ids]
+
+        # Then start looking up any 'related repos' for them.
+        # This finder class manages the searches and avoids duplicate searches.
+        finder = RepoFinder(client=ctx.client)
+        find_related_fs = [f_map(repo_f, finder.find_related) for repo_f in repo_fs]
+
+        # Once all the find_related searches have been set up, we can get the
+        # iterable over all repos.
+        repo_iter_f = f_map(f_sequence(find_related_fs), lambda _: finder.all_results)
+
+        return f_flat_map(
+            repo_iter_f,
+            lambda repos: self.ensure_product_versions_uptodate_in_repos(ctx, repos),
+        )
+
+    def ensure_product_versions_uptodate_in_repos(self, ctx, repos):
+        # Ensures that the product_versions field contains all the product
+        # versions from this cert, in all repos in 'repos', which should be
+        # the fully calculated set of applicable repos.
+        updates = []
+
+        def pvs_to_add(repo):
+            out = []
+            for pv in self.product_versions:
+                if pv not in (repo.product_versions or []):
+                    out.append(pv)
+            return out
+
+        for repo in repos:
+            pvs = pvs_to_add(repo)
+            if pvs:
+                LOG.info(
+                    "%s: adding product_versions %s from %s",
+                    repo.id,
+                    ", ".join(sorted(pvs)),
+                    self.pushsource_item.src,
+                )
+                updates.append(
+                    ctx.client.update_repository(
+                        attr.evolve(
+                            repo,
+                            product_versions=(repo.product_versions or []) + pvs,
+                        )
+                    )
+                )
+
+        # once all updates have completed...
+        all_updated = f_sequence(updates)
+
+        # Just return ourselves again, as is the convention for
+        # the ensure_* methods.
+        return f_map(all_updated, lambda _: self)

--- a/requirements.in
+++ b/requirements.in
@@ -5,3 +5,4 @@ fastpurge
 more_executors>=2.7.0
 pushcollector>=1.2.0
 pushsource>=2.14.0
+rhsm

--- a/requirements.txt
+++ b/requirements.txt
@@ -163,6 +163,11 @@ importlib-resources==5.4.0 \
     --hash=sha256:33a95faed5fc19b4bc16b29a6eeae248a3fe69dd55d4d229d2b480e23eeaad45 \
     --hash=sha256:d756e2f85dd4de2ba89be0b21dba2a3bbec2e871a42a3a16719258a11f87506b
     # via jsonschema
+iniparse==0.5 \
+    --hash=sha256:88ca60473b1637055a937933d48840be1b1b6835f381a6158ef118a532583675 \
+    --hash=sha256:932e5239d526e7acb504017bb707be67019ac428a6932368e6851691093aa842 \
+    --hash=sha256:db6ef1d8a02395448e0e7b17ac0aa28b8d338b632bbd1ffca08c02ddae32cf97
+    # via rhsm
 jsonschema==4.4.0 \
     --hash=sha256:636694eb41b3535ed608fe04129f26542b59ed99808b4f688aa32dcf55317a83 \
     --hash=sha256:77281a1f71684953ee8b3d488371b162419767973789272434bbc3f29d9c8823
@@ -315,12 +320,16 @@ requests==2.27.1 \
 requests-gssapi==1.2.3 \
     --hash=sha256:20784508981401f7153c933eed095338933a40818da65a259dbf2d80dccb150e
     # via koji
+rhsm==1.19.2 \
+    --hash=sha256:156525483560d821dd858194af9692803d339b379f7a378c382a3782d0902329
+    # via -r requirements.in
 six==1.16.0 \
     --hash=sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926 \
     --hash=sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254
     # via
     #   -r requirements.in
     #   fastpurge
+    #   iniparse
     #   kobo
     #   koji
     #   more-executors

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -291,6 +291,11 @@ iniconfig==1.1.1 \
     --hash=sha256:011e24c64b7f47f6ebd835bb12a743f2fbe9a26d4cecaa7f53bc4f35ee9da8b3 \
     --hash=sha256:bc3af051d7d14b2ee5ef9969666def0cd1a000e121eaea580d4a313df4b37f32
     # via pytest
+iniparse==0.5 \
+    --hash=sha256:88ca60473b1637055a937933d48840be1b1b6835f381a6158ef118a532583675 \
+    --hash=sha256:932e5239d526e7acb504017bb707be67019ac428a6932368e6851691093aa842 \
+    --hash=sha256:db6ef1d8a02395448e0e7b17ac0aa28b8d338b632bbd1ffca08c02ddae32cf97
+    # via rhsm
 isort==5.10.1 \
     --hash=sha256:6f62d78e2f89b4500b080fe3a81690850cd254227f27f75c3a0c491a1f351ba7 \
     --hash=sha256:e8443a5e7a020e9d7f97f1d7d9cd17c88bcb3bc7e218bf9cf5095fe550be2951
@@ -614,6 +619,9 @@ requests-mock==1.9.3 \
     --hash=sha256:0a2d38a117c08bb78939ec163522976ad59a6b7fdd82b709e23bb98004a44970 \
     --hash=sha256:8d72abe54546c1fc9696fa1516672f1031d72a55a1d66c85184f972a24ba0eba
     # via -r test-requirements.in
+rhsm==1.19.2 \
+    --hash=sha256:156525483560d821dd858194af9692803d339b379f7a378c382a3782d0902329
+    # via -r requirements.in
 rpm-py-installer==1.1.0 \
     --hash=sha256:66e5f4f9247752ed386345642683103afaee50fb16928878a204bc12504b9bbe
     # via -r test-requirements.in
@@ -623,6 +631,7 @@ six==1.16.0 \
     # via
     #   -r requirements.in
     #   fastpurge
+    #   iniparse
     #   kobo
     #   koji
     #   more-executors

--- a/tests/logs/push/test_push/test_empty_push.pulp.yaml
+++ b/tests/logs/push/test_push/test_empty_push.pulp.yaml
@@ -4,12 +4,16 @@ repos:
 - _class: YumRepository
   id: all-rpm-content
 - _class: YumRepository
+  arch: x86_64
+  eng_product_id: 123
   id: dest1
 - _class: YumRepository
   id: dest2
 - _class: FileRepository
   id: iso-dest1
 - _class: FileRepository
+  arch: x86_64
+  eng_product_id: 123
   id: iso-dest2
 - _class: FileRepository
   id: redhat-maintenance

--- a/tests/logs/push/test_push/test_typical_push.pulp.yaml
+++ b/tests/logs/push/test_push/test_typical_push.pulp.yaml
@@ -4,13 +4,21 @@ repos:
 - _class: YumRepository
   id: all-rpm-content
 - _class: YumRepository
+  arch: x86_64
+  eng_product_id: 123
   id: dest1
+  product_versions:
+  - '6.10'
 - _class: YumRepository
   id: dest2
 - _class: FileRepository
   id: iso-dest1
 - _class: FileRepository
+  arch: x86_64
+  eng_product_id: 123
   id: iso-dest2
+  product_versions:
+  - '6.10'
 - _class: FileRepository
   id: redhat-maintenance
 units:

--- a/tests/logs/push/test_push/test_update_push.pulp.yaml
+++ b/tests/logs/push/test_push/test_update_push.pulp.yaml
@@ -4,13 +4,21 @@ repos:
 - _class: YumRepository
   id: all-rpm-content
 - _class: YumRepository
+  arch: x86_64
+  eng_product_id: 123
   id: dest1
+  product_versions:
+  - '6.10'
 - _class: YumRepository
   id: dest2
 - _class: FileRepository
   id: iso-dest1
 - _class: FileRepository
+  arch: x86_64
+  eng_product_id: 123
   id: iso-dest2
+  product_versions:
+  - '6.10'
 - _class: FileRepository
   id: redhat-maintenance
 units:

--- a/tests/logs/push/test_push_prepush/test_pre_push.pulp.yaml
+++ b/tests/logs/push/test_push_prepush/test_pre_push.pulp.yaml
@@ -4,12 +4,16 @@ repos:
 - _class: YumRepository
   id: all-rpm-content
 - _class: YumRepository
+  arch: x86_64
+  eng_product_id: 123
   id: dest1
 - _class: YumRepository
   id: dest2
 - _class: FileRepository
   id: iso-dest1
 - _class: FileRepository
+  arch: x86_64
+  eng_product_id: 123
   id: iso-dest2
 - _class: FileRepository
   id: redhat-maintenance

--- a/tests/logs/push/test_push_prepush/test_pre_push_no_dest.pulp.yaml
+++ b/tests/logs/push/test_push_prepush/test_pre_push_no_dest.pulp.yaml
@@ -4,12 +4,16 @@ repos:
 - _class: YumRepository
   id: all-rpm-content
 - _class: YumRepository
+  arch: x86_64
+  eng_product_id: 123
   id: dest1
 - _class: YumRepository
   id: dest2
 - _class: FileRepository
   id: iso-dest1
 - _class: FileRepository
+  arch: x86_64
+  eng_product_id: 123
   id: iso-dest2
 - _class: FileRepository
   id: redhat-maintenance

--- a/tests/push/conftest.py
+++ b/tests/push/conftest.py
@@ -90,8 +90,12 @@ def fake_controller(fake_state_path):
 
     # Add the repositories which are referenced from the staging area.
     controller.insert_repository(FileRepository(id="iso-dest1"))
-    controller.insert_repository(FileRepository(id="iso-dest2"))
-    controller.insert_repository(YumRepository(id="dest1"))
+    controller.insert_repository(
+        FileRepository(id="iso-dest2", arch="x86_64", eng_product_id=123)
+    )
+    controller.insert_repository(
+        YumRepository(id="dest1", arch="x86_64", eng_product_id=123)
+    )
     controller.insert_repository(YumRepository(id="dest2"))
 
     yield controller

--- a/tests/push/test_productid_updates_versions.py
+++ b/tests/push/test_productid_updates_versions.py
@@ -1,0 +1,134 @@
+from pushsource import ProductIdPushItem
+
+import rhsm.certificate
+from pubtools.pulplib import FakeController, YumRepository
+from pubtools._pulp.tasks.push.items import PulpProductIdPushItem
+from pubtools._pulp.tasks.push.items.base import UploadContext
+
+
+class FakeProduct(object):
+    def __init__(self, version):
+        self.version = version
+
+
+class FakeCert(object):
+    def __init__(self, versions):
+        self.products = [FakeProduct(v) for v in versions]
+
+
+def test_updates_product_versions(monkeypatch, tmpdir):
+    """Uploading a productid to a repo will update the product_versions field
+    on that repo and related repos.
+    """
+
+    ctrl = FakeController()
+
+    # Set up a family of repos with various product_versions.
+    repo1 = YumRepository(id="repo1")
+    repo2 = YumRepository(
+        id="repo2",
+        arch="x86_64",
+        eng_product_id=1234,
+        platform_full_version="xyz",
+        product_versions=["a", "b"],
+    )
+    repo3 = YumRepository(
+        id="repo3",
+        arch="x86_64",
+        eng_product_id=1234,
+        platform_full_version="xyz",
+        product_versions=["b", "c"],
+    )
+    repo4 = YumRepository(
+        id="repo4",
+        arch="x86_64",
+        eng_product_id=1234,
+        platform_full_version="xyz",
+        product_versions=None,
+    )
+    repo5 = YumRepository(
+        id="repo5",
+        arch="x86_64",
+        eng_product_id=1234,
+        platform_full_version="xyz",
+        product_versions=["c", "d"],
+    )
+    repo6 = YumRepository(
+        id="repo6",
+        arch="x86_64",
+        eng_product_id=1234,
+        product_versions=["d", "e"],
+    )
+    repo7 = YumRepository(
+        id="repo7",
+        arch="s390x",
+        product_versions=["b"],
+    )
+    repo8 = YumRepository(
+        id="repo8",
+        arch="s390x",
+        product_versions=[],
+    )
+
+    ctrl.insert_repository(repo1)
+    ctrl.insert_repository(repo2)
+    ctrl.insert_repository(repo3)
+    ctrl.insert_repository(repo4)
+    ctrl.insert_repository(repo5)
+    ctrl.insert_repository(repo6)
+    ctrl.insert_repository(repo7)
+    ctrl.insert_repository(repo8)
+
+    # Set up cert parser to use a fake cert object (saves us having to explicitly
+    # generate certs with certain values)
+    monkeypatch.setattr(
+        rhsm.certificate, "create_from_file", lambda _: FakeCert(["a", "d"])
+    )
+
+    # make a fake productid.
+    # content doesn't matter since we patched the cert parser, it just has
+    # to be an existing file.
+    productid = tmpdir.join("productid")
+    productid.write("")
+
+    # make an item targeting two of the repos
+    item = PulpProductIdPushItem(
+        pushsource_item=ProductIdPushItem(
+            name="test", src=str(productid), dest=["repo2", "repo7"]
+        )
+    )
+
+    upload_ctx = UploadContext(client=ctrl.client)
+
+    # Try uploading the item
+    upload_f = item.ensure_uploaded(upload_ctx)
+
+    # It should succeed
+    uploaded = upload_f.result()
+
+    # It should be present in the target repos
+    assert uploaded.in_pulp_repos == ["repo2", "repo7"]
+
+    # Now what we're really interested in: what side effect did that
+    # have on the repos?
+    # Let's use this little helper to find out
+    def get_pv(repo_id):
+        return ctrl.client.get_repository(repo_id).product_versions
+
+    # nothing changed here as this repo doesn't have any matching notes
+    assert get_pv("repo1") == None
+
+    # These were all updated to insert ["a", "d"] as expected
+    assert get_pv("repo2") == ["a", "b", "d"]
+    assert get_pv("repo3") == ["a", "b", "c", "d"]
+    assert get_pv("repo4") == ["a", "d"]
+    assert get_pv("repo5") == ["a", "c", "d"]
+
+    # This was not changed due to platform_full_version mismatch
+    assert get_pv("repo6") == ["d", "e"]
+
+    # These two were changed. Note that repos 2..5 and repos 7..8
+    # have different sets of notes, showing that repo 2 found related
+    # repos (3,4,5) and repo 7 found related repo 8.
+    assert get_pv("repo7") == ["a", "b", "d"]
+    assert get_pv("repo8") == ["a", "d"]


### PR DESCRIPTION
The legacy push code implemented the following side-effect:
when a productid cert is uploaded into a repo, version strings are
extracted from the cert and appended to the product_versions field in
that repo plus other repos with certain matching notes.

That side-effect of productid upload remains important, but was missing
from pubtools-pulp-push. Add it now.