### PR TITLE
Flush CDN cache by ARL [RHELDST-17152]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- n/a
+- Added purging CDN cache by ARL
 
 ## [1.24.0] - 2023-03-28
 

--- a/pubtools/_pulp/cdn.py
+++ b/pubtools/_pulp/cdn.py
@@ -1,0 +1,144 @@
+import logging
+import os
+import re
+import threading
+from collections import namedtuple
+
+import requests
+from more_executors import Executors
+from more_executors.futures import f_map
+
+LOG = logging.getLogger("pubtools.pulp")
+
+
+HeaderPair = namedtuple("HeaderPair", ["request", "response"])
+
+
+class CdnClient(object):
+    # Client for requesting special headers from CDN service.
+
+    # Default number of request thread modifiable by an env variable.
+    # This is not a documented/supported feature of the library.
+    _REQUEST_THREADS = int(os.environ.get("CDN_REQUEST_THREADS", "4"))
+    _ATTEMPTS = int(os.environ.get("CDN_RETRY_ATTEMPTS", "9"))
+    _SLEEP = float(os.environ.get("CDN_RETRY_SLEEP", "1.0"))
+    _EXPONENT = float(os.environ.get("CDN_RETRY_EXPONENT", "3.0"))
+    _MAX_SLEEP = float(os.environ.get("CDN_RETRY_MAX_SLEEP", "120.0"))
+
+    TTL_REGEX = re.compile(r".*/(\d+[smhd])/.*")
+    CACHE_KEY_HEADER = HeaderPair("akamai-x-get-cache-key", "X-Cache-Key")
+
+    def __init__(self, url, max_retry_sleep=_MAX_SLEEP, **kwargs):
+        """Create a new CDN client.
+
+        Arguments:
+            url (str)
+                Base URL of CDN
+            max_retry_sleep (float)
+                Max number of seconds to sleep between retries.
+                Mainly provided so that tests can reduce the time needed to retry.
+            kwargs
+                Remaining arguments are used to initialize the requests.Session()
+                used within this class (e.g. "verify", "cert").
+        """
+        self._url = url
+        self._tls = threading.local()
+
+        retry_args = {
+            "max_sleep": max_retry_sleep,
+            "max_attempts": CdnClient._ATTEMPTS,
+            "sleep": CdnClient._SLEEP,
+            "exponent": CdnClient._EXPONENT,
+        }
+
+        self._session_attrs = kwargs
+        self._executor = (
+            Executors.thread_pool(name="cdn-client", max_workers=self._REQUEST_THREADS)
+            .with_map(self._check_http_response)
+            .with_retry(**retry_args)
+        )
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc_details):
+        self._executor.__exit__(*exc_details)
+
+    @staticmethod
+    def _check_http_response(response):
+        response.raise_for_status()
+        return response
+
+    @property
+    def _session(self):
+        if not hasattr(self._tls, "session"):
+            self._tls.session = requests.Session()
+            for key, value in self._session_attrs.items():
+                setattr(self._tls.session, key, value)
+        return self._tls.session
+
+    def _head(self, *args, **kwargs):
+        return self._session.head(*args, **kwargs)
+
+    def _on_failure(self, header, exception):
+        LOG.error("Requesting header %s failed: %s", header, exception)
+        raise exception
+
+    def _get_headers_for_path(self, path, headers):
+        url = os.path.join(self._url, path)
+
+        LOG.info("Getting headers %s for %s", list(headers.values()), url)
+
+        out = self._executor.submit(self._head, url, headers=headers)
+        out = f_map(
+            out,
+            fn=lambda resp: resp.headers,
+            error_fn=lambda ex: self._on_failure(list(headers.values()), ex),
+        )
+
+        return out
+
+    def _get_ttl(self, path):
+        headers = {"Pragma": self.CACHE_KEY_HEADER.request}
+        out = self._get_headers_for_path(path, headers)
+
+        def _parse_ttl(value):
+            parsed = re.match(
+                self.TTL_REGEX, value.get(self.CACHE_KEY_HEADER.response) or ""
+            )
+            return parsed.group(1) if parsed else None
+
+        return f_map(out, _parse_ttl)
+
+    def _is_valid_template(self, template):
+        return all(["{ttl}" in template, "path" in template])
+
+    def get_arl_for_path(self, path, templates):
+        """Get ARL for particular path using provided templates.
+        This method generates ARLs for given path according to
+        provided ARL templates. TTL value is requested from CDN
+        special headers.
+
+        Arguments:
+            path (str)
+                Relative path/URL (e.g. content/foo/bar/repomd.xml).
+            templates (List[str])
+                A list of templates used for generating ARLs.
+                (e.g. ["/foo/bar/{ttl}/{path}", ...]). The {ttl} and
+                {path} formatting substrings are required.
+        Returns:
+            List[Future]
+                A list of futures holding formatted ARLs.
+        """
+
+        def _format_template(ttl, template, path):
+            return f_map(ttl, lambda x: template.format(ttl=x, path=path))
+
+        out = []
+        ttl_ft = self._get_ttl(path)
+
+        for item in templates:
+            if self._is_valid_template(item):
+                out.append(_format_template(ttl_ft, item, path))
+
+        return out

--- a/pubtools/_pulp/services/__init__.py
+++ b/pubtools/_pulp/services/__init__.py
@@ -3,3 +3,4 @@ from .fastpurge_ import FastPurgeClientService
 from .pulp import PulpClientService
 from .cachingpulp import CachingPulpClientService
 from .udcache import UdCacheClientService
+from .cdn import CdnClientService

--- a/pubtools/_pulp/services/cdn.py
+++ b/pubtools/_pulp/services/cdn.py
@@ -1,0 +1,78 @@
+import threading
+
+from pubtools._pulp.cdn import CdnClient
+
+from .base import Service
+
+# Because class is designed as a mix-in...
+# pylint: disable=no-member
+
+
+class CdnClientService(Service):
+    """A service providing a CDN client.
+
+    A client will only be available if the user provided CDN-related
+    arguments to the command.
+    """
+
+    def __init__(self, *args, **kwargs):
+        self.__lock = threading.Lock()
+        self.__instance = None
+        super(CdnClientService, self).__init__(*args, **kwargs)
+
+    def add_service_args(self, parser):
+        super(CdnClientService, self).add_service_args(parser)
+
+        group = parser.add_argument_group("CDN Client environment")
+
+        group.add_argument(
+            "--cdn-url",
+            help=(
+                "Base URL of CDN, "
+                "if omitted, CDN won't be requested for special data (e.g. headers for ARLs)"
+            ),
+        )
+        group.add_argument("--cdn-cert", help="Client certificate for CDN client")
+        group.add_argument(
+            "--cdn-key",
+            help="Client key for CDN client",
+        )
+        group.add_argument(
+            "--cdn-ca-cert",
+            help="CA certificate for CDN",
+        )
+        group.add_argument(
+            "--cdn-arl-template",
+            help="ARL template used for flushing cache by ARL",
+            nargs="*",
+        )
+
+    @property
+    def cdn_client(self):
+        """A CDN client used during task, instantiated on demand.
+
+        May return None if needed arguments for CDN cache flush are not provided,
+        in which case getting extra data from CDN is skipped.
+        """
+        with self.__lock:
+            if not self.__instance:
+                self.__instance = self.__get_instance()
+        return self.__instance
+
+    def __get_instance(self):
+        args = self._service_args
+        if not args.cdn_url:
+            # disable requests made to CDN
+            return None
+
+        return CdnClient(
+            url=args.cdn_url,
+            cert=(args.cdn_cert, args.cdn_key),
+            verify=args.cdn_ca_cert,
+        )
+
+    def __exit__(self, *exc_details):
+        if self.__instance:
+            self.__instance.__exit__(*exc_details)
+
+        super(CdnClientService, self).__exit__(*exc_details)

--- a/tests/cdn/test_cdn_client.py
+++ b/tests/cdn/test_cdn_client.py
@@ -1,0 +1,123 @@
+import logging
+from concurrent.futures import as_completed
+
+from pubtools._pulp.cdn import CdnClient
+
+
+def test_format_arl_template(requests_mock, caplog):
+    """Client formats ARL template with live TTL."""
+    caplog.set_level(logging.INFO)
+
+    # test templates also with invalid template which should be skipped from processing
+    templates = [
+        "/fake/template-1/{ttl}/{path}",
+        "/fake/template-2/{ttl}/{path}",
+        "invalid-template/{xyz}",
+    ]
+
+    with CdnClient(
+        "https://cdn.example.com/", cert=("path/cert", "path/key")
+    ) as client:
+        url_ttl = [
+            ("https://cdn.example.com/content/foo/test-path-1/repomd.xml", "10h"),
+            ("https://cdn.example.com/content/foo/test-path-2/other-file.xml", "30m"),
+        ]
+
+        for url, ttl in url_ttl:
+            headers = {"X-Cache-Key": f"/fake/cache-key/{ttl}/something"}
+            requests_mock.register_uri("HEAD", url, headers=headers)
+
+        fts = []
+        # Let client get arl for given paths
+        fts.extend(
+            client.get_arl_for_path("content/foo/test-path-1/repomd.xml", templates)
+        )
+        fts.extend(
+            client.get_arl_for_path("content/foo/test-path-2/other-file.xml", templates)
+        )
+
+        # It should succeed and return expected ARLs
+        arls = [ft.result() for ft in as_completed(fts)]
+        assert sorted(arls) == [
+            "/fake/template-1/10h/content/foo/test-path-1/repomd.xml",
+            "/fake/template-1/30m/content/foo/test-path-2/other-file.xml",
+            "/fake/template-2/10h/content/foo/test-path-1/repomd.xml",
+            "/fake/template-2/30m/content/foo/test-path-2/other-file.xml",
+        ]
+    # It should have called above URLs
+    fetched_urls = [req.url for req in requests_mock.request_history]
+    assert sorted(fetched_urls) == [url for url, _ in url_ttl]
+
+    # It should log 'Getting headers...' for each path
+    assert caplog.messages == [
+        "Getting headers ['akamai-x-get-cache-key'] for "
+        "https://cdn.example.com/content/foo/test-path-1/repomd.xml",
+        "Getting headers ['akamai-x-get-cache-key'] for "
+        "https://cdn.example.com/content/foo/test-path-2/other-file.xml",
+    ]
+
+
+def test_retries(requests_mock):
+    """Client retries automatically on error."""
+    templates = [
+        "/fake/template-1/{ttl}/{path}",
+    ]
+    with CdnClient("https://cdn.example.com/", max_retry_sleep=0.001) as client:
+        url = "https://cdn.example.com/content/foo/test-path-1/repomd.xml"
+
+        requests_mock.register_uri(
+            "HEAD",
+            url,
+            [
+                # Fails on first try
+                {"status_code": 500},
+                # Then succeeds
+                {
+                    "status_code": 200,
+                    "headers": {"X-Cache-Key": f"/fake/cache-key/10h/something"},
+                },
+            ],
+        )
+
+        # It should succeed due to retrying
+        results = [
+            item.result()
+            for item in client.get_arl_for_path(
+                "content/foo/test-path-1/repomd.xml", templates
+            )
+        ]
+
+    # It should have called above URL twice
+    fetched_urls = [req.url for req in requests_mock.request_history]
+    assert fetched_urls == [url] * 2
+
+    # Checked ARL result
+    assert results[0] == "/fake/template-1/10h/content/foo/test-path-1/repomd.xml"
+
+
+def test_logs(requests_mock, caplog):
+    """Client produces logs after requests."""
+
+    caplog.set_level(logging.INFO)
+
+    templates = [
+        "/fake/template-1/{ttl}/{path}",
+    ]
+    with CdnClient("https://cdn.example.com/", max_retry_sleep=0.001) as client:
+        url = "https://cdn.example.com/content/foo/test-path-1/repomd.xml"
+
+        requests_mock.register_uri("HEAD", url, status_code=500)
+
+        # It should eventually fail with the HTTP error
+        exception = client.get_arl_for_path(
+            "content/foo/test-path-1/repomd.xml", templates
+        )[0].exception()
+        assert "500 Server Error" in str(exception)
+
+    # It should have logged what it was doing and what failed
+    assert caplog.messages == [
+        "Getting headers ['akamai-x-get-cache-key'] for "
+        "https://cdn.example.com/content/foo/test-path-1/repomd.xml",
+        "Requesting header ['akamai-x-get-cache-key'] failed: 500 Server Error: None "
+        "for url: https://cdn.example.com/content/foo/test-path-1/repomd.xml",
+    ]

--- a/tests/logs/publish/test_publish/test_repo_publish_cache_cleanup_with_arl.jsonl
+++ b/tests/logs/publish/test_publish/test_repo_publish_cache_cleanup_with_arl.jsonl
@@ -1,0 +1,10 @@
+{"event": {"type": "check-repos-start"}}
+{"event": {"type": "check-repos-end"}}
+{"event": {"type": "publish-start"}}
+{"event": {"type": "publish-end"}}
+{"event": {"type": "flush-cdn-cache-start"}}
+{"event": {"type": "flush-cdn-cache-end"}}
+{"event": {"type": "set-cdn_published-start"}}
+{"event": {"type": "set-cdn_published-end"}}
+{"event": {"type": "flush-ud-cache-start"}}
+{"event": {"type": "flush-ud-cache-end"}}

--- a/tests/logs/publish/test_publish/test_repo_publish_cache_cleanup_with_arl.txt
+++ b/tests/logs/publish/test_publish/test_repo_publish_cache_cleanup_with_arl.txt
@@ -1,0 +1,12 @@
+[    INFO] Check repos: started
+[    INFO] Check repos: finished
+[    INFO] Publish: started
+[    INFO] Publishing repo1
+[    INFO] Publish: finished
+[    INFO] Flush CDN cache: started
+[    INFO] Flush CDN cache: finished
+[    INFO] Set cdn_published: started
+[    INFO] Set cdn_published: finished
+[    INFO] Flush UD cache: started
+[    INFO] Flush UD cache: finished
+[    INFO] Publishing repositories completed


### PR DESCRIPTION
This change introduces a CDN client that is used for generating ARLs
that are required for a complete CDN cache purging on certain environments.

Flushing CDN cache by ARLs is enabled only if CDN-related arguments are
passed via CLI. ARLs are generated according to provided templates, only
the TTL value is requested for each path from CDN.