### PR TITLE
Fix compatibility with tox 4

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@ envlist = py27,py38,static,docs
 [testenv]
 deps=-rtest-requirements.txt
 commands=pytest -v {posargs}
-whitelist_externals=sh
+allowlist_externals=sh
 
 [testenv:py27]
 deps=
@@ -24,13 +24,6 @@ commands=
 usedevelop=true
 commands=
 	pytest --cov-report=html --cov-report=xml --cov=pubtools {posargs}
-
-[testenv:cov-travis]
-passenv = TRAVIS TRAVIS_*
-usedevelop=true
-commands=
-	pytest --cov=pubtools {posargs}
-	coveralls
 
 [testenv:docs]
 use_develop=true


### PR DESCRIPTION
The term 'whitelist' must be replaced with 'allowlist' for compatibility with tox >= 4.0.0.