### PR TITLE
Published-before should accept datetime [RHELDST-12600]

### DIFF
--- a/pubtools/_pulp/tasks/publish.py
+++ b/pubtools/_pulp/tasks/publish.py
@@ -22,13 +22,14 @@ LOG = logging.getLogger("pubtools.pulp")
 
 
 def publish_date(str_date):
-    for date_format in ['%Y-%m-%dT%H:%M:%SZ', '%Y-%m-%d']:
+    for date_format in ["%Y-%m-%dT%H:%M:%SZ", "%Y-%m-%d"]:
         try:
             return datetime.strptime(str_date, date_format)
         except ValueError:
             pass
-    raise ArgumentTypeError("published-before date should be in YYYY-mm-ddTHH:MM:SSZ or YYYY-mm-dd format")
-
+    raise ArgumentTypeError(
+        "published-before date should be in YYYY-mm-ddTHH:MM:SSZ or YYYY-mm-dd format"
+    )
 
 
 class Publish(PulpClientService, Publisher, PulpTask):

--- a/pubtools/_pulp/tasks/publish.py
+++ b/pubtools/_pulp/tasks/publish.py
@@ -1,6 +1,7 @@
 import logging
 import sys
 import re
+from argparse import ArgumentTypeError
 from datetime import datetime
 
 from pubtools.pulplib import Criteria, Matcher
@@ -21,8 +22,13 @@ LOG = logging.getLogger("pubtools.pulp")
 
 
 def publish_date(str_date):
-    # validates publish-before date
-    return datetime.strptime(str_date, "%Y-%m-%d")
+    for date_format in ['%Y-%m-%dT%H:%M:%SZ', '%Y-%m-%d']:
+        try:
+            return datetime.strptime(str_date, date_format)
+        except ValueError:
+            pass
+    raise ArgumentTypeError("published-before date should be in YYYY-mm-ddTHH:MM:SSZ or YYYY-mm-dd format")
+
 
 
 class Publish(PulpClientService, Publisher, PulpTask):

--- a/tests/logs/publish/test_publish/test_publish_repos_not_published_before_a_datetime.jsonl
+++ b/tests/logs/publish/test_publish/test_publish_repos_not_published_before_a_datetime.jsonl
@@ -1,0 +1,2 @@
+{"event": {"type": "check-repos-start"}}
+{"event": {"type": "check-repos-error"}}

--- a/tests/logs/publish/test_publish/test_publish_repos_not_published_before_a_datetime.txt
+++ b/tests/logs/publish/test_publish/test_publish_repos_not_published_before_a_datetime.txt
@@ -1,0 +1,4 @@
+[    INFO] Check repos: started
+[   ERROR] No repo(s) found to publish
+[   ERROR] Check repos: failed
+# Raised: 30

--- a/tests/logs/publish/test_publish/test_publish_repos_published_before_a_datetime.jsonl
+++ b/tests/logs/publish/test_publish/test_publish_repos_published_before_a_datetime.jsonl
@@ -1,0 +1,10 @@
+{"event": {"type": "check-repos-start"}}
+{"event": {"type": "check-repos-end"}}
+{"event": {"type": "publish-start"}}
+{"event": {"type": "publish-end"}}
+{"event": {"type": "flush-cdn-cache-start"}}
+{"event": {"type": "flush-cdn-cache-end"}}
+{"event": {"type": "set-cdn_published-start"}}
+{"event": {"type": "set-cdn_published-end"}}
+{"event": {"type": "flush-ud-cache-start"}}
+{"event": {"type": "flush-ud-cache-end"}}

--- a/tests/logs/publish/test_publish/test_publish_repos_published_before_a_datetime.txt
+++ b/tests/logs/publish/test_publish/test_publish_repos_published_before_a_datetime.txt
@@ -1,0 +1,14 @@
+[    INFO] Check repos: started
+[    INFO] Check repos: finished
+[    INFO] Publish: started
+[    INFO] Publishing repo3
+[    INFO] Publish: finished
+[    INFO] Flush CDN cache: started
+[    INFO] CDN cache flush is not enabled.
+[    INFO] Flush CDN cache: finished
+[    INFO] Set cdn_published: started
+[    INFO] Set cdn_published: finished
+[    INFO] Flush UD cache: started
+[    INFO] UD cache flush is not enabled.
+[    INFO] Flush UD cache: finished
+[    INFO] Publishing repositories completed

--- a/tests/publish/test_publish.py
+++ b/tests/publish/test_publish.py
@@ -385,10 +385,12 @@ def test_publish_repos_published_before_exception(command_tester):
                     "--published-before",
                     "2019-09-07BADFORMAT01:00:00Z",
                 ],
-                allow_raise=True
+                allow_raise=True,
             )
-        assert "published-before date should be in YYYY-mm-ddTHH:MM:SSZ " \
+        assert (
+            "published-before date should be in YYYY-mm-ddTHH:MM:SSZ "
             "or YYYY-mm-dd format" in e.traceback
+        )
         assert e.value.code == 2
 
 


### PR DESCRIPTION
Pub allows users to provide a datetime value for the published-before argument in the publish command, but the library implementation didn't accept it. This change adds in the extra format.