### PR TITLE
Add PKI support for pulp client

### DIFF
--- a/pubtools/_pulp/services/pulp.py
+++ b/pubtools/_pulp/services/pulp.py
@@ -5,6 +5,7 @@ import logging
 import warnings
 
 from pubtools import pulplib
+from pubtools.pluggy import pm
 
 from .base import Service
 from .fakepulp import new_fake_controller
@@ -48,6 +49,16 @@ class PulpClientService(Service):
             default=None,
         )
         group.add_argument(
+            "--pulp-certificate",
+            help="Pulp certificate. Can also be a single file (.pem)",
+            default=None,
+        )
+        group.add_argument(
+            "--pulp-certificate-key",
+            help="Pulp certificate key",
+            default=None,
+        )
+        group.add_argument(
             "--pulp-insecure",
             action="store_true",
             help="Allow unverified HTTPS connection to Pulp",
@@ -87,8 +98,12 @@ class PulpClientService(Service):
 
     def new_pulp_client(self, **kwargs):
         """Creates and returns a new Pulp client with appropriate config."""
+        cert = None
         auth = None
         args = self._service_args
+
+        # Use hook to get the certificate path(s). Defined here, used later.
+        hook_rets = pm.hook.get_cert_key_paths(server_url=args.pulp_url)
 
         if not args.pulp_fake and not args.pulp_url:
             LOG.error("At least one of --pulp-url or --pulp-fake must be provided")
@@ -98,6 +113,39 @@ class PulpClientService(Service):
             LOG.warning("Using a fake Pulp client, no changes will be made to Pulp!")
             return self.pulp_fake_controller.new_client()
 
+        # certificate provided as argument
+        if args.pulp_certificate:
+            LOG.info(
+                "Pulp certificate %s was provided as argument", args.pulp_certificate
+            )
+            if args.pulp_certificate_key:
+                LOG.info(
+                    "Pulp certificate key %s was provided as argument",
+                    args.pulp_certificate_key,
+                )
+                cert = (args.pulp_certificate, args.pulp_certificate_key)
+            else:
+                cert = args.pulp_certificate
+        # certificate paths provided using hook (pm.hook.get_cert_key_paths())
+        elif hook_rets and os.path.exists(hook_rets[0]):
+            LOG.debug("Pulp certificate was not passed as argument")
+            cert_file = hook_rets[0]
+            LOG.info(
+                "Pulp certificate %s was provided through the get_cert_key_paths hook",
+                cert,
+            )
+            key_file = (
+                hook_rets[1] if hook_rets[1] and os.path.exists(hook_rets[1]) else None
+            )
+            if key_file:
+                cert = (cert_file, key_file)
+            else:
+                cert = cert_file
+        else:
+            LOG.debug(
+                "Pulp certificate was not passed through the get_cert_key_paths hook"
+            )
+
         # checks if pulp password is available as environment variable
         if args.pulp_user:
             pulp_password = args.pulp_password or os.environ.get("PULP_PASSWORD")
@@ -106,7 +154,10 @@ class PulpClientService(Service):
             auth = (args.pulp_user, pulp_password)
 
         kwargs = kwargs.copy()
-        kwargs["auth"] = auth
+        if cert:
+            kwargs["cert"] = cert
+        else:
+            kwargs["auth"] = auth
 
         if args.pulp_insecure:
             kwargs["verify"] = False

--- a/tests/push/test_push.py
+++ b/tests/push/test_push.py
@@ -131,12 +131,14 @@ def test_typical_push(
     )
 
     # It should have invoked hook(s).
-    assert len(hookspy) == 24
+    assert len(hookspy) == 25
     (hook_name, hook_kwargs) = hookspy[0]
     assert hook_name == "task_start"
     (hook_name, hook_kwargs) = hookspy[1]
-    assert hook_name == "pulp_repository_pre_publish"
+    assert hook_name == "get_cert_key_paths"
     (hook_name, hook_kwargs) = hookspy[2]
+    assert hook_name == "pulp_repository_pre_publish"
+    (hook_name, hook_kwargs) = hookspy[3]
     assert hook_name == "pulp_repository_published"
     # after pulp_repository_published there's 13 calls of pulp_item_push_finished
     (hook_name, hook_kwargs) = hookspy[-15]


### PR DESCRIPTION
With the move to certificates and read-only passwords based authentication, the following were implemented:
- adds --pulp-certificate and --pulp-certificate-key arguments
- supports single file (e.g. .pem) or multiple files (e.g. .cert,.key)  certificates
- supports looking up the cert/key path via the get_cert_key_paths hook defined here: https://release-engineering.github.io/pubtools/hooks.html