### PR TITLE
Fix an internal queue able to grow unbounded [RHELDST-11375]

### DIFF
--- a/tests/push/test_phase_limits.py
+++ b/tests/push/test_phase_limits.py
@@ -1,9 +1,10 @@
 import time
+from threading import Lock, Thread
 
 from concurrent.futures import ThreadPoolExecutor
 from more_executors.futures import f_return
 
-from pubtools._pulp.tasks.push.phase import Context, Phase, context
+from pubtools._pulp.tasks.push.phase import Context, Phase, context, base
 
 
 def return_later(value, delay=0.2):
@@ -37,6 +38,26 @@ class ManyFutureOutputsPhase(Phase):
         # thousands of futures.
         for i in range(1, self.PUT_COUNT):
             self.put_future_output(f_return(i))
+
+
+class CountingPhase(Phase):
+    """A phase which puts many items while keeping track of the maximum
+    number of future puts."""
+
+    PUT_COUNT = 100
+
+    def __init__(self, *args, **kwargs):
+        self.executor = kwargs.pop("executor")
+        self.max_future_puts = 0
+        super(CountingPhase, self).__init__(*args, **kwargs)
+
+    def put_future_outputs(self, *args, **kwargs):
+        super(CountingPhase, self).put_future_outputs(*args, **kwargs)
+        self.max_future_puts = max(self.max_future_puts, len(self._Phase__future_puts))
+
+    def run(self):
+        for i in range(0, self.PUT_COUNT):
+            self.put_future_output(self.executor.submit(return_later, i, 0.001))
 
 
 def test_future_output_limits(monkeypatch):
@@ -73,3 +94,53 @@ def test_future_output_limits(monkeypatch):
     # Order is not guaranteed, but every output should successfully make
     # it through.
     assert sorted(outputs) == sorted(range(0, phase.PUT_COUNT))
+
+
+def test_future_output_bounded(monkeypatch):
+    """Verify that put_future_output applies a limit on amount of futures enqueued."""
+
+    # Make the queue size much less than the PUT_COUNT.
+    monkeypatch.setattr(context, "QUEUE_SIZE", 10)
+    monkeypatch.setattr(base, "QUEUE_SIZE", context.QUEUE_SIZE)
+
+    outputs = []
+
+    # We are going to have to set up a consumer of the phase's output queue to
+    # prevent deadlock.
+    def read_queue(queue):
+        while True:
+            out = queue.get()
+            outputs.append(out)
+            if out in (phase.ERROR, phase.FINISHED):
+                break
+
+            # As we are trying to see what happens if the producer is faster
+            # than the consumer, we need the reader to be a bit slow.
+            time.sleep(0.01)
+
+    ctx = Context()
+
+    with ThreadPoolExecutor() as executor:
+        phase = CountingPhase(context=ctx, in_queue=None, executor=executor)
+
+        reader = Thread(target=read_queue, args=(phase.out_queue,))
+        reader.start()
+
+        # Try running the phase - it should do PUT_COUNT puts onto its
+        # own output queue. It should not deadlock since we have a reader.
+        with phase:
+            pass
+
+        reader.join(30.0)
+        assert not reader.is_alive()
+
+    # It should have completed normally
+    assert outputs[-1] is phase.FINISHED
+
+    # While running, the max pending future_puts should never be allowed
+    # to exceed this value
+    assert phase.max_future_puts <= context.QUEUE_SIZE
+
+    # (and sanity check that it's more than 1 as it otherwise means our
+    # test didn't really test what it was supposed to)
+    assert phase.max_future_puts > 1


### PR DESCRIPTION
For a phase using put_future_outputs there are effectively two levels of
queue for the output:

1. The phase's proper out_queue (connected to the next phase)
2. A "queue" of futures waiting to put a value on out_queue

These both need to have some constraints on their size to avoid
unreasonable memory usage if we're doing a large push. Previously, (1)
was constrained by the queue size but (2) was not. This commit
refactors the code so that (2) is also constrained, avoiding memory
usage problems.