### PR TITLE
Increase default phase timeout

### DIFF
--- a/pubtools/_pulp/tasks/push/phase/constants.py
+++ b/pubtools/_pulp/tasks/push/phase/constants.py
@@ -53,7 +53,7 @@ DEFAULT_PROGRESS_TYPE = PROGRESS_TYPE_QUEUE
 """Default progress type for phases."""
 
 
-PHASE_TIMEOUT = int(os.getenv("PUBTOOLS_PULP_PHASE_TIMEOUT") or "200000")
+PHASE_TIMEOUT = int(os.getenv("PUBTOOLS_PULP_PHASE_TIMEOUT") or "2000000")  # ~23 days
 """How long, in seconds, we're willing to wait while joining phase threads.
 
 Should be a large value. In fact, the code should strictly speaking not


### PR DESCRIPTION
A timeout must be set for all phases here for the reasons explained in the comment, even though in practice we don't really expect that timeout to ever be reached.

Problem: the earlier value worked out to about ~55 hours and it is genuinely possible for some push tasks to take that long during execution, resulting in a spurious timeout as happened in Pub task 545951.

Bump it up by 10x. The new value is about 23 days which surely ought to be enough...