### PR TITLE
Reduce log spam for cancelled copy tasks

### DIFF
--- a/pubtools/_pulp/tasks/push/items/base.py
+++ b/pubtools/_pulp/tasks/push/items/base.py
@@ -261,7 +261,7 @@ class PulpPushItem(object):
 
         # Add some reasonable logging onto the copies...
         def log_copy_done(f):
-            if not f.exception():
+            if not f.cancelled() and not f.exception():
                 tasks = f.result()
                 oper = copy_opers[f]
                 for t in tasks:


### PR DESCRIPTION
The code here is responsible for logging a summary of a successfully completed copy. The intent is to do this only when a copy succeeded, hence the f.exception() check. However, f.exception() itself raises an exception if the future was cancelled which would generate a lot of log spam.

Fix it to do the logging only if the future succeeded, per the original intent.