### PR TITLE
refactor: split progress logging from context

### DIFF
--- a/pubtools/_pulp/tasks/push/command.py
+++ b/pubtools/_pulp/tasks/push/command.py
@@ -15,6 +15,7 @@ from .phase import (
     Associate,
     Publish,
     Context,
+    ProgressLogger,
 )
 from ..common import Publisher, PulpTask
 from ...services import (
@@ -184,7 +185,7 @@ class Push(
         # start them all.
         #
         # This will start all the phases...
-        with exitstack([ctx.progress_logger()] + phases):
+        with exitstack([ProgressLogger.for_context(ctx)] + phases):
             LOG.debug("All push phases are now running.")
             # ...and exiting the 'with' block here will wait for them to
             # complete.

--- a/pubtools/_pulp/tasks/push/phase/__init__.py
+++ b/pubtools/_pulp/tasks/push/phase/__init__.py
@@ -9,3 +9,4 @@ from .collect import Collect
 from .associate import Associate
 from .publish import Publish
 from .context import Context
+from .progress import ProgressLogger

--- a/pubtools/_pulp/tasks/push/phase/context.py
+++ b/pubtools/_pulp/tasks/push/phase/context.py
@@ -1,13 +1,9 @@
 # -*- coding: utf-8 -*-
 
-import os
 import logging
-import shutil
 from collections import namedtuple
 
-from contextlib import contextmanager
-
-from threading import Lock, Thread, Event
+from threading import Lock, Event
 
 from six.moves.queue import Queue
 
@@ -17,9 +13,6 @@ from .base import Phase, QUEUE_SIZE
 # pylint: disable=redundant-u-string-prefix
 
 LOG = logging.getLogger("pubtools.pulp")
-
-# How long, in seconds, between our logging of current phase progress.
-PROGRESS_INTERVAL = int(os.getenv("PUBTOOLS_PULP_PROGRESS_INTERVAL") or "600")
 
 QueueCounts = namedtuple("QueueCounts", ["put", "get", "done"])
 
@@ -140,25 +133,13 @@ class Context(object):
         self._queues.append(out)
         return out
 
-    def dump_progress(self, width=None):
-        """Output a log with progress info for each queue associated with the
-        context.
+    @property
+    def queue_counts(self):
+        """Get current item counts in every counting queue.
 
-        The log has a visual component (progress bars) and also a structured
-        event logged via 'extra'.
+        Returns a list of tuple("queue name", tuple(put, get, done)).
         """
-
-        if width is None:
-            width = int(os.environ.get("COLUMNS") or "80")
-
-            # Conditional due to py2
-            if hasattr(shutil, "get_terminal_size"):
-                (width, _) = shutil.get_terminal_size()
-
-        snapshot = []
-        max_namelen = 0
-        max_count = 1
-        items_known = self.items_known.is_set()
+        out = []
 
         for queue in self._queues:
             if not isinstance(queue, CountingQueue):
@@ -166,115 +147,7 @@ class Context(object):
                 # such as the one used by Collect phase.
                 continue
 
-            max_namelen = max(max_namelen, len(queue.name))
             counts = queue.counts
-            snapshot.append((queue.name, counts))
-            max_count = max(max_count, *counts)
+            out.append((queue.name, counts))
 
-        # When reporting progress, we may or may not know exactly how many
-        # items we're dealing with, depending how far we are in the push.
-        # If we know the exact count, use it.
-        if items_known:
-            max_count = self.items_count or 1
-
-        template_str = "[ %%%ds | %%s%%s%%s%%s ]" % max_namelen
-        bar_width = max(width - max_namelen - 10, 10)
-
-        # We will create both human-oriented strings and machine-oriented
-        # structured metrics (logged via 'extra'). In practice this can be
-        # gathered into JSONL logs.
-        formatted_strs = []
-        event = {"type": "progress-report", "phases": []}
-
-        for (name, counts) in snapshot:
-            # We want to draw a progress bar like this:
-            #
-            # "▇▇▇▇▄▄▄▄▄▁▁▁▁              "
-            #
-            # The bar fills in from left to right.
-            #
-            # '▇' => done processing
-            # '▄' => currently in progress
-            # '▁' => waiting in queue
-            # ' ' => items not yet arrived in queue (estimated)
-            #
-
-            # Proportions of the bar from left to right
-            part1 = float(counts.done) / max_count
-            part2 = float(counts.get - counts.done) / max_count
-            part3 = float(counts.put - counts.get) / max_count
-            part4 = 1.0 - part3 - part2 - part1
-
-            # How much is that in character count?
-            part1 = int(part1 * bar_width)
-            part2 = int(part2 * bar_width)
-            part3 = int(part3 * bar_width)
-            part4 = int(part4 * bar_width)
-
-            # FIXME: code below uses fmt off/on to allow u string literals
-            # with black. Drop this when python2 support goes away!
-            # fmt: off
-            bar1 = u"▇" * part1
-            bar2 = u"▄" * part2
-            bar3 = u"▁" * part3
-            bar4 = u" " * part4
-            # fmt: on
-
-            # Seeing as we've truncated downwards to get integers, we may
-            # need to pad a few more spaces to fill out the bar
-            while len(bar1 + bar2 + bar3 + bar4) < bar_width:
-                bar4 = bar4 + " "
-
-            bar_str = template_str % (name, bar1, bar2, bar3, bar4)
-
-            # If we don't know the exact item counts, we'd better indicate this
-            # since the progress bar can otherwise be rather misleading. We do
-            # this by pasting '???' near the end.
-            if not items_known:
-                bar_str = bar_str[:-6] + " ??? ]"
-
-            formatted_strs.append(bar_str)
-
-            # Add counts to the structured event as well.
-            event["phases"].append(
-                {
-                    "name": name,
-                    "in-queue": counts.put - counts.get,
-                    "in-progress": counts.get - counts.done,
-                    "done": counts.done,
-                    "total": max_count,
-                }
-            )
-
-        LOG.info("Progress:\n  %s", "\n  ".join(formatted_strs), extra={"event": event})
-
-    @contextmanager
-    def progress_logger(self, interval=PROGRESS_INTERVAL):
-        """A context manager for periodically logging the progress of all queues.
-
-        While the context is open, progress will be logged periodically via
-        dump_progress. This logging ends once the context is closed.
-        """
-
-        if interval <= 0:
-            # Allows the feature to be entirely disabled.
-            yield
-            return
-
-        stop_logging = Event()
-
-        def loop():
-            while not stop_logging.is_set():
-                self.dump_progress()
-                stop_logging.wait(timeout=interval)
-
-        thread = Thread(name="progress-logger", target=loop)
-        thread.daemon = True
-
-        thread.start()
-        try:
-            yield
-        finally:
-            stop_logging.set()
-            thread.join()
-            self.dump_progress()
+        return out

--- a/pubtools/_pulp/tasks/push/phase/progress.py
+++ b/pubtools/_pulp/tasks/push/phase/progress.py
@@ -1,0 +1,154 @@
+import logging
+import os
+from threading import Event, Thread
+import shutil
+from contextlib import contextmanager
+
+
+LOG = logging.getLogger("pubtools.pulp")
+
+# How long, in seconds, between our logging of current phase progress.
+PROGRESS_INTERVAL = int(os.getenv("PUBTOOLS_PULP_PROGRESS_INTERVAL") or "300")
+
+
+class ProgressLogger(object):
+    """A helper to periodically log a context's progress info."""
+
+    def __init__(self, context):
+        self.ctx = context
+
+    def dump_progress(self, width=None):
+        """Output a log with progress info for each queue associated with the
+        context.
+
+        The log has a visual component (progress bars) and also a structured
+        event logged via 'extra'.
+        """
+
+        if width is None:
+            width = int(os.environ.get("COLUMNS") or "80")
+
+            # Conditional due to py2
+            if hasattr(shutil, "get_terminal_size"):
+                (width, _) = shutil.get_terminal_size()
+
+        snapshot = []
+        max_namelen = 0
+        max_count = 1
+        items_known = self.ctx.items_known.is_set()
+
+        snapshot = self.ctx.queue_counts
+        for (queue_name, queue_counts) in snapshot:
+            max_namelen = max(max_namelen, len(queue_name))
+            max_count = max(max_count, *queue_counts)
+
+        # When reporting progress, we may or may not know exactly how many
+        # items we're dealing with, depending how far we are in the push.
+        # If we know the exact count, use it.
+        if items_known:
+            max_count = self.ctx.items_count or 1
+
+        template_str = "[ %%%ds | %%s%%s%%s%%s ]" % max_namelen
+        bar_width = max(width - max_namelen - 10, 10)
+
+        # We will create both human-oriented strings and machine-oriented
+        # structured metrics (logged via 'extra'). In practice this can be
+        # gathered into JSONL logs.
+        formatted_strs = []
+        event = {"type": "progress-report", "phases": []}
+
+        for (name, counts) in snapshot:
+            # We want to draw a progress bar like this:
+            #
+            # "▇▇▇▇▄▄▄▄▄▁▁▁▁              "
+            #
+            # The bar fills in from left to right.
+            #
+            # '▇' => done processing
+            # '▄' => currently in progress
+            # '▁' => waiting in queue
+            # ' ' => items not yet arrived in queue (estimated)
+            #
+
+            # Proportions of the bar from left to right
+            part1 = float(counts.done) / max_count
+            part2 = float(counts.get - counts.done) / max_count
+            part3 = float(counts.put - counts.get) / max_count
+            part4 = 1.0 - part3 - part2 - part1
+
+            # How much is that in character count?
+            part1 = int(part1 * bar_width)
+            part2 = int(part2 * bar_width)
+            part3 = int(part3 * bar_width)
+            part4 = int(part4 * bar_width)
+
+            # FIXME: code below uses fmt off/on to allow u string literals
+            # with black. Drop this when python2 support goes away!
+            # fmt: off
+            bar1 = u"▇" * part1
+            bar2 = u"▄" * part2
+            bar3 = u"▁" * part3
+            bar4 = u" " * part4
+            # fmt: on
+
+            # Seeing as we've truncated downwards to get integers, we may
+            # need to pad a few more spaces to fill out the bar
+            while len(bar1 + bar2 + bar3 + bar4) < bar_width:
+                bar4 = bar4 + " "
+
+            bar_str = template_str % (name, bar1, bar2, bar3, bar4)
+
+            # If we don't know the exact item counts, we'd better indicate this
+            # since the progress bar can otherwise be rather misleading. We do
+            # this by pasting '???' near the end.
+            if not items_known:
+                bar_str = bar_str[:-6] + " ??? ]"
+
+            formatted_strs.append(bar_str)
+
+            # Add counts to the structured event as well.
+            event["phases"].append(
+                {
+                    "name": name,
+                    "in-queue": counts.put - counts.get,
+                    "in-progress": counts.get - counts.done,
+                    "done": counts.done,
+                    "total": max_count,
+                }
+            )
+
+        LOG.info("Progress:\n  %s", "\n  ".join(formatted_strs), extra={"event": event})
+
+    @classmethod
+    @contextmanager
+    def for_context(cls, ctx, interval=PROGRESS_INTERVAL):
+        """A context manager for periodically logging the progress of a context.
+
+        While the context is open, progress will be logged periodically via
+        dump_progress. This logging ends once the context is closed.
+        """
+
+        if interval <= 0:
+            # Allows the feature to be entirely disabled.
+            yield
+            return
+
+        stop_logging = Event()
+
+        logger = cls(ctx)
+
+        def loop():
+            while not stop_logging.is_set():
+                logger.dump_progress()
+                stop_logging.wait(timeout=interval)
+
+        thread = Thread(name="progress-logger", target=loop)
+        thread.daemon = True
+
+        thread.start()
+        try:
+            yield
+        finally:
+            stop_logging.set()
+            thread.join()
+            logger.dump_progress()

--- a/tests/push/test_context_counts.py
+++ b/tests/push/test_context_counts.py
@@ -6,7 +6,7 @@ import threading
 
 from threading import Semaphore
 
-from pubtools._pulp.tasks.push.phase import Context, Phase
+from pubtools._pulp.tasks.push.phase import Context, Phase, ProgressLogger
 from pubtools._pulp.tasks.push.contextlib_compat import exitstack
 
 
@@ -36,6 +36,7 @@ def test_context_counts(caplog):
     by dump_progress."""
 
     ctx = Context()
+    progress = ProgressLogger(ctx)
     queues = ctx._queues
 
     in_sem1 = Semaphore(0)
@@ -109,7 +110,7 @@ def test_context_counts(caplog):
             assert c3 == (15, 10, 5)
 
             caplog.set_level(logging.INFO)
-            ctx.dump_progress(width=70)
+            progress.dump_progress(width=70)
 
             # When visualized, this is what it should look like.
             # Note the ??? because the total number of items hasn't been set on
@@ -163,7 +164,7 @@ def test_context_counts(caplog):
             # a known item count.
             ctx.items_count = 100
             ctx.items_known.set()
-            ctx.dump_progress(width=70)
+            progress.dump_progress(width=70)
 
             # Now it should look like this. Compare to previously:
             # - bars have shrunk since actual item count (100) is larger than the
@@ -201,6 +202,6 @@ def test_context_progress_logger_disabled():
     # nothing happens by checking that the thread count is stable.
     threadcount = len(threading.enumerate())
 
-    with ctx.progress_logger(interval=0):
+    with ProgressLogger.for_context(ctx, interval=0):
         # Should not have spawned a new thread.
         assert len(threading.enumerate()) == threadcount


### PR DESCRIPTION
The progress logging does not have much to do with the rest of the
Context class. Move it elsewhere so that each class is more focused on a
single responsibility.