### PR TITLE
tuning: slash default queue size significantly [RHELDST-11374]

### DIFF
--- a/pubtools/_pulp/tasks/push/phase/base.py
+++ b/pubtools/_pulp/tasks/push/phase/base.py
@@ -30,7 +30,7 @@ PHASE_TIMEOUT = int(os.getenv("PUBTOOLS_PULP_PHASE_TIMEOUT") or "200000")
 # - if too small, pushes will slow down as phases won't be pipelined as much
 # - if too large, memory usage may be too high on pushes with large numbers
 #   of items as queues fill up
-QUEUE_SIZE = int(os.getenv("PUBTOOLS_PULP_QUEUE_SIZE") or "10000")
+QUEUE_SIZE = int(os.getenv("PUBTOOLS_PULP_QUEUE_SIZE") or "200")
 
 # Max number of items processed in a batch, for phases designed to use batching.
 # Generally should be the max number of items we're willing to fetch in a single

--- a/tests/push/test_associate_item_order.py
+++ b/tests/push/test_associate_item_order.py
@@ -10,7 +10,7 @@ def test_associate_order():
     """Associate phase reorders items so that RPMs are processed last."""
 
     ctx = Context()
-    queue = ctx.new_queue()
+    queue = ctx.new_queue(maxsize=10000)
     phase = Associate(
         context=ctx,
         pulp_client=None,


### PR DESCRIPTION
There are still memory usage issues with large push tasks.
After doing some analysis and testing I found that the size of each
future is much larger than I'd expected, around 3.3KiB each on python2
(and roughly half of that on py3).

The number of futures which will exist at any one time is roughly
expected to be some multiple of this tunable. The 10,000 number had no
specific calculations behind it and was far too optimistic.
The new number of 200 is set according to some rough estimates that a
number of 2000 would end up consuming roughly 200MB of memory for Future
objects, and then cutting it further by a factor of 10 to get a generous
safety margin.

One unit test needs a larger queue size because the test is written in a
way which will deadlock otherwise.