### PR TITLE
Avoid storing unused fields for RPMs [RHELDST-11376]

### DIFF
--- a/pubtools/_pulp/tasks/push/items/base.py
+++ b/pubtools/_pulp/tasks/push/items/base.py
@@ -362,6 +362,11 @@ class PulpPushItem(object):
             # Not quite PUSHED yet as we still want to ensure repos are published.
             pushsource_state = "EXISTS"
 
+        # Get a more lean version of the unit with only needed fields,
+        # if possible
+        if unit:
+            unit = self.thin_unit(unit)
+
         out = attr.evolve(
             self,
             pulp_unit=unit,
@@ -530,6 +535,17 @@ class PulpPushItem(object):
           the item
         """
         raise NotImplementedError()
+
+    def thin_unit(self, unit):
+        """Given a unit, returns the same unit with irrelevant fields discarded.
+
+        The sole purpose of this method is to reduce memory usage for pushes
+        dealing with a lot of units. The default implementation does nothing.
+
+        Subclasses SHOULD override this method where applicable to discard
+        irrelevant fields on units.
+        """
+        return unit
 
     @property
     def supports_signing(self):

--- a/pubtools/_pulp/tasks/push/items/rpm.py
+++ b/pubtools/_pulp/tasks/push/items/rpm.py
@@ -120,6 +120,22 @@ class PulpRpmPushItem(PulpPushItem):
         # Any prior upload of identical content can be reused.
         return self.pushsource_item.sha256sum
 
+    def thin_unit(self, unit):
+        # RpmUnits contain some complex fields but only a minority
+        # are relevant to us. Here we keep only those fields we
+        # need to operate successfully.
+        return RpmUnit(
+            name=unit.name,
+            version=unit.version,
+            release=unit.release,
+            arch=unit.arch,
+            sha256sum=unit.sha256sum,
+            repository_memberships=unit.repository_memberships,
+            cdn_path=unit.cdn_path,
+            cdn_published=unit.cdn_published,
+            unit_id=unit.unit_id,
+        )
+
     def ensure_uploaded(self, ctx, repo_f=None):
         # Overridden to force our desired upload repo.
         return super(PulpRpmPushItem, self).ensure_uploaded(ctx, ctx.upload_repo)

--- a/tests/push/test_rpm_thin_unit.py
+++ b/tests/push/test_rpm_thin_unit.py
@@ -1,0 +1,53 @@
+from datetime import datetime
+from pushsource import RpmPushItem
+from pubtools.pulplib import RpmUnit, RpmDependency
+
+from pubtools._pulp.tasks.push.items import PulpRpmPushItem
+
+
+def test_rpm_thin_unit():
+    """RPM push items discard fields unnecessary for push."""
+
+    # Make an item
+    item = PulpRpmPushItem(
+        pushsource_item=RpmPushItem(name="bash-5.0.7-1.fc30.x86_64.rpm")
+    )
+
+    # Start with a 'full' unit as returned from pulp, with various
+    # unused fields available
+    unit_in = RpmUnit(
+        name="bash",
+        version="5.0.7",
+        release="1.fc30",
+        arch="x86_64",
+        epoch="9001",
+        signing_key="a1b2c3d4",
+        filename="bash-5.0.7-1.fc30.x86_64.rpm",
+        sourcerpm="bash-5.0.7-1.fc30.src.rpm",
+        md5sum="d3b07a382ec010c01889250fce66fb13",
+        sha1sum="f3d9ae4aeea6946a8668445395ba10b7399523a0",
+        sha256sum="49ae93732fcf8d63fe1cce759664982dbd5b23161f007dba8561862adc96d063",
+        cdn_path="/origin/some/path.rpm",
+        cdn_published=datetime(2022, 4, 29, 14, 48),
+        repository_memberships=["a", "b", "c"],
+        unit_id="best-unit",
+        requires=[RpmDependency(name="foo", flags="EQ", version="1.0.0")],
+    )
+
+    # Get the item with unit attached
+    item = item.with_unit(unit_in)
+
+    # Now have a look at what the unit has become:
+    # It's a cut down version of the above with many fields thrown
+    # away if they are not required for push.
+    assert item.pulp_unit == RpmUnit(
+        name="bash",
+        version="5.0.7",
+        release="1.fc30",
+        arch="x86_64",
+        sha256sum="49ae93732fcf8d63fe1cce759664982dbd5b23161f007dba8561862adc96d063",
+        cdn_path="/origin/some/path.rpm",
+        cdn_published=datetime(2022, 4, 29, 14, 48),
+        repository_memberships=["a", "b", "c"],
+        unit_id="best-unit",
+    )


### PR DESCRIPTION
This commit aims to reduce memory usage by throwing away many fields
on Pulp units which are never used during push. In theory, any unit
types could benefit from this; in practice RpmUnit is the only content
type where this currently seems to be worthwhile, as it contains many
fields not used at all during push including some complex ones such
as requires/provides.

(Note it would be even better if we don't query these from Pulp in the
first place, but pulplib.Client does not currently implement that
feature.)