### PR TITLE
Fix monotonic dependency issues

### DIFF
--- a/pubtools/_pulp/tasks/push/phase/base.py
+++ b/pubtools/_pulp/tasks/push/phase/base.py
@@ -1,7 +1,11 @@
 import logging
 import os
 from threading import Thread
-from monotonic import monotonic
+
+try:
+    from time import monotonic
+except ImportError:  # pragma: no cover
+    from monotonic import monotonic
 from six.moves.queue import Empty
 
 from .buffer import OutputBuffer

--- a/pubtools/_pulp/tasks/push/phase/buffer.py
+++ b/pubtools/_pulp/tasks/push/phase/buffer.py
@@ -3,7 +3,11 @@ import concurrent.futures
 from collections import namedtuple
 
 from more_executors import f_map
-from monotonic import monotonic
+
+try:
+    from time import monotonic
+except ImportError:  # pragma: no cover
+    from monotonic import monotonic
 
 
 # Internal class to keep track of whether a value represents a single item

--- a/pubtools/_pulp/tasks/push/phase/context.py
+++ b/pubtools/_pulp/tasks/push/phase/context.py
@@ -2,7 +2,11 @@ import logging
 
 from pushsource import ModuleMdPushItem
 from threading import Event
-from monotonic import monotonic
+
+try:
+    from time import monotonic
+except ImportError:  # pragma: no cover
+    from monotonic import monotonic
 import concurrent.futures
 from collections import defaultdict
 from six.moves.queue import Queue, Full, Empty

--- a/requirements.in
+++ b/requirements.in
@@ -6,3 +6,4 @@ more_executors>=2.7.0
 pushcollector>=1.2.0
 pushsource>=2.14.0
 rhsm
+monotonic; python_version < '3.3'


### PR DESCRIPTION
Fix two problems with 'monotonic' dependency:

- it should not be required on python 3, since time.monotonic can be used instead

- it was used without declaring it as a dependency. This worked until now because it was a transitive dependency via at least pubtools-pulplib and more-executors. However, those projects now have new releases available which no longer depend on 'monotonic', so it will no longer be pulled in transitively.