### PR TITLE
Erratums are always uploaded to all-rpm-content repo

### DIFF
--- a/tests/logs/push/test_push/test_nopublish_push.pulp.yaml
+++ b/tests/logs/push/test_push/test_nopublish_push.pulp.yaml
@@ -121,6 +121,7 @@ units:
     type: other
   release: '0'
   repository_memberships:
+  - all-rpm-content
   - dest1
   rights: Copyright 2020 Red Hat Inc
   severity: None
@@ -2746,6 +2747,7 @@ units:
     type: other
   release: '0'
   repository_memberships:
+  - all-rpm-content
   - dest1
   rights: Copyright 2019 Red Hat Inc
   severity: None
@@ -2891,6 +2893,7 @@ units:
     type: other
   release: '0'
   repository_memberships:
+  - all-rpm-content
   - dest1
   rights: Copyright 2020 Red Hat Inc
   severity: Important

--- a/tests/logs/push/test_push/test_typical_push.pulp.yaml
+++ b/tests/logs/push/test_push/test_typical_push.pulp.yaml
@@ -121,6 +121,7 @@ units:
     type: other
   release: '0'
   repository_memberships:
+  - all-rpm-content
   - dest1
   rights: Copyright 2020 Red Hat Inc
   severity: None
@@ -2746,6 +2747,7 @@ units:
     type: other
   release: '0'
   repository_memberships:
+  - all-rpm-content
   - dest1
   rights: Copyright 2019 Red Hat Inc
   severity: None
@@ -2891,6 +2893,7 @@ units:
     type: other
   release: '0'
   repository_memberships:
+  - all-rpm-content
   - dest1
   rights: Copyright 2020 Red Hat Inc
   severity: Important

--- a/tests/logs/push/test_push/test_update_push.pulp.yaml
+++ b/tests/logs/push/test_push/test_update_push.pulp.yaml
@@ -121,6 +121,7 @@ units:
     type: other
   release: '0'
   repository_memberships:
+  - all-rpm-content
   - dest1
   rights: Copyright 2020 Red Hat Inc
   severity: None
@@ -2746,6 +2747,7 @@ units:
     type: other
   release: '0'
   repository_memberships:
+  - all-rpm-content
   - dest1
   rights: Copyright 2019 Red Hat Inc
   severity: None
@@ -2891,6 +2893,7 @@ units:
     type: other
   release: '0'
   repository_memberships:
+  - all-rpm-content
   - dest1
   rights: Copyright 2020 Red Hat Inc
   severity: Important


### PR DESCRIPTION
Pulp maintains the pkglist for (erratum_id, repo) pair. If an
erratum is uploaded for an existing erratum, it's overwritten if
repo is the same, else is appended.
Currently, the erratum is uploaded to one of the repos picked
randomly from the destination list. This messed up the pkglist
as the packages that were modified in the new erratum upload did't
reflect in the package list as the list is appended rather than
modified/overwritten.
Hence, this patch ensures that the erratums are always uploaded to
the all-rpm-content repo to have the same (erratum_id, repo) pair
generating a consistent pkglist.