### PR TITLE
refactor: make each push phase use own pulplib client

### DIFF
--- a/pubtools/_pulp/services/fakepulp.py
+++ b/pubtools/_pulp/services/fakepulp.py
@@ -182,8 +182,8 @@ class PersistentFake(object):
         self.save()
 
 
-def new_fake_client(state_path=None):
-    """Create and return a new fake Pulp client.
+def new_fake_controller(state_path=None):
+    """Create and return a new fake Pulp controller.
 
     On top of the fake built in to pulplib library, this adds persistent state
     stored under ~/.config/pubtools-pulp by default.
@@ -194,4 +194,4 @@ def new_fake_client(state_path=None):
     state_path = state_path or os.path.expanduser("~/.config/pubtools-pulp/fake.yaml")
     fake = PersistentFake(state_path)
     fake.load()
-    return fake.ctrl.client
+    return fake.ctrl

--- a/pubtools/_pulp/tasks/push/phase/query_pulp.py
+++ b/pubtools/_pulp/tasks/push/phase/query_pulp.py
@@ -18,16 +18,17 @@ class QueryPulp(Phase):
     - none.
     """
 
-    def __init__(self, context, pulp_client, in_queue, **_):
+    def __init__(self, context, pulp_client_factory, in_queue, **_):
         super(QueryPulp, self).__init__(
             context, in_queue=in_queue, name="Query items in Pulp"
         )
-        self.pulp_client = pulp_client
+        self.pulp_client_factory = pulp_client_factory
 
     def run(self):
-        for batch in self.iter_input_batched():
-            for items in PulpPushItem.items_by_type(batch):
-                updated_items_f = PulpPushItem.items_with_pulp_state_single_batch(
-                    self.pulp_client, items
-                )
-                self.put_future_outputs(updated_items_f)
+        with self.pulp_client_factory() as client:
+            for batch in self.iter_input_batched():
+                for items in PulpPushItem.items_by_type(batch):
+                    updated_items_f = PulpPushItem.items_with_pulp_state_single_batch(
+                        client, items
+                    )
+                    self.put_future_outputs(updated_items_f)

--- a/pubtools/_pulp/tasks/push/phase/update.py
+++ b/pubtools/_pulp/tasks/push/phase/update.py
@@ -25,29 +25,30 @@ class Update(Phase):
     - mutates unit fields (under pulp_user_metadata) in Pulp.
     """
 
-    def __init__(self, context, pulp_client, in_queue, **_):
+    def __init__(self, context, pulp_client_factory, in_queue, **_):
         super(Update, self).__init__(
             context, in_queue=in_queue, name="Update items in Pulp"
         )
-        self.pulp_client = pulp_client
+        self.pulp_client_factory = pulp_client_factory
 
     def run(self):
         no_update_needed = 0
         update_needed = 0
 
-        for item in self.iter_input():
-            if item.pulp_state not in State.NEEDS_UPDATE:
-                # This item is already up-to-date in Pulp (or just doesn't support
-                # being updated)
-                no_update_needed += 1
-                self.put_output(item)
-            else:
-                # This item needs an update.
-                update_needed += 1
-                self.put_future_output(item.ensure_uptodate(self.pulp_client))
+        with self.pulp_client_factory() as client:
+            for item in self.iter_input():
+                if item.pulp_state not in State.NEEDS_UPDATE:
+                    # This item is already up-to-date in Pulp (or just doesn't support
+                    # being updated)
+                    no_update_needed += 1
+                    self.put_output(item)
+                else:
+                    # This item needs an update.
+                    update_needed += 1
+                    self.put_future_output(item.ensure_uptodate(client))
 
-        LOG.info(
-            "Update: %s item(s) already up-to-date, %s updating",
-            no_update_needed,
-            update_needed,
-        )
+            LOG.info(
+                "Update: %s item(s) already up-to-date, %s updating",
+                no_update_needed,
+                update_needed,
+            )

--- a/requirements.in
+++ b/requirements.in
@@ -1,6 +1,6 @@
 six
 pubtools>=0.3.0
-pubtools-pulplib>=2.29.0
+pubtools-pulplib>=2.32.0
 fastpurge
 more_executors>=2.7.0
 pushcollector>=1.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -125,7 +125,9 @@ frozendict==2.3.2 \
     --hash=sha256:c0a3640e9d7533d164160b758351aa49d9e85bbe0bd76d219d4021e90ffa6a52 \
     --hash=sha256:c1c70826aa4a50fa283fe161834ac4a3ac7c753902c980bb8b595b0998a38ddb \
     --hash=sha256:fb09761e093cfabb2f179dbfdb2521e1ec5701df714d1eb5c51fa7849027be19
-    # via pushsource
+    # via
+    #   pubtools-pulplib
+    #   pushsource
 frozenlist2==1.0.0 \
     --hash=sha256:33f6c6bb2c7d38524ec3c2d6f2d8a3ee2625a9e13096d8bc64db012b516a95e0 \
     --hash=sha256:caffe66813e42de320b10d08b8c0604c7eb3f142a8482ad3130243e084f37a2f
@@ -214,9 +216,9 @@ pubtools==1.2.1 \
     # via
     #   -r requirements.in
     #   pubtools-pulplib
-pubtools-pulplib==2.30.0 \
-    --hash=sha256:b2faf6afa55f5a47e13ea134f092bf0033a955f6219fc7d864d57f8b53c177fd \
-    --hash=sha256:bde202e1cd4280a43f2a054c6af25af6ac0248dfe6cfc632638d9ca4858aa845
+pubtools-pulplib==2.32.0 \
+    --hash=sha256:6628a1fce79229a34fe1695e9807efc9d728e2dff425452286a5dd913b1b65ca \
+    --hash=sha256:6b257f8ae7c1059f52a73239912dba5993e7d854e7614c9d1bf36b907f1dc649
     # via -r requirements.in
 pushcollector==1.3.0 \
     --hash=sha256:18281fcd4247ca8b668c25348bbc2f9cc032912cecc7037824a74ad8adcbb1c3 \

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -241,7 +241,9 @@ frozendict==2.3.2 \
     --hash=sha256:c0a3640e9d7533d164160b758351aa49d9e85bbe0bd76d219d4021e90ffa6a52 \
     --hash=sha256:c1c70826aa4a50fa283fe161834ac4a3ac7c753902c980bb8b595b0998a38ddb \
     --hash=sha256:fb09761e093cfabb2f179dbfdb2521e1ec5701df714d1eb5c51fa7849027be19
-    # via pushsource
+    # via
+    #   pubtools-pulplib
+    #   pushsource
 frozenlist2==1.0.0 \
     --hash=sha256:33f6c6bb2c7d38524ec3c2d6f2d8a3ee2625a9e13096d8bc64db012b516a95e0 \
     --hash=sha256:caffe66813e42de320b10d08b8c0604c7eb3f142a8482ad3130243e084f37a2f
@@ -474,9 +476,9 @@ pubtools==1.2.1 \
     # via
     #   -r requirements.in
     #   pubtools-pulplib
-pubtools-pulplib==2.30.0 \
-    --hash=sha256:b2faf6afa55f5a47e13ea134f092bf0033a955f6219fc7d864d57f8b53c177fd \
-    --hash=sha256:bde202e1cd4280a43f2a054c6af25af6ac0248dfe6cfc632638d9ca4858aa845
+pubtools-pulplib==2.32.0 \
+    --hash=sha256:6628a1fce79229a34fe1695e9807efc9d728e2dff425452286a5dd913b1b65ca \
+    --hash=sha256:6b257f8ae7c1059f52a73239912dba5993e7d854e7614c9d1bf36b907f1dc649
     # via -r requirements.in
 pushcollector==1.3.0 \
     --hash=sha256:18281fcd4247ca8b668c25348bbc2f9cc032912cecc7037824a74ad8adcbb1c3 \

--- a/tests/fake/test_fake_persistence.py
+++ b/tests/fake/test_fake_persistence.py
@@ -3,7 +3,11 @@ import os
 from pubtools.pluggy import task_context
 from pubtools.pulplib import ModulemdDefaultsUnit, ModulemdUnit
 
-from pubtools._pulp.services.fakepulp import new_fake_client
+from pubtools._pulp.services.fakepulp import new_fake_controller
+
+
+def new_fake_client(state_path):
+    return new_fake_controller(state_path).client
 
 
 def test_state_persisted(tmpdir, data_path):

--- a/tests/push/test_associate_item_order.py
+++ b/tests/push/test_associate_item_order.py
@@ -13,7 +13,7 @@ def test_associate_order():
     queue = ctx.new_queue()
     phase = Associate(
         context=ctx,
-        pulp_client=None,
+        pulp_client_factory=lambda: None,
         pre_push=None,
         allow_unsigned=True,
         in_queue=queue,

--- a/tests/push/test_push_fake_client.py
+++ b/tests/push/test_push_fake_client.py
@@ -1,0 +1,21 @@
+import sys
+
+from pubtools._pulp.tasks.push import Push
+
+
+def test_push_fake_client_for_phase(monkeypatch):
+    """--pulp-fake causes Push to use a new fake client for each phase."""
+
+    monkeypatch.setattr(sys, "argv", ["", "--pulp-fake"])
+
+    push = Push()
+
+    client1 = push.pulp_client_for_phase()
+    client2 = push.pulp_client_for_phase()
+
+    # It should give me two different clients
+    assert client1 is not client2
+
+    # And they both should be fakes
+    assert "Fake" in str(type(client1))
+    assert "Fake" in str(type(client2))

--- a/tests/push/test_upload_sharing.py
+++ b/tests/push/test_upload_sharing.py
@@ -29,6 +29,13 @@ class ClientWrapper(object):
         self.search_content = delegate.search_content
         self.uploads = []
 
+    def __enter__(self):
+        self.delegate.__enter__()
+        return self
+
+    def __exit__(self, *args, **kwargs):
+        self.delegate.__exit__(*args, **kwargs)
+
     def get_repository(self, *args, **kwargs):
         wrapper = partial(RepoWrapper, uploads=self.uploads)
         return f_map(self.delegate.get_repository(*args, **kwargs), wrapper)
@@ -50,7 +57,7 @@ def test_uploads_shared(data_path):
     queue = ctx.new_queue()
     phase = Upload(
         context=ctx,
-        pulp_client=client_wrapper,
+        pulp_client_factory=lambda: client_wrapper,
         pre_push=None,
         in_queue=queue,
         update_push_items=lambda _: None,

--- a/tests/shared/test_pulp_cache.py
+++ b/tests/shared/test_pulp_cache.py
@@ -1,4 +1,6 @@
 import sys
+import attr
+
 from pubtools.pulplib import Client, FakeController, FileRepository
 from pubtools._pulp.task import PulpTask
 from pubtools._pulp.services import CachingPulpClientService
@@ -35,8 +37,9 @@ def test_client_caches(monkeypatch):
         task.pulp_ctrl.insert_repository(FileRepository(id="test-repo"))
 
         # Let's try getting it via the caching client.
-        repo1 = task.caching_pulp_client.get_repository("test-repo")
-        repo2 = task.caching_pulp_client.get_repository("test-repo")
+        with task.caching_pulp_client as client:
+            repo1 = task.caching_pulp_client.get_repository("test-repo")
+            repo2 = task.caching_pulp_client.get_repository("test-repo")
 
         # Due to the caching, it should give me back *exactly* the same
         # object in both cases.
@@ -80,3 +83,43 @@ def test_client_no_cache_errors(monkeypatch):
 
         # And those calls succeeded.
         assert repo2.result().id == "test-repo"
+
+
+def test_update_invalidates(monkeypatch):
+    """update_repository should invalidate the cache for that repository"""
+
+    with TaskWithPulpClient() as task:
+        monkeypatch.setattr(
+            sys,
+            "argv",
+            [
+                "",
+                "--pulp-url",
+                "http://some.url",
+            ],
+        )
+
+        # Add some repo
+        task.pulp_ctrl.insert_repository(
+            FileRepository(id="test-repo", product_versions=["a", "b"])
+        )
+
+        # Let's try getting it via the caching client.
+        repo1 = task.caching_pulp_client.get_repository("test-repo").result()
+        repo2 = task.caching_pulp_client.get_repository("test-repo").result()
+
+        # Initially consistent
+        assert repo1.product_versions == ["a", "b"]
+        assert repo2.product_versions == ["a", "b"]
+
+        # Let's update the repo
+        task.caching_pulp_client.update_repository(
+            attr.evolve(repo1, product_versions=["new", "versions"])
+        ).result()
+
+        # Let's get the repo again...
+        repo3 = task.caching_pulp_client.get_repository("test-repo")
+
+        # The cache should have been smart enough to realize it can't
+        # return the old cached value since the repo was updated.
+        assert repo3.product_versions == ["new", "versions"]


### PR DESCRIPTION
Sharing the same client between all phases of push has the following
issue: the client internally can only have so many HTTP requests in
flight to Pulp at once. If all of those requests are being used up by
one phase then other phases depending on requests will be unable to
make progress.

In the worst-case scenario this could lead to a deadlock. This has not
been observed in production today, but it becomes more likely when
reducing the queue size as seen in #134. Fix it by letting each phase
use its own client which cannot interfere with the progress of other
phases.

One downside of this is that the caching pulp client used during push
will now be less effective, as cached values can't be shared between
phases.

Requires some refactoring of --pulp-fake support to ensure that all fake
clients are sharing the same state, which in turn needs the latest
version of pulplib.