### PR TITLE
Fix CI failure installing rpm-py-installer

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Install system dependencies
         run: sudo apt-get install -y libkrb5-dev
       - name: Install Tox
-        run: pip install tox
+        run: pip install tox 'virtualenv<20.21.1'
       - name: Run Tox
         run: tox -e docs
       - name: Publish

--- a/.github/workflows/tox-test.yml
+++ b/.github/workflows/tox-test.yml
@@ -16,7 +16,7 @@ jobs:
         with:
           python-version: 3.8
       - name: Install Tox
-        run: pip install tox
+        run: pip install tox 'virtualenv<20.21.1'
       - name: Run Tox
         run: tox -e py38
   static:
@@ -30,7 +30,7 @@ jobs:
         with:
           python-version: 3.8
       - name: Install Tox
-        run: pip install tox
+        run: pip install tox 'virtualenv<20.21.1'
       - name: Run Tox
         run: tox -e static
   coverage:
@@ -44,7 +44,7 @@ jobs:
         with:
           python-version: 3.8
       - name: Install Tox
-        run: pip install tox
+        run: pip install tox 'virtualenv<20.21.1'
       - name: Install pytest cov
         run: pip install pytest-cov
       - name: Run Tox
@@ -65,7 +65,7 @@ jobs:
         with:
           python-version: 3.8
       - name: Install Tox
-        run: pip install tox
+        run: pip install tox 'virtualenv<20.21.1'
       - name: Run Tox
         run: tox -e docs
   bandit-exitzero:
@@ -81,7 +81,7 @@ jobs:
         with:
           python-version: 3.8
       - name: Install Tox
-        run: pip install tox
+        run: pip install tox 'virtualenv<20.21.1'
       - name: Run Tox
         run: tox -e bandit-exitzero
   bandit:
@@ -97,6 +97,6 @@ jobs:
         with:
           python-version: 3.8
       - name: Install Tox
-        run: pip install tox
+        run: pip install tox 'virtualenv<20.21.1'
       - name: Run Tox
         run: tox -e bandit


### PR DESCRIPTION
This became broken by the release of pip 23.1 and virtualenv 20.21.1. Details on bug report:
junaruga/rpm-py-installer#276

Until there is a proper resolution, pin to an older virtualenv to avoid the issue.

Since the relevant deps here are used during installation of tox itself, the pinning unfortunately cannot be done using the requirements files consumed from within tox.