### PR TITLE
logs: demote 'Doing Pulp search' to DEBUG level

### DIFF
--- a/pubtools/_pulp/tasks/push/items/base.py
+++ b/pubtools/_pulp/tasks/push/items/base.py
@@ -185,7 +185,7 @@ class PulpPushItem(object):
             Criteria.with_unit_type(unit_type),
             Criteria.or_(*[item.criteria() for item in items]),
         )
-        LOG.info("Doing Pulp search: %s", crit)
+        LOG.debug("Doing Pulp search: %s", crit)
 
         units_f = pulp_client.search_content(crit)
         matcher = partial(cls.match_items_units, items)


### PR DESCRIPTION
This log seems too verbose for INFO. The criteria objects tend to be way
too large for casual consumption seeing as we search for hundreds of
items at a time.