### PR TITLE
Drop Python2 support

### DIFF
--- a/.github/workflows/tox-test.yml
+++ b/.github/workflows/tox-test.yml
@@ -3,22 +3,6 @@ name: Tox tests
 on: [push, pull_request]
 
 jobs:
-  py27:
-    runs-on: ubuntu-20.04
-    steps:
-      - uses: actions/checkout@v2
-      - name: Install RPM
-        run: sudo apt-get install -y rpm libkrb5-dev
-      - name: Upgrade pip
-        run: pip install --upgrade pip
-      - name: Setup Python
-        uses: actions/setup-python@v2
-        with:
-          python-version: 2.7
-      - name: Install Tox
-        run: pip install tox
-      - name: Run Tox
-        run: tox -e py27
   py38:
     runs-on: ubuntu-latest
     steps:

--- a/legacy.constraints
+++ b/legacy.constraints
@@ -1,6 +1,0 @@
-# Oldest supported versions of major libraries can be added to this
-# file. They'll be tested with Python 2.7.
-
-# constraints from pubtools-pulplib 
-attrs==17.4.0
-jsonschema==2.3.0

--- a/pubtools/_pulp/arguments.py
+++ b/pubtools/_pulp/arguments.py
@@ -1,11 +1,6 @@
 import os
 from argparse import Action
 
-import six
-
-# short alias for version specific base string type
-_STRING = six.string_types[0]
-
 
 def from_environ(key, delegate_converter=lambda x: x):
     """A converter for use as an argparse "type" argument which supports
@@ -128,7 +123,7 @@ class SplitAndExtend(Action):
         # so unless this action is being used in conjunction with
         # parser.add_argument(type=<some non-string type>) this
         # should not be the case.
-        split = values.split(self.split_on) if isinstance(values, _STRING) else values
+        split = values.split(self.split_on) if isinstance(values, str) else values
         items.extend(split)
         setattr(namespace, self.dest, items)
 

--- a/pubtools/_pulp/tasks/push/items/rpm.py
+++ b/pubtools/_pulp/tasks/push/items/rpm.py
@@ -2,7 +2,6 @@ import os
 
 from pushsource import RpmPushItem
 import attr
-import six
 from pubtools.pulplib import RpmUnit, Criteria
 
 from .base import supports_type, PulpPushItem, UploadContext
@@ -58,13 +57,10 @@ class PulpRpmPushItem(PulpPushItem):
         except Exception as exc:  # pylint: disable=broad-except
             # Crashes above may be a bit hard to understand, so we raise with
             # a more self-explanatory message.
-            six.raise_from(
-                ValueError(
+            raise ValueError(
                     "Invalid RPM filename %s (expected: "
                     "[name]-[version]-[release].[arch].rpm)" % self.pushsource_item.name
-                ),
-                exc,
-            )
+                ) from exc
 
     @property
     def cdn_path(self):

--- a/pubtools/_pulp/tasks/push/items/rpm.py
+++ b/pubtools/_pulp/tasks/push/items/rpm.py
@@ -58,9 +58,9 @@ class PulpRpmPushItem(PulpPushItem):
             # Crashes above may be a bit hard to understand, so we raise with
             # a more self-explanatory message.
             raise ValueError(
-                    "Invalid RPM filename %s (expected: "
-                    "[name]-[version]-[release].[arch].rpm)" % self.pushsource_item.name
-                ) from exc
+                "Invalid RPM filename %s (expected: "
+                "[name]-[version]-[release].[arch].rpm)" % self.pushsource_item.name
+            ) from exc
 
     @property
     def cdn_path(self):

--- a/pubtools/_pulp/tasks/push/phase/base.py
+++ b/pubtools/_pulp/tasks/push/phase/base.py
@@ -6,7 +6,7 @@ try:
     from time import monotonic
 except ImportError:  # pragma: no cover
     from monotonic import monotonic
-from six.moves.queue import Empty
+from queue import Empty
 
 from .buffer import OutputBuffer
 from .errors import PhaseInterrupted

--- a/pubtools/_pulp/tasks/push/phase/context.py
+++ b/pubtools/_pulp/tasks/push/phase/context.py
@@ -9,7 +9,7 @@ except ImportError:  # pragma: no cover
     from monotonic import monotonic
 import concurrent.futures
 from collections import defaultdict
-from six.moves.queue import Queue, Full, Empty
+from queue import Queue, Full, Empty
 
 
 from .errors import PhaseInterrupted

--- a/requirements.in
+++ b/requirements.in
@@ -1,4 +1,3 @@
-six
 pubtools>=0.3.0
 pubtools-pulplib>=2.33.0
 fastpurge

--- a/setup.py
+++ b/setup.py
@@ -32,14 +32,11 @@ setup(
         "Development Status :: 4 - Beta",
         "Intended Audience :: Developers",
         "License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)",
-        "Programming Language :: Python :: 2",
-        "Programming Language :: Python :: 2.6",
-        "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3",
         "Topic :: Software Development :: Libraries :: Python Modules",
     ],
     install_requires=get_requirements(),
-    python_requires=">=2.6",
+    python_requires=">=3.6",
     entry_points={
         "console_scripts": [
             "pubtools-pulp-garbage-collect = pubtools._pulp.tasks.garbage_collect:entry_point",

--- a/tox.ini
+++ b/tox.ini
@@ -1,18 +1,10 @@
 [tox]
-envlist = py27,py38,static,docs
+envlist = py38,static,docs
 
 [testenv]
 deps=-rtest-requirements.txt
 commands=pytest -v {posargs}
 allowlist_externals=sh
-
-[testenv:py27]
-deps=
-	# Note: we need to explicitly list requirements.in here
-	# so it's processed at the same time as the constraints file
-	-rrequirements.in
-	-clegacy.constraints
-	-rtest-requirements.in
 
 [testenv:static]
 deps=


### PR DESCRIPTION
After Supercharge Pub 3 was delivered, Python 2 support is no longer required in it's dependencies as well. Dropping Python 2 will make the repos easier to maintain and will speed up Tox and Github Actions since some steps can be removed.