### PR TITLE
Added errata flush in the UD cache flush step post publish

### DIFF
--- a/pubtools/_pulp/tasks/common.py
+++ b/pubtools/_pulp/tasks/common.py
@@ -129,7 +129,9 @@ class Publisher(CDNCache, UdCache):
             )
         return out
 
-    def publish_with_cache_flush(self, repos, units=None, pulp_client=None, errata=None):
+    def publish_with_cache_flush(
+        self, repos, units=None, pulp_client=None, errata=None
+    ):
         # Ensure all repos in 'repos' are fully published, and CDN/UD caches are flushed.
         #
         # If 'units' are provided, ensures those units have cdn_published field set after
@@ -155,7 +157,9 @@ class Publisher(CDNCache, UdCache):
         set_published = f_sequence(self.set_cdn_published(units, pulp_client))
 
         # flush UD cache only after cdn_published is set (if applicable)
-        flush_ud = f_flat_map(set_published, lambda _: f_sequence(self.flush_ud(repos, errata)))
+        flush_ud = f_flat_map(
+            set_published, lambda _: f_sequence(self.flush_ud(repos, errata))
+        )
         out.append(flush_ud)
 
         return out

--- a/pubtools/_pulp/tasks/push/phase/publish.py
+++ b/pubtools/_pulp/tasks/push/phase/publish.py
@@ -86,7 +86,9 @@ class Publish(Phase):
         )
 
         # Start publishing them, including cache flushes.
-        publish_fs = self.publish_with_cache_flush(repo_fs, set_cdn_published, errata=errata_units)
+        publish_fs = self.publish_with_cache_flush(
+            repo_fs, set_cdn_published, errata=errata_units
+        )
 
         # Then wait for publishes to finish.
         for f in publish_fs:

--- a/pubtools/_pulp/tasks/push/phase/publish.py
+++ b/pubtools/_pulp/tasks/push/phase/publish.py
@@ -1,7 +1,7 @@
 import logging
 
 import attr
-from pubtools.pulplib import Criteria
+from pubtools.pulplib import Criteria, ErratumUnit
 
 from .base import Phase
 from . import constants
@@ -59,6 +59,7 @@ class Publish(Phase):
         # away - the CDN origin supports near-atomic update.
         all_repo_ids = set()
         set_cdn_published = set()
+        errata_units = set()
         all_items = []
 
         for item in self.iter_input():
@@ -69,6 +70,9 @@ class Publish(Phase):
             unit = item.pulp_unit
             if hasattr(unit, "cdn_published") and unit.cdn_published is None:
                 set_cdn_published.add(unit)
+
+            if isinstance(unit, ErratumUnit):
+                errata_units.add(unit)
 
             all_items.append(item)
 
@@ -82,7 +86,7 @@ class Publish(Phase):
         )
 
         # Start publishing them, including cache flushes.
-        publish_fs = self.publish_with_cache_flush(repo_fs, set_cdn_published)
+        publish_fs = self.publish_with_cache_flush(repo_fs, set_cdn_published, errata=errata_units)
 
         # Then wait for publishes to finish.
         for f in publish_fs:

--- a/pubtools/_pulp/ud.py
+++ b/pubtools/_pulp/ud.py
@@ -110,3 +110,16 @@ class UdCacheClient(object):
                 A future resolved once flush has completed.
         """
         return self._flush_object("repo", repo_id)
+
+    def flush_erratum(self, erratum_id):
+        """Flush a particular erratum by ID.
+
+        Arguments:
+            erratum_id (str)
+                Erratum ID
+
+        Returns:
+            Future[None]
+                A future resolved when flush has completed
+        """
+        return self._flush_object("erratum", erratum_id)

--- a/tests/ud/test_ud_cache_client.py
+++ b/tests/ud/test_ud_cache_client.py
@@ -32,7 +32,7 @@ def test_flush(requests_mock, caplog):
     assert caplog.messages == [
         "Invalidating eng-product 1234",
         "Invalidating repo some-repo",
-        "Invalidating erratum RHBA-1234"
+        "Invalidating erratum RHBA-1234",
     ]
 
 


### PR DESCRIPTION
Currently, UD cache flush only flushes repos after publish.
This patch adds errata flushes as well to the UD cache flush
post publish.