### PR TITLE
Retry all failed associations with up-to-date data

### DIFF
--- a/pubtools/_pulp/tasks/push/phase/associate.py
+++ b/pubtools/_pulp/tasks/push/phase/associate.py
@@ -27,6 +27,9 @@ class Associate(Phase):
     # so we'll avoid marking it as started until then
     STARTUP_TYPE = constants.STARTUP_TYPE_NOTIFY
 
+    # How many times to retry association if some item gets missing:
+    ASSOCIATION_RETRY_COUNT = constants.ASSOCIATION_RETRY_COUNT
+
     def __init__(self, context, pulp_client, pre_push, allow_unsigned, in_queue, **_):
         super(Associate, self).__init__(
             context, in_queue=in_queue, name="Associate items in Pulp"
@@ -128,6 +131,9 @@ class Associate(Phase):
         for batch in self.iter_for_associate():
             for items in PulpPushItem.items_by_type(batch):
                 for associated_f in PulpPushItem.associated_items_single_batch(
-                    self.pulp_client, items, self.copy_options
+                    self.pulp_client,
+                    items,
+                    self.copy_options,
+                    self.ASSOCIATION_RETRY_COUNT,
                 ):
                     self.put_future_outputs(associated_f)

--- a/pubtools/_pulp/tasks/push/phase/constants.py
+++ b/pubtools/_pulp/tasks/push/phase/constants.py
@@ -112,3 +112,8 @@ OUT_BATCH_TIMEOUT = float(os.getenv("PUBTOOLS_PULP_OUT_BATCH_TIMEOUT") or "10.0"
 
 OUT_MAX_FUTURES = int(os.getenv("PUBTOOLS_PULP_OUT_MAX_FUTURES") or "10")
 """Max number of pending futures in output buffer."""
+
+# The following tune the behaviour of individual phases
+
+ASSOCIATION_RETRY_COUNT = int(os.getenv("PUBTOOLS_PULP_ASSOCIATION_RETRY_COUNT") or "2")
+"""Number of retries for association of pulp items."""

--- a/tests/logs/push/test_association_race/test_association_race.pulp.yaml
+++ b/tests/logs/push/test_association_race/test_association_race.pulp.yaml
@@ -1,0 +1,7933 @@
+repos:
+- _class: FileRepository
+  id: all-iso-content
+- _class: YumRepository
+  id: all-rpm-content
+- _class: YumRepository
+  arch: x86_64
+  eng_product_id: 123
+  id: dest1
+  product_versions:
+  - '6.10'
+- _class: YumRepository
+  id: dest2
+- _class: FileRepository
+  id: iso-dest1
+- _class: FileRepository
+  arch: x86_64
+  eng_product_id: 123
+  id: iso-dest2
+  product_versions:
+  - '6.10'
+- _class: FileRepository
+  id: redhat-maintenance
+units:
+- _class: ErratumUnit
+  container_list:
+  - e2e/test-operator-container:
+      digest: sha256:2321a7d13d9fa53f05437663cf2dc217d15f3cda4b67076c941b10f0491cf9d7
+      images:
+        ppc64le:
+          digest: sha256:05649a19718fde131372c761d359302ccbe81f9744d2893ac4c826b05d670206
+        s390x:
+          digest: sha256:06d1c5e4fa6a5d1ff868388f3feadf193d04128b62d1181e37fe4ab8ecda27e1
+        x86_64:
+          digest: sha256:c2e3030306f71b94cbffe2d16fcebe6e14f2842ae26789926bcf1afeeecb5859
+  content_types:
+  - docker
+  description: 'The devtools/rust-toolset-rhel7 container image has been updated for
+    Red Hat Developer Tools to address the following security advisory: RHSA-2020:0374
+    (see References)
+
+
+    Users of devtools/rust-toolset-rhel7 container images are advised to upgrade to
+    these updated images, which contain backported patches to correct these security
+    issues, fix these bugs and add these enhancements. Users of these images are also
+    encouraged to rebuild all container images that depend on these images.
+
+
+    You can find images updated by this advisory in Red Hat Container Catalog (see
+    References).'
+  from_: release-engineering@redhat.com
+  id: RHBA-2020:0518
+  issued: 2020-02-17 09:14:49 UTC
+  pkglist: []
+  pushcount: '1'
+  reboot_suggested: false
+  references:
+  - _class: ErratumReference
+    href: https://access.redhat.com/errata/RHBA-2020:0518
+    id: RHBA-2020:0518
+    title: RHBA-2020:0518
+    type: self
+  - _class: ErratumReference
+    href: https://bugzilla.redhat.com/show_bug.cgi?id=1744149
+    id: '1744149'
+    title: 'CVE-2019-14816 kernel: heap overflow in mwifiex_update_vs_ie() function
+      of Marvell WiFi driver'
+    type: bugzilla
+  - _class: ErratumReference
+    href: https://bugzilla.redhat.com/show_bug.cgi?id=1771909
+    id: '1771909'
+    title: 'CVE-2019-17133 kernel: buffer overflow in cfg80211_mgd_wext_giwessid in
+      net/wireless/wext-sme.c'
+    type: bugzilla
+  - _class: ErratumReference
+    href: https://bugzilla.redhat.com/show_bug.cgi?id=1773519
+    id: '1773519'
+    title: 'CVE-2019-14901 kernel: heap overflow in marvell/mwifiex/tdls.c'
+    type: bugzilla
+  - _class: ErratumReference
+    href: https://bugzilla.redhat.com/show_bug.cgi?id=1774671
+    id: '1774671'
+    title: 'CVE-2019-14898 kernel: incomplete fix  for race condition between mmget_not_zero()/get_task_mm()
+      and core dumping in CVE-2019-11599'
+    type: bugzilla
+  - _class: ErratumReference
+    href: https://bugzilla.redhat.com/show_bug.cgi?id=1774870
+    id: '1774870'
+    title: 'CVE-2019-14895 kernel: heap-based buffer overflow in mwifiex_process_country_ie()
+      function in drivers/net/wireless/marvell/mwifiex/sta_ioctl.c'
+    type: bugzilla
+  - _class: ErratumReference
+    href: https://www.redhat.com/security/data/cve/CVE-2019-13734.html
+    id: CVE-2019-13734
+    title: CVE-2019-13734
+    type: cve
+  - _class: ErratumReference
+    href: https://www.redhat.com/security/data/cve/CVE-2019-14816.html
+    id: CVE-2019-14816
+    title: CVE-2019-14816
+    type: cve
+  - _class: ErratumReference
+    href: https://www.redhat.com/security/data/cve/CVE-2019-14895.html
+    id: CVE-2019-14895
+    title: CVE-2019-14895
+    type: cve
+  - _class: ErratumReference
+    href: https://www.redhat.com/security/data/cve/CVE-2019-14898.html
+    id: CVE-2019-14898
+    title: CVE-2019-14898
+    type: cve
+  - _class: ErratumReference
+    href: https://www.redhat.com/security/data/cve/CVE-2019-14901.html
+    id: CVE-2019-14901
+    title: CVE-2019-14901
+    type: cve
+  - _class: ErratumReference
+    href: https://www.redhat.com/security/data/cve/CVE-2019-17133.html
+    id: CVE-2019-17133
+    title: CVE-2019-17133
+    type: cve
+  - _class: ErratumReference
+    href: https://access.redhat.com/errata/RHSA-2020:0374
+    id: ref_0
+    title: other_reference_0
+    type: other
+  - _class: ErratumReference
+    href: https://access.redhat.com/containers/?tab=images#/registry.access.redhat.com/devtools/rust-toolset-rhel7
+    id: ref_1
+    title: other_reference_1
+    type: other
+  release: '0'
+  repository_memberships:
+  - all-rpm-content
+  - dest1
+  rights: Copyright 2020 Red Hat Inc
+  severity: None
+  solution: 'The Red Hat Developer Tools container image provided by this update can
+    be downloaded from the Red Hat Container Registry at registry.access.redhat.com.
+    Installation instructions for your platform are available at Red Hat Container
+    Catalog (see References).
+
+
+    Dockerfiles and scripts should be amended either to refer to this new image specifically,
+    or to the latest image generally.'
+  status: final
+  summary: Updated devtools/rust-toolset-rhel7 container image is now available for
+    Red Hat Developer Tools.
+  title: updated devtools/rust-toolset-rhel7 container image
+  type: bugfix
+  unit_id: (hidden)
+  updated: 2020-02-17 09:14:49 UTC
+  version: '1'
+- _class: ErratumUnit
+  content_types:
+  - module
+  description: For detailed information on changes in this release, see the Red Hat
+    Enterprise Linux 8.1 Release Notes linked from the References section.
+  from_: release-engineering@redhat.com
+  id: RHBA-2019:3384
+  issued: 2019-11-05 17:38:32 UTC
+  pkglist:
+  - _class: ErratumPackageCollection
+    module:
+      _class: ErratumModule
+      arch: x86_64
+      context: cdc1202b
+      name: ruby
+      stream: '2.5'
+      version: '8010020190711131821'
+    name: RHBA-2019:3384-ruby-2.5-cdc1202b-x86_64
+    packages:
+    - _class: ErratumPackage
+      arch: i686
+      epoch: '0'
+      filename: ruby-2.5.5-105.module+el8.1.0+3656+f80bfa1d.i686.rpm
+      md5sum: 6ea7b135735c83cfc5ee67b8b233fc04
+      name: ruby
+      reboot_suggested: false
+      release: 105.module+el8.1.0+3656+f80bfa1d
+      sha256sum: e7abfc09ed5e095bac1a62cf11c24211ec950079a84944d0dfcd0a854a163363
+      src: rubygem-mongo-2.5.1-2.module+el8.1.0+3656+f80bfa1d.src.rpm
+      version: 2.5.5
+    - _class: ErratumPackage
+      arch: SRPMS
+      epoch: '0'
+      filename: ruby-2.5.5-105.module+el8.1.0+3656+f80bfa1d.src.rpm
+      md5sum: 026b049a21504fc773244164a2d0ff12
+      name: ruby
+      reboot_suggested: false
+      release: 105.module+el8.1.0+3656+f80bfa1d
+      sha256sum: 2edef90b7b9cf7222d932258d8978e4c7c41bf6eeffdfd5032b01d02e6d50e6d
+      src: rubygem-mongo-2.5.1-2.module+el8.1.0+3656+f80bfa1d.src.rpm
+      version: 2.5.5
+    - _class: ErratumPackage
+      arch: x86_64
+      epoch: '0'
+      filename: ruby-2.5.5-105.module+el8.1.0+3656+f80bfa1d.x86_64.rpm
+      md5sum: 50f28ca87e0aa5a3c2960ce1187ed698
+      name: ruby
+      reboot_suggested: false
+      release: 105.module+el8.1.0+3656+f80bfa1d
+      sha256sum: ff5ed92f8e6b898d9edabc8545787a51c67848ae5ae9f611011327c442914230
+      src: rubygem-mongo-2.5.1-2.module+el8.1.0+3656+f80bfa1d.src.rpm
+      version: 2.5.5
+    - _class: ErratumPackage
+      arch: i686
+      epoch: '0'
+      filename: ruby-debuginfo-2.5.5-105.module+el8.1.0+3656+f80bfa1d.i686.rpm
+      md5sum: f12ec92f06ea542b4c1c8b60df75c4c2
+      name: ruby-debuginfo
+      reboot_suggested: false
+      release: 105.module+el8.1.0+3656+f80bfa1d
+      sha256sum: 71aae7bdceb18c1409557dc4c777fa9c9b8728cafbb4b4f091ac0f01fc02054f
+      src: rubygem-mongo-2.5.1-2.module+el8.1.0+3656+f80bfa1d.src.rpm
+      version: 2.5.5
+    - _class: ErratumPackage
+      arch: x86_64
+      epoch: '0'
+      filename: ruby-debuginfo-2.5.5-105.module+el8.1.0+3656+f80bfa1d.x86_64.rpm
+      md5sum: 611cc3d7943d1b11755c9ed19b4df6d0
+      name: ruby-debuginfo
+      reboot_suggested: false
+      release: 105.module+el8.1.0+3656+f80bfa1d
+      sha256sum: 93f8f14e52d7ffb788f49bbbf78c7d7e71d7d429164a3361cb7f67679c6c2b1b
+      src: rubygem-mongo-2.5.1-2.module+el8.1.0+3656+f80bfa1d.src.rpm
+      version: 2.5.5
+    - _class: ErratumPackage
+      arch: i686
+      epoch: '0'
+      filename: ruby-debugsource-2.5.5-105.module+el8.1.0+3656+f80bfa1d.i686.rpm
+      md5sum: 43fa0635c6d3bd0f1d3e6373f4df7f9a
+      name: ruby-debugsource
+      reboot_suggested: false
+      release: 105.module+el8.1.0+3656+f80bfa1d
+      sha256sum: f0bbbc2a1722cf0563e8bf33b1c98386e3252af41d761976a131ea145793d297
+      src: rubygem-mongo-2.5.1-2.module+el8.1.0+3656+f80bfa1d.src.rpm
+      version: 2.5.5
+    - _class: ErratumPackage
+      arch: x86_64
+      epoch: '0'
+      filename: ruby-debugsource-2.5.5-105.module+el8.1.0+3656+f80bfa1d.x86_64.rpm
+      md5sum: 3a1982b8b41a64ee71cb9b02fbb83cd4
+      name: ruby-debugsource
+      reboot_suggested: false
+      release: 105.module+el8.1.0+3656+f80bfa1d
+      sha256sum: ef0034ff4df7f5055212beec0fe9b5fd7bec36ce1a6ffc51950431797f8dd645
+      src: rubygem-mongo-2.5.1-2.module+el8.1.0+3656+f80bfa1d.src.rpm
+      version: 2.5.5
+    - _class: ErratumPackage
+      arch: i686
+      epoch: '0'
+      filename: ruby-devel-2.5.5-105.module+el8.1.0+3656+f80bfa1d.i686.rpm
+      md5sum: 82097d4550e67c853adf15722b082025
+      name: ruby-devel
+      reboot_suggested: false
+      release: 105.module+el8.1.0+3656+f80bfa1d
+      sha256sum: af024076ea2c878f89f6d77c7bf3abe5e23a8c9410b401533fe1897cad8af355
+      src: rubygem-mongo-2.5.1-2.module+el8.1.0+3656+f80bfa1d.src.rpm
+      version: 2.5.5
+    - _class: ErratumPackage
+      arch: x86_64
+      epoch: '0'
+      filename: ruby-devel-2.5.5-105.module+el8.1.0+3656+f80bfa1d.x86_64.rpm
+      md5sum: 26ed8b41246e0a50ade8b3ea948b7e9b
+      name: ruby-devel
+      reboot_suggested: false
+      release: 105.module+el8.1.0+3656+f80bfa1d
+      sha256sum: 899e3d8b4b3f4b75e77ae9302c999da3b4d37c97ad7fcce8d0f95b077ccffa77
+      src: rubygem-mongo-2.5.1-2.module+el8.1.0+3656+f80bfa1d.src.rpm
+      version: 2.5.5
+    - _class: ErratumPackage
+      arch: noarch
+      epoch: '0'
+      filename: ruby-doc-2.5.5-105.module+el8.1.0+3656+f80bfa1d.noarch.rpm
+      md5sum: 4542696784ee298fdbe88e6159a46a80
+      name: ruby-doc
+      reboot_suggested: false
+      release: 105.module+el8.1.0+3656+f80bfa1d
+      sha256sum: c543f6373a753dde041cc6a6e649e16ec7d4b4260b5b06f6aa62cb3ff5d9c720
+      src: rubygem-mongo-2.5.1-2.module+el8.1.0+3656+f80bfa1d.src.rpm
+      version: 2.5.5
+    - _class: ErratumPackage
+      arch: noarch
+      epoch: '0'
+      filename: ruby-irb-2.5.5-105.module+el8.1.0+3656+f80bfa1d.noarch.rpm
+      md5sum: 5611cb614525baf20774849e9019c25e
+      name: ruby-irb
+      reboot_suggested: false
+      release: 105.module+el8.1.0+3656+f80bfa1d
+      sha256sum: 9d6c163678783908a6a6488cc9277a54aba730d93489b0c55294d8ec48606507
+      src: rubygem-mongo-2.5.1-2.module+el8.1.0+3656+f80bfa1d.src.rpm
+      version: 2.5.5
+    - _class: ErratumPackage
+      arch: i686
+      epoch: '0'
+      filename: ruby-libs-2.5.5-105.module+el8.1.0+3656+f80bfa1d.i686.rpm
+      md5sum: 39f9a7c6ae7e9ea03982a9ed6b8eaf2f
+      name: ruby-libs
+      reboot_suggested: false
+      release: 105.module+el8.1.0+3656+f80bfa1d
+      sha256sum: eea665a635ae9d41a814b0cca431ff7167da7d5223021400e7c5ae4923e2337d
+      src: rubygem-mongo-2.5.1-2.module+el8.1.0+3656+f80bfa1d.src.rpm
+      version: 2.5.5
+    - _class: ErratumPackage
+      arch: x86_64
+      epoch: '0'
+      filename: ruby-libs-2.5.5-105.module+el8.1.0+3656+f80bfa1d.x86_64.rpm
+      md5sum: ebd4240d00b2c57481862570d641e89d
+      name: ruby-libs
+      reboot_suggested: false
+      release: 105.module+el8.1.0+3656+f80bfa1d
+      sha256sum: d12e3dd0fd2a02794538ce4c2c602bd989c52d3d10b7b1cd1adeaa8a1e602ba6
+      src: rubygem-mongo-2.5.1-2.module+el8.1.0+3656+f80bfa1d.src.rpm
+      version: 2.5.5
+    - _class: ErratumPackage
+      arch: i686
+      epoch: '0'
+      filename: ruby-libs-debuginfo-2.5.5-105.module+el8.1.0+3656+f80bfa1d.i686.rpm
+      md5sum: 9ad9009513f75a30b9d98777c2b36341
+      name: ruby-libs-debuginfo
+      reboot_suggested: false
+      release: 105.module+el8.1.0+3656+f80bfa1d
+      sha256sum: 04fbb31e929b6e9fe1b55a6ad3f61617a53d7f8b926d92f513835ebbfe8eed0a
+      src: rubygem-mongo-2.5.1-2.module+el8.1.0+3656+f80bfa1d.src.rpm
+      version: 2.5.5
+    - _class: ErratumPackage
+      arch: x86_64
+      epoch: '0'
+      filename: ruby-libs-debuginfo-2.5.5-105.module+el8.1.0+3656+f80bfa1d.x86_64.rpm
+      md5sum: 1d1a4138cfd8d6e9d3fbd9e772c88622
+      name: ruby-libs-debuginfo
+      reboot_suggested: false
+      release: 105.module+el8.1.0+3656+f80bfa1d
+      sha256sum: e0ff098501b1f19d228b7ec071a50a5ecfb393fb8df88f9c1d780c3714e7e320
+      src: rubygem-mongo-2.5.1-2.module+el8.1.0+3656+f80bfa1d.src.rpm
+      version: 2.5.5
+    - _class: ErratumPackage
+      arch: noarch
+      epoch: '0'
+      filename: rubygem-abrt-0.3.0-4.module+el8.1.0+3656+f80bfa1d.noarch.rpm
+      md5sum: 02ddde5ae4c9f4d7563cfd21f13d2a88
+      name: rubygem-abrt
+      reboot_suggested: false
+      release: 4.module+el8.1.0+3656+f80bfa1d
+      sha256sum: 2579312600c5f242ff8edbf3b44b3d444962429ad40c17a28ce16500c798d860
+      src: rubygem-mongo-2.5.1-2.module+el8.1.0+3656+f80bfa1d.src.rpm
+      version: 0.3.0
+    - _class: ErratumPackage
+      arch: SRPMS
+      epoch: '0'
+      filename: rubygem-abrt-0.3.0-4.module+el8.1.0+3656+f80bfa1d.src.rpm
+      md5sum: 42a0e559c2bfc475d454cd406ab50331
+      name: rubygem-abrt
+      reboot_suggested: false
+      release: 4.module+el8.1.0+3656+f80bfa1d
+      sha256sum: d92c862b65872af7f701367225dc4c9ea799161e19594a7fbc6fa0e19bd2e667
+      src: rubygem-mongo-2.5.1-2.module+el8.1.0+3656+f80bfa1d.src.rpm
+      version: 0.3.0
+    - _class: ErratumPackage
+      arch: noarch
+      epoch: '0'
+      filename: rubygem-abrt-doc-0.3.0-4.module+el8.1.0+3656+f80bfa1d.noarch.rpm
+      md5sum: 7d714a33d672aaf9b8d975f446bdc5bd
+      name: rubygem-abrt-doc
+      reboot_suggested: false
+      release: 4.module+el8.1.0+3656+f80bfa1d
+      sha256sum: 4526c3514005042da89bd0884d0404b154ffba64b54112453269e4369b741d4c
+      src: rubygem-mongo-2.5.1-2.module+el8.1.0+3656+f80bfa1d.src.rpm
+      version: 0.3.0
+    - _class: ErratumPackage
+      arch: i686
+      epoch: '0'
+      filename: rubygem-bigdecimal-1.3.4-105.module+el8.1.0+3656+f80bfa1d.i686.rpm
+      md5sum: 90199a0c925bbd2a4f17b75dfb9579a6
+      name: rubygem-bigdecimal
+      reboot_suggested: false
+      release: 105.module+el8.1.0+3656+f80bfa1d
+      sha256sum: 0296fd2138dca7d44a46a6a34bc8bff528cacd3d331527efacd837654beb560e
+      src: rubygem-mongo-2.5.1-2.module+el8.1.0+3656+f80bfa1d.src.rpm
+      version: 1.3.4
+    - _class: ErratumPackage
+      arch: x86_64
+      epoch: '0'
+      filename: rubygem-bigdecimal-1.3.4-105.module+el8.1.0+3656+f80bfa1d.x86_64.rpm
+      md5sum: dab893b351883a5c06553b96c5e8cbcd
+      name: rubygem-bigdecimal
+      reboot_suggested: false
+      release: 105.module+el8.1.0+3656+f80bfa1d
+      sha256sum: 26cadb76e788f8623565ffadcf9ee7fcb18b73aabdf6d15bc935c88a980ceeb3
+      src: rubygem-mongo-2.5.1-2.module+el8.1.0+3656+f80bfa1d.src.rpm
+      version: 1.3.4
+    - _class: ErratumPackage
+      arch: i686
+      epoch: '0'
+      filename: rubygem-bigdecimal-debuginfo-1.3.4-105.module+el8.1.0+3656+f80bfa1d.i686.rpm
+      md5sum: 5fc5966d3d10eb8c0261df39a3d8912d
+      name: rubygem-bigdecimal-debuginfo
+      reboot_suggested: false
+      release: 105.module+el8.1.0+3656+f80bfa1d
+      sha256sum: 495eb666be85a5a9b6e9aeeacb2b88c4a54da89836e83044a9046a5232298388
+      src: rubygem-mongo-2.5.1-2.module+el8.1.0+3656+f80bfa1d.src.rpm
+      version: 1.3.4
+    - _class: ErratumPackage
+      arch: x86_64
+      epoch: '0'
+      filename: rubygem-bigdecimal-debuginfo-1.3.4-105.module+el8.1.0+3656+f80bfa1d.x86_64.rpm
+      md5sum: e92bfa7c39869c908c64a9b9bd410b6d
+      name: rubygem-bigdecimal-debuginfo
+      reboot_suggested: false
+      release: 105.module+el8.1.0+3656+f80bfa1d
+      sha256sum: 3242937b814a5805b524f6817730130e7ee724bde595a7b494ea36f4c4f09bc5
+      src: rubygem-mongo-2.5.1-2.module+el8.1.0+3656+f80bfa1d.src.rpm
+      version: 1.3.4
+    - _class: ErratumPackage
+      arch: SRPMS
+      epoch: '0'
+      filename: rubygem-bson-4.3.0-2.module+el8.1.0+3656+f80bfa1d.src.rpm
+      md5sum: aa443b78952f171bd930d7f2866a8bd0
+      name: rubygem-bson
+      reboot_suggested: false
+      release: 2.module+el8.1.0+3656+f80bfa1d
+      sha256sum: 8abe79db0675e5019fbdffd7aef41e9f09810aa30671c445b75dcce54028661a
+      src: rubygem-mongo-2.5.1-2.module+el8.1.0+3656+f80bfa1d.src.rpm
+      version: 4.3.0
+    - _class: ErratumPackage
+      arch: x86_64
+      epoch: '0'
+      filename: rubygem-bson-4.3.0-2.module+el8.1.0+3656+f80bfa1d.x86_64.rpm
+      md5sum: af1875082d95142e8d49315e6e365641
+      name: rubygem-bson
+      reboot_suggested: false
+      release: 2.module+el8.1.0+3656+f80bfa1d
+      sha256sum: 4f76f2ea9dc8fffd76a17f020d4bb59ce78adf103f54e6b915f42ae2ff7cb9e4
+      src: rubygem-mongo-2.5.1-2.module+el8.1.0+3656+f80bfa1d.src.rpm
+      version: 4.3.0
+    - _class: ErratumPackage
+      arch: x86_64
+      epoch: '0'
+      filename: rubygem-bson-debuginfo-4.3.0-2.module+el8.1.0+3656+f80bfa1d.x86_64.rpm
+      md5sum: 5ed8dc66d8bf597f510a2b37bb5c251b
+      name: rubygem-bson-debuginfo
+      reboot_suggested: false
+      release: 2.module+el8.1.0+3656+f80bfa1d
+      sha256sum: d0f9f0a8ba5d97919ab1db49ea0414cb20a11abbcf11e6bd006d7b447230248a
+      src: rubygem-mongo-2.5.1-2.module+el8.1.0+3656+f80bfa1d.src.rpm
+      version: 4.3.0
+    - _class: ErratumPackage
+      arch: x86_64
+      epoch: '0'
+      filename: rubygem-bson-debugsource-4.3.0-2.module+el8.1.0+3656+f80bfa1d.x86_64.rpm
+      md5sum: 67d58c76e617700ab76c7b029846d816
+      name: rubygem-bson-debugsource
+      reboot_suggested: false
+      release: 2.module+el8.1.0+3656+f80bfa1d
+      sha256sum: d217b074bb416f3896a467c860e3c1bba0308eb5a31b2fb10d07e1161e18a928
+      src: rubygem-mongo-2.5.1-2.module+el8.1.0+3656+f80bfa1d.src.rpm
+      version: 4.3.0
+    - _class: ErratumPackage
+      arch: noarch
+      epoch: '0'
+      filename: rubygem-bson-doc-4.3.0-2.module+el8.1.0+3656+f80bfa1d.noarch.rpm
+      md5sum: d5e07d87425397c127e32cda38937ec9
+      name: rubygem-bson-doc
+      reboot_suggested: false
+      release: 2.module+el8.1.0+3656+f80bfa1d
+      sha256sum: 9e2077a81214adffe1f0df18008e65f1ff10c65d61a11ef221b4ee2c94d4d842
+      src: rubygem-mongo-2.5.1-2.module+el8.1.0+3656+f80bfa1d.src.rpm
+      version: 4.3.0
+    - _class: ErratumPackage
+      arch: noarch
+      epoch: '0'
+      filename: rubygem-bundler-1.16.1-3.module+el8.1.0+3656+f80bfa1d.noarch.rpm
+      md5sum: adef4b585f2875cea6515a94bf8be2ba
+      name: rubygem-bundler
+      reboot_suggested: false
+      release: 3.module+el8.1.0+3656+f80bfa1d
+      sha256sum: fe344ebaa7887d3dc3695b8a5322f8507715d381ea265a7cf737960023471b06
+      src: rubygem-mongo-2.5.1-2.module+el8.1.0+3656+f80bfa1d.src.rpm
+      version: 1.16.1
+    - _class: ErratumPackage
+      arch: SRPMS
+      epoch: '0'
+      filename: rubygem-bundler-1.16.1-3.module+el8.1.0+3656+f80bfa1d.src.rpm
+      md5sum: 255642638b99991609b390a955768b2a
+      name: rubygem-bundler
+      reboot_suggested: false
+      release: 3.module+el8.1.0+3656+f80bfa1d
+      sha256sum: 32d5ee895ade306fd17a05184b728246cf423c093eeb27d9201f35b3e3c051b4
+      src: rubygem-mongo-2.5.1-2.module+el8.1.0+3656+f80bfa1d.src.rpm
+      version: 1.16.1
+    - _class: ErratumPackage
+      arch: noarch
+      epoch: '0'
+      filename: rubygem-bundler-doc-1.16.1-3.module+el8.1.0+3656+f80bfa1d.noarch.rpm
+      md5sum: b089a978e86c3dbfcc97ca1ba56e4d5e
+      name: rubygem-bundler-doc
+      reboot_suggested: false
+      release: 3.module+el8.1.0+3656+f80bfa1d
+      sha256sum: d507c993e4b5b576ac7a696b129a5236c08f23dc45ea5a6e37b105744831be08
+      src: rubygem-mongo-2.5.1-2.module+el8.1.0+3656+f80bfa1d.src.rpm
+      version: 1.16.1
+    - _class: ErratumPackage
+      arch: noarch
+      epoch: '0'
+      filename: rubygem-did_you_mean-1.2.0-105.module+el8.1.0+3656+f80bfa1d.noarch.rpm
+      md5sum: 11562927ab8bd761f5777fb251954631
+      name: rubygem-did_you_mean
+      reboot_suggested: false
+      release: 105.module+el8.1.0+3656+f80bfa1d
+      sha256sum: bb5bd5973be8aa064e1f7d692ec80b89b5668f7723ddcd08f29bd6e7896a63e3
+      src: rubygem-mongo-2.5.1-2.module+el8.1.0+3656+f80bfa1d.src.rpm
+      version: 1.2.0
+    - _class: ErratumPackage
+      arch: i686
+      epoch: '0'
+      filename: rubygem-io-console-0.4.6-105.module+el8.1.0+3656+f80bfa1d.i686.rpm
+      md5sum: 7ca9a667aef9a7c28eb6fbdd2fc7825f
+      name: rubygem-io-console
+      reboot_suggested: false
+      release: 105.module+el8.1.0+3656+f80bfa1d
+      sha256sum: fe476371802dfd6098702711f39c2bd8a90864c993b9ee8f5fd288fd928b450b
+      src: rubygem-mongo-2.5.1-2.module+el8.1.0+3656+f80bfa1d.src.rpm
+      version: 0.4.6
+    - _class: ErratumPackage
+      arch: x86_64
+      epoch: '0'
+      filename: rubygem-io-console-0.4.6-105.module+el8.1.0+3656+f80bfa1d.x86_64.rpm
+      md5sum: 817f98fdd41c65aab5d57f6b820b5ac0
+      name: rubygem-io-console
+      reboot_suggested: false
+      release: 105.module+el8.1.0+3656+f80bfa1d
+      sha256sum: 3fe779e446d0b4b573fe1d6e973c495e6cd084b26cdae62789ed9e70780763a1
+      src: rubygem-mongo-2.5.1-2.module+el8.1.0+3656+f80bfa1d.src.rpm
+      version: 0.4.6
+    - _class: ErratumPackage
+      arch: i686
+      epoch: '0'
+      filename: rubygem-io-console-debuginfo-0.4.6-105.module+el8.1.0+3656+f80bfa1d.i686.rpm
+      md5sum: 25ff2e568116386f067c9307b0cfc6a0
+      name: rubygem-io-console-debuginfo
+      reboot_suggested: false
+      release: 105.module+el8.1.0+3656+f80bfa1d
+      sha256sum: b4d7a313aac08fd856bf178908f2476b4c9f050036f8848bb6ff3f619f155f2c
+      src: rubygem-mongo-2.5.1-2.module+el8.1.0+3656+f80bfa1d.src.rpm
+      version: 0.4.6
+    - _class: ErratumPackage
+      arch: x86_64
+      epoch: '0'
+      filename: rubygem-io-console-debuginfo-0.4.6-105.module+el8.1.0+3656+f80bfa1d.x86_64.rpm
+      md5sum: 1a73d3afd89687e69093f5abab29f568
+      name: rubygem-io-console-debuginfo
+      reboot_suggested: false
+      release: 105.module+el8.1.0+3656+f80bfa1d
+      sha256sum: 4676dbcacee5973adef9fea91ba557518e7a26123eadbc56a8811205b5fa44b9
+      src: rubygem-mongo-2.5.1-2.module+el8.1.0+3656+f80bfa1d.src.rpm
+      version: 0.4.6
+    - _class: ErratumPackage
+      arch: i686
+      epoch: '0'
+      filename: rubygem-json-2.1.0-105.module+el8.1.0+3656+f80bfa1d.i686.rpm
+      md5sum: 401274eeeffbe6df5b724b0a63bf8a74
+      name: rubygem-json
+      reboot_suggested: false
+      release: 105.module+el8.1.0+3656+f80bfa1d
+      sha256sum: 05b55ea132bec6490519e21ac0850934b430dee7d534678195d82c2e88062a42
+      src: rubygem-mongo-2.5.1-2.module+el8.1.0+3656+f80bfa1d.src.rpm
+      version: 2.1.0
+    - _class: ErratumPackage
+      arch: x86_64
+      epoch: '0'
+      filename: rubygem-json-2.1.0-105.module+el8.1.0+3656+f80bfa1d.x86_64.rpm
+      md5sum: 94ede442c53e74597806bf4efdb78482
+      name: rubygem-json
+      reboot_suggested: false
+      release: 105.module+el8.1.0+3656+f80bfa1d
+      sha256sum: a3863d120dcfffc46deebcdc8e2926caa7ef6a42933ac72c9d7f8953a279ff7f
+      src: rubygem-mongo-2.5.1-2.module+el8.1.0+3656+f80bfa1d.src.rpm
+      version: 2.1.0
+    - _class: ErratumPackage
+      arch: i686
+      epoch: '0'
+      filename: rubygem-json-debuginfo-2.1.0-105.module+el8.1.0+3656+f80bfa1d.i686.rpm
+      md5sum: d4f778382b40bab1dedb3295146ba1af
+      name: rubygem-json-debuginfo
+      reboot_suggested: false
+      release: 105.module+el8.1.0+3656+f80bfa1d
+      sha256sum: d77c4dca9713d21119a8368a04e7bc513bbb84eda48653f6f7e831cb6e6d9546
+      src: rubygem-mongo-2.5.1-2.module+el8.1.0+3656+f80bfa1d.src.rpm
+      version: 2.1.0
+    - _class: ErratumPackage
+      arch: x86_64
+      epoch: '0'
+      filename: rubygem-json-debuginfo-2.1.0-105.module+el8.1.0+3656+f80bfa1d.x86_64.rpm
+      md5sum: 4ffb35bed61b3f6c64f9477304659f53
+      name: rubygem-json-debuginfo
+      reboot_suggested: false
+      release: 105.module+el8.1.0+3656+f80bfa1d
+      sha256sum: 82ba87ebc5ef0c18b4de252e606ecb890658c276b839284077129a70c3d02346
+      src: rubygem-mongo-2.5.1-2.module+el8.1.0+3656+f80bfa1d.src.rpm
+      version: 2.1.0
+    - _class: ErratumPackage
+      arch: noarch
+      epoch: '0'
+      filename: rubygem-minitest-5.10.3-105.module+el8.1.0+3656+f80bfa1d.noarch.rpm
+      md5sum: 93df8b3a09f80f449f5c0bd7792de82c
+      name: rubygem-minitest
+      reboot_suggested: false
+      release: 105.module+el8.1.0+3656+f80bfa1d
+      sha256sum: fdb2f2c36da88d7e4b493f248f092e561059a5a53764d3534961006e42b6b063
+      src: rubygem-mongo-2.5.1-2.module+el8.1.0+3656+f80bfa1d.src.rpm
+      version: 5.10.3
+    - _class: ErratumPackage
+      arch: noarch
+      epoch: '0'
+      filename: rubygem-mongo-2.5.1-2.module+el8.1.0+3656+f80bfa1d.noarch.rpm
+      md5sum: 849ed5b828db0f37a1c2edff58eeb363
+      name: rubygem-mongo
+      reboot_suggested: false
+      release: 2.module+el8.1.0+3656+f80bfa1d
+      sha256sum: 9b5c365e81f801d82f196b89b60184d6135ecd163611738cc07a8f75f1a9b466
+      src: rubygem-mongo-2.5.1-2.module+el8.1.0+3656+f80bfa1d.src.rpm
+      version: 2.5.1
+    - _class: ErratumPackage
+      arch: SRPMS
+      epoch: '0'
+      filename: rubygem-mongo-2.5.1-2.module+el8.1.0+3656+f80bfa1d.src.rpm
+      md5sum: 1561038e7132203944c9ca13d0617d65
+      name: rubygem-mongo
+      reboot_suggested: false
+      release: 2.module+el8.1.0+3656+f80bfa1d
+      sha256sum: 5b8d89427998167d5c2f9e7a546f7c5dde349f97463935bf40e06130e5383b63
+      src: rubygem-mongo-2.5.1-2.module+el8.1.0+3656+f80bfa1d.src.rpm
+      version: 2.5.1
+    - _class: ErratumPackage
+      arch: noarch
+      epoch: '0'
+      filename: rubygem-mongo-doc-2.5.1-2.module+el8.1.0+3656+f80bfa1d.noarch.rpm
+      md5sum: fa4a10ebdb5b964a2d10019b148981e9
+      name: rubygem-mongo-doc
+      reboot_suggested: false
+      release: 2.module+el8.1.0+3656+f80bfa1d
+      sha256sum: cba0a8b1b342a3a11801c21a9c403b4c028a290cf45c1589b16a191c7e8ba90f
+      src: rubygem-mongo-2.5.1-2.module+el8.1.0+3656+f80bfa1d.src.rpm
+      version: 2.5.1
+    - _class: ErratumPackage
+      arch: SRPMS
+      epoch: '0'
+      filename: rubygem-mysql2-0.4.10-4.module+el8.1.0+3656+f80bfa1d.src.rpm
+      md5sum: 9e1cd68b55f6e11efe9967dda1f958ae
+      name: rubygem-mysql2
+      reboot_suggested: false
+      release: 4.module+el8.1.0+3656+f80bfa1d
+      sha256sum: 7bd7206950c3bdbd8c81073410e7912f0dc35fc319fb2ee084786e446056587a
+      src: rubygem-mongo-2.5.1-2.module+el8.1.0+3656+f80bfa1d.src.rpm
+      version: 0.4.10
+    - _class: ErratumPackage
+      arch: x86_64
+      epoch: '0'
+      filename: rubygem-mysql2-0.4.10-4.module+el8.1.0+3656+f80bfa1d.x86_64.rpm
+      md5sum: da899b92a6a31fb9c1e3d9a91594b24c
+      name: rubygem-mysql2
+      reboot_suggested: false
+      release: 4.module+el8.1.0+3656+f80bfa1d
+      sha256sum: a43c894e595f14bdabe42cbc68bdfe3e6a3c63dba941d5b0fcd65f143454d36f
+      src: rubygem-mongo-2.5.1-2.module+el8.1.0+3656+f80bfa1d.src.rpm
+      version: 0.4.10
+    - _class: ErratumPackage
+      arch: x86_64
+      epoch: '0'
+      filename: rubygem-mysql2-debuginfo-0.4.10-4.module+el8.1.0+3656+f80bfa1d.x86_64.rpm
+      md5sum: 46578c87838234d89b0dce425e1bb4ef
+      name: rubygem-mysql2-debuginfo
+      reboot_suggested: false
+      release: 4.module+el8.1.0+3656+f80bfa1d
+      sha256sum: e5cf33cab75e90626c7fd72e7e61aa0394111bc2938e2c00b5c30dc44405e80b
+      src: rubygem-mongo-2.5.1-2.module+el8.1.0+3656+f80bfa1d.src.rpm
+      version: 0.4.10
+    - _class: ErratumPackage
+      arch: x86_64
+      epoch: '0'
+      filename: rubygem-mysql2-debugsource-0.4.10-4.module+el8.1.0+3656+f80bfa1d.x86_64.rpm
+      md5sum: 353b7f8951e98569bee69068d0f0539b
+      name: rubygem-mysql2-debugsource
+      reboot_suggested: false
+      release: 4.module+el8.1.0+3656+f80bfa1d
+      sha256sum: aef4d0858f00f3a9c9fc606d8d1c4ebfc5fd20668f0614f86cb17a6defa54bc7
+      src: rubygem-mongo-2.5.1-2.module+el8.1.0+3656+f80bfa1d.src.rpm
+      version: 0.4.10
+    - _class: ErratumPackage
+      arch: noarch
+      epoch: '0'
+      filename: rubygem-mysql2-doc-0.4.10-4.module+el8.1.0+3656+f80bfa1d.noarch.rpm
+      md5sum: b58e5ec1fb18490197d60834e5709e80
+      name: rubygem-mysql2-doc
+      reboot_suggested: false
+      release: 4.module+el8.1.0+3656+f80bfa1d
+      sha256sum: 1d25f8d911a95b4abc5649e738ef1bd649ecf60f1d7fca5f444ec154765620d3
+      src: rubygem-mongo-2.5.1-2.module+el8.1.0+3656+f80bfa1d.src.rpm
+      version: 0.4.10
+    - _class: ErratumPackage
+      arch: noarch
+      epoch: '0'
+      filename: rubygem-net-telnet-0.1.1-105.module+el8.1.0+3656+f80bfa1d.noarch.rpm
+      md5sum: b2375afcc76507d6feccf12ff75fc49a
+      name: rubygem-net-telnet
+      reboot_suggested: false
+      release: 105.module+el8.1.0+3656+f80bfa1d
+      sha256sum: e28f21a6f4f141d65cc8bff6e40f179cec29d77ba0e7b7c01943dc23b68d1751
+      src: rubygem-mongo-2.5.1-2.module+el8.1.0+3656+f80bfa1d.src.rpm
+      version: 0.1.1
+    - _class: ErratumPackage
+      arch: i686
+      epoch: '0'
+      filename: rubygem-openssl-2.1.2-105.module+el8.1.0+3656+f80bfa1d.i686.rpm
+      md5sum: 2d6230ce976309ffe28fe3de7cd37be5
+      name: rubygem-openssl
+      reboot_suggested: false
+      release: 105.module+el8.1.0+3656+f80bfa1d
+      sha256sum: d1ce7a54b04c16e0919c13e3514f1d6d612202770f9a870cd58d1ed5ae9d40fe
+      src: rubygem-mongo-2.5.1-2.module+el8.1.0+3656+f80bfa1d.src.rpm
+      version: 2.1.2
+    - _class: ErratumPackage
+      arch: x86_64
+      epoch: '0'
+      filename: rubygem-openssl-2.1.2-105.module+el8.1.0+3656+f80bfa1d.x86_64.rpm
+      md5sum: c268eb6b8043fed9c26a62943ed851e1
+      name: rubygem-openssl
+      reboot_suggested: false
+      release: 105.module+el8.1.0+3656+f80bfa1d
+      sha256sum: 4b725842d8bc92de9670a88313dfde2e74b79adf38ce68f863322aca71875135
+      src: rubygem-mongo-2.5.1-2.module+el8.1.0+3656+f80bfa1d.src.rpm
+      version: 2.1.2
+    - _class: ErratumPackage
+      arch: i686
+      epoch: '0'
+      filename: rubygem-openssl-debuginfo-2.1.2-105.module+el8.1.0+3656+f80bfa1d.i686.rpm
+      md5sum: 72e269cb6dc32298b2a10f5d5cbbb1ce
+      name: rubygem-openssl-debuginfo
+      reboot_suggested: false
+      release: 105.module+el8.1.0+3656+f80bfa1d
+      sha256sum: 1055328187cc6a8c0be2ed64a9013dc8ee206ed1291583164eeb4286ab10ff2e
+      src: rubygem-mongo-2.5.1-2.module+el8.1.0+3656+f80bfa1d.src.rpm
+      version: 2.1.2
+    - _class: ErratumPackage
+      arch: x86_64
+      epoch: '0'
+      filename: rubygem-openssl-debuginfo-2.1.2-105.module+el8.1.0+3656+f80bfa1d.x86_64.rpm
+      md5sum: 9dfdf5c8a965af84d52477689d7e6b3f
+      name: rubygem-openssl-debuginfo
+      reboot_suggested: false
+      release: 105.module+el8.1.0+3656+f80bfa1d
+      sha256sum: 6f933d143008375cccdeb997a5ec0dddb011d7407719a8503d7c9098a9ef7328
+      src: rubygem-mongo-2.5.1-2.module+el8.1.0+3656+f80bfa1d.src.rpm
+      version: 2.1.2
+    - _class: ErratumPackage
+      arch: SRPMS
+      epoch: '0'
+      filename: rubygem-pg-1.0.0-2.module+el8.1.0+3656+f80bfa1d.src.rpm
+      md5sum: a9bdc2dd5d271638750c1293a875ad77
+      name: rubygem-pg
+      reboot_suggested: false
+      release: 2.module+el8.1.0+3656+f80bfa1d
+      sha256sum: 5e71aa5e93b054478e1f399862d6c8030cd459fe8ff8f5369d5660779efded04
+      src: rubygem-mongo-2.5.1-2.module+el8.1.0+3656+f80bfa1d.src.rpm
+      version: 1.0.0
+    - _class: ErratumPackage
+      arch: x86_64
+      epoch: '0'
+      filename: rubygem-pg-1.0.0-2.module+el8.1.0+3656+f80bfa1d.x86_64.rpm
+      md5sum: b110a58564378a7f743e2a840ff810df
+      name: rubygem-pg
+      reboot_suggested: false
+      release: 2.module+el8.1.0+3656+f80bfa1d
+      sha256sum: 9020df03432cbbb21021b493d7d73aae008b67254bfc46757a4188c4aa089b53
+      src: rubygem-mongo-2.5.1-2.module+el8.1.0+3656+f80bfa1d.src.rpm
+      version: 1.0.0
+    - _class: ErratumPackage
+      arch: x86_64
+      epoch: '0'
+      filename: rubygem-pg-debuginfo-1.0.0-2.module+el8.1.0+3656+f80bfa1d.x86_64.rpm
+      md5sum: d18ec9dbe35400c54f198de76d8d1b47
+      name: rubygem-pg-debuginfo
+      reboot_suggested: false
+      release: 2.module+el8.1.0+3656+f80bfa1d
+      sha256sum: eff0c0ca7f5035bf070ecc7e08e03cfdba3febc340f5e75c0f790eb8dc98fb58
+      src: rubygem-mongo-2.5.1-2.module+el8.1.0+3656+f80bfa1d.src.rpm
+      version: 1.0.0
+    - _class: ErratumPackage
+      arch: x86_64
+      epoch: '0'
+      filename: rubygem-pg-debugsource-1.0.0-2.module+el8.1.0+3656+f80bfa1d.x86_64.rpm
+      md5sum: 4e5b1910e4e332a4f716cec457e95ece
+      name: rubygem-pg-debugsource
+      reboot_suggested: false
+      release: 2.module+el8.1.0+3656+f80bfa1d
+      sha256sum: 68bbc19cffeb612e1fe7a38b07037748364dbed3a2507d8734e8daf9556f7924
+      src: rubygem-mongo-2.5.1-2.module+el8.1.0+3656+f80bfa1d.src.rpm
+      version: 1.0.0
+    - _class: ErratumPackage
+      arch: noarch
+      epoch: '0'
+      filename: rubygem-pg-doc-1.0.0-2.module+el8.1.0+3656+f80bfa1d.noarch.rpm
+      md5sum: 6a578f72ba96eca4938404a8449b5f16
+      name: rubygem-pg-doc
+      reboot_suggested: false
+      release: 2.module+el8.1.0+3656+f80bfa1d
+      sha256sum: 9a74af094119652d9ff29127d9aadd9b67a46feb0a0c3102687d43b638a53dce
+      src: rubygem-mongo-2.5.1-2.module+el8.1.0+3656+f80bfa1d.src.rpm
+      version: 1.0.0
+    - _class: ErratumPackage
+      arch: noarch
+      epoch: '0'
+      filename: rubygem-power_assert-1.1.1-105.module+el8.1.0+3656+f80bfa1d.noarch.rpm
+      md5sum: e87bc67208ce3eb03d3abc054017598b
+      name: rubygem-power_assert
+      reboot_suggested: false
+      release: 105.module+el8.1.0+3656+f80bfa1d
+      sha256sum: e907b442294a0f7e84cc8e5ac60839c702bae4ad198c208b2870eb0aa35864d1
+      src: rubygem-mongo-2.5.1-2.module+el8.1.0+3656+f80bfa1d.src.rpm
+      version: 1.1.1
+    - _class: ErratumPackage
+      arch: i686
+      epoch: '0'
+      filename: rubygem-psych-3.0.2-105.module+el8.1.0+3656+f80bfa1d.i686.rpm
+      md5sum: 29c9f5bf54ac9e37d7f20f6157027fc0
+      name: rubygem-psych
+      reboot_suggested: false
+      release: 105.module+el8.1.0+3656+f80bfa1d
+      sha256sum: b3761ea9ead6825f5f15dc19996fd72a641527ddc6d4d3de19df5af88760db78
+      src: rubygem-mongo-2.5.1-2.module+el8.1.0+3656+f80bfa1d.src.rpm
+      version: 3.0.2
+    - _class: ErratumPackage
+      arch: x86_64
+      epoch: '0'
+      filename: rubygem-psych-3.0.2-105.module+el8.1.0+3656+f80bfa1d.x86_64.rpm
+      md5sum: f7fd206526a8c954ca8b8b985159f374
+      name: rubygem-psych
+      reboot_suggested: false
+      release: 105.module+el8.1.0+3656+f80bfa1d
+      sha256sum: 0058549549f342904d3f0d1069f3e2080d4e9e1c5c97072a15f2cd05eb1b71ff
+      src: rubygem-mongo-2.5.1-2.module+el8.1.0+3656+f80bfa1d.src.rpm
+      version: 3.0.2
+    - _class: ErratumPackage
+      arch: i686
+      epoch: '0'
+      filename: rubygem-psych-debuginfo-3.0.2-105.module+el8.1.0+3656+f80bfa1d.i686.rpm
+      md5sum: 81d43f217b3c2cbe091815d3834f4cb2
+      name: rubygem-psych-debuginfo
+      reboot_suggested: false
+      release: 105.module+el8.1.0+3656+f80bfa1d
+      sha256sum: b61f25e9db8b2c100355681cb5269b347d5a59d534f50c0105f82a76701ae389
+      src: rubygem-mongo-2.5.1-2.module+el8.1.0+3656+f80bfa1d.src.rpm
+      version: 3.0.2
+    - _class: ErratumPackage
+      arch: x86_64
+      epoch: '0'
+      filename: rubygem-psych-debuginfo-3.0.2-105.module+el8.1.0+3656+f80bfa1d.x86_64.rpm
+      md5sum: d2fa625199732ee002934cd24f3fa62b
+      name: rubygem-psych-debuginfo
+      reboot_suggested: false
+      release: 105.module+el8.1.0+3656+f80bfa1d
+      sha256sum: b02ea0e2035611368fc1555675de9d8c278211f84b7e6c643aadbd7684b8d442
+      src: rubygem-mongo-2.5.1-2.module+el8.1.0+3656+f80bfa1d.src.rpm
+      version: 3.0.2
+    - _class: ErratumPackage
+      arch: noarch
+      epoch: '0'
+      filename: rubygem-rake-12.3.0-105.module+el8.1.0+3656+f80bfa1d.noarch.rpm
+      md5sum: 0d536baf5e34db662ccfea564913a30d
+      name: rubygem-rake
+      reboot_suggested: false
+      release: 105.module+el8.1.0+3656+f80bfa1d
+      sha256sum: 36c8e13add7dccc90ccefacc2036da3637c0cf38da33c6379e5e759ec00301b5
+      src: rubygem-mongo-2.5.1-2.module+el8.1.0+3656+f80bfa1d.src.rpm
+      version: 12.3.0
+    - _class: ErratumPackage
+      arch: noarch
+      epoch: '0'
+      filename: rubygem-rdoc-6.0.1-105.module+el8.1.0+3656+f80bfa1d.noarch.rpm
+      md5sum: 2943e0d2c8a249abb6a405332cb85c12
+      name: rubygem-rdoc
+      reboot_suggested: false
+      release: 105.module+el8.1.0+3656+f80bfa1d
+      sha256sum: 5ee36835abbab4fc36ce732191ecb751f89020c92c03b4ed387c1171d4955819
+      src: rubygem-mongo-2.5.1-2.module+el8.1.0+3656+f80bfa1d.src.rpm
+      version: 6.0.1
+    - _class: ErratumPackage
+      arch: noarch
+      epoch: '0'
+      filename: rubygem-test-unit-3.2.7-105.module+el8.1.0+3656+f80bfa1d.noarch.rpm
+      md5sum: 1637e066d29aa755d864089dd1f8d1a3
+      name: rubygem-test-unit
+      reboot_suggested: false
+      release: 105.module+el8.1.0+3656+f80bfa1d
+      sha256sum: d4df4bad13e2cdeb9cbf022e4989ab940b0dced5b77d68a5ff694710c78d0da7
+      src: rubygem-mongo-2.5.1-2.module+el8.1.0+3656+f80bfa1d.src.rpm
+      version: 3.2.7
+    - _class: ErratumPackage
+      arch: noarch
+      epoch: '0'
+      filename: rubygem-xmlrpc-0.3.0-105.module+el8.1.0+3656+f80bfa1d.noarch.rpm
+      md5sum: d51d3fb7942200cc6b7e409eff96d734
+      name: rubygem-xmlrpc
+      reboot_suggested: false
+      release: 105.module+el8.1.0+3656+f80bfa1d
+      sha256sum: 0a245b8c8d2d4f07cf67ccedf9fd64707d2e737e729a75ef933e35a2d323993d
+      src: rubygem-mongo-2.5.1-2.module+el8.1.0+3656+f80bfa1d.src.rpm
+      version: 0.3.0
+    - _class: ErratumPackage
+      arch: noarch
+      epoch: '0'
+      filename: rubygems-2.7.6.2-105.module+el8.1.0+3656+f80bfa1d.noarch.rpm
+      md5sum: 9e86bdda0538344a6487fe5ffbeb7098
+      name: rubygems
+      reboot_suggested: false
+      release: 105.module+el8.1.0+3656+f80bfa1d
+      sha256sum: 9ef40ee367fc9edd93823856e0716e6a7ee7caebf48a67030e51269adb0cc952
+      src: rubygem-mongo-2.5.1-2.module+el8.1.0+3656+f80bfa1d.src.rpm
+      version: 2.7.6.2
+    - _class: ErratumPackage
+      arch: noarch
+      epoch: '0'
+      filename: rubygems-devel-2.7.6.2-105.module+el8.1.0+3656+f80bfa1d.noarch.rpm
+      md5sum: c7a349bb3056fd730a6828ab695c0531
+      name: rubygems-devel
+      reboot_suggested: false
+      release: 105.module+el8.1.0+3656+f80bfa1d
+      sha256sum: 0018c8abd50ddf6347d8b50a12d28e345cb1e963a825a177ad295cc86fc8406e
+      src: rubygem-mongo-2.5.1-2.module+el8.1.0+3656+f80bfa1d.src.rpm
+      version: 2.7.6.2
+    short: ''
+  - _class: ErratumPackageCollection
+    module:
+      _class: ErratumModule
+      arch: aarch64
+      context: cdc1202b
+      name: ruby
+      stream: '2.5'
+      version: '8010020190711131821'
+    name: RHBA-2019:3384-ruby-2.5-cdc1202b-aarch64
+    packages:
+    - _class: ErratumPackage
+      arch: aarch64
+      epoch: '0'
+      filename: ruby-2.5.5-105.module+el8.1.0+3656+f80bfa1d.aarch64.rpm
+      md5sum: ce9d9dde8fd10492f7eec559aad0d548
+      name: ruby
+      reboot_suggested: false
+      release: 105.module+el8.1.0+3656+f80bfa1d
+      sha256sum: 4390f4ed4aefa2a356b8122576b4b38df33b16a4eb0b46235dd651dcf25c726d
+      src: rubygem-mongo-2.5.1-2.module+el8.1.0+3656+f80bfa1d.src.rpm
+      version: 2.5.5
+    - _class: ErratumPackage
+      arch: SRPMS
+      epoch: '0'
+      filename: ruby-2.5.5-105.module+el8.1.0+3656+f80bfa1d.src.rpm
+      md5sum: 026b049a21504fc773244164a2d0ff12
+      name: ruby
+      reboot_suggested: false
+      release: 105.module+el8.1.0+3656+f80bfa1d
+      sha256sum: 2edef90b7b9cf7222d932258d8978e4c7c41bf6eeffdfd5032b01d02e6d50e6d
+      src: rubygem-mongo-2.5.1-2.module+el8.1.0+3656+f80bfa1d.src.rpm
+      version: 2.5.5
+    - _class: ErratumPackage
+      arch: aarch64
+      epoch: '0'
+      filename: ruby-debuginfo-2.5.5-105.module+el8.1.0+3656+f80bfa1d.aarch64.rpm
+      md5sum: 42e793e8bcab3e1a0287b85e58acd111
+      name: ruby-debuginfo
+      reboot_suggested: false
+      release: 105.module+el8.1.0+3656+f80bfa1d
+      sha256sum: 857dc3b8427572703a3d53288b2086ddab2e83c3ef017c0f8cd6c5e134cdbe3f
+      src: rubygem-mongo-2.5.1-2.module+el8.1.0+3656+f80bfa1d.src.rpm
+      version: 2.5.5
+    - _class: ErratumPackage
+      arch: aarch64
+      epoch: '0'
+      filename: ruby-debugsource-2.5.5-105.module+el8.1.0+3656+f80bfa1d.aarch64.rpm
+      md5sum: bc79ecc1b9a6a0957291365679ecbea6
+      name: ruby-debugsource
+      reboot_suggested: false
+      release: 105.module+el8.1.0+3656+f80bfa1d
+      sha256sum: e1a14488e1bd8724cb9af46c0a0b46aadeb1d1ffcede9c2606ffd2369010bd58
+      src: rubygem-mongo-2.5.1-2.module+el8.1.0+3656+f80bfa1d.src.rpm
+      version: 2.5.5
+    - _class: ErratumPackage
+      arch: aarch64
+      epoch: '0'
+      filename: ruby-devel-2.5.5-105.module+el8.1.0+3656+f80bfa1d.aarch64.rpm
+      md5sum: 6a9e0ef59f50d66809cb92262468e68e
+      name: ruby-devel
+      reboot_suggested: false
+      release: 105.module+el8.1.0+3656+f80bfa1d
+      sha256sum: f0f177ddabe07c45ef3afd88443d859dd8abc15529deb97e92c6f855c26ffe9d
+      src: rubygem-mongo-2.5.1-2.module+el8.1.0+3656+f80bfa1d.src.rpm
+      version: 2.5.5
+    - _class: ErratumPackage
+      arch: noarch
+      epoch: '0'
+      filename: ruby-doc-2.5.5-105.module+el8.1.0+3656+f80bfa1d.noarch.rpm
+      md5sum: 4542696784ee298fdbe88e6159a46a80
+      name: ruby-doc
+      reboot_suggested: false
+      release: 105.module+el8.1.0+3656+f80bfa1d
+      sha256sum: c543f6373a753dde041cc6a6e649e16ec7d4b4260b5b06f6aa62cb3ff5d9c720
+      src: rubygem-mongo-2.5.1-2.module+el8.1.0+3656+f80bfa1d.src.rpm
+      version: 2.5.5
+    - _class: ErratumPackage
+      arch: noarch
+      epoch: '0'
+      filename: ruby-irb-2.5.5-105.module+el8.1.0+3656+f80bfa1d.noarch.rpm
+      md5sum: 5611cb614525baf20774849e9019c25e
+      name: ruby-irb
+      reboot_suggested: false
+      release: 105.module+el8.1.0+3656+f80bfa1d
+      sha256sum: 9d6c163678783908a6a6488cc9277a54aba730d93489b0c55294d8ec48606507
+      src: rubygem-mongo-2.5.1-2.module+el8.1.0+3656+f80bfa1d.src.rpm
+      version: 2.5.5
+    - _class: ErratumPackage
+      arch: aarch64
+      epoch: '0'
+      filename: ruby-libs-2.5.5-105.module+el8.1.0+3656+f80bfa1d.aarch64.rpm
+      md5sum: 23862db730fb7bc01c4f4cb31ba91887
+      name: ruby-libs
+      reboot_suggested: false
+      release: 105.module+el8.1.0+3656+f80bfa1d
+      sha256sum: 465ed7f15873ccfdb04876f1d618872957a3709692b89daeb4a692ea5027bc11
+      src: rubygem-mongo-2.5.1-2.module+el8.1.0+3656+f80bfa1d.src.rpm
+      version: 2.5.5
+    - _class: ErratumPackage
+      arch: aarch64
+      epoch: '0'
+      filename: ruby-libs-debuginfo-2.5.5-105.module+el8.1.0+3656+f80bfa1d.aarch64.rpm
+      md5sum: 8ec8a13d84c18739c5c21679f8dca340
+      name: ruby-libs-debuginfo
+      reboot_suggested: false
+      release: 105.module+el8.1.0+3656+f80bfa1d
+      sha256sum: 54f37a98ddecf8400e9d016eac03da171cf049a8b17c4fb89217019aab745063
+      src: rubygem-mongo-2.5.1-2.module+el8.1.0+3656+f80bfa1d.src.rpm
+      version: 2.5.5
+    - _class: ErratumPackage
+      arch: noarch
+      epoch: '0'
+      filename: rubygem-abrt-0.3.0-4.module+el8.1.0+3656+f80bfa1d.noarch.rpm
+      md5sum: 02ddde5ae4c9f4d7563cfd21f13d2a88
+      name: rubygem-abrt
+      reboot_suggested: false
+      release: 4.module+el8.1.0+3656+f80bfa1d
+      sha256sum: 2579312600c5f242ff8edbf3b44b3d444962429ad40c17a28ce16500c798d860
+      src: rubygem-mongo-2.5.1-2.module+el8.1.0+3656+f80bfa1d.src.rpm
+      version: 0.3.0
+    - _class: ErratumPackage
+      arch: SRPMS
+      epoch: '0'
+      filename: rubygem-abrt-0.3.0-4.module+el8.1.0+3656+f80bfa1d.src.rpm
+      md5sum: 42a0e559c2bfc475d454cd406ab50331
+      name: rubygem-abrt
+      reboot_suggested: false
+      release: 4.module+el8.1.0+3656+f80bfa1d
+      sha256sum: d92c862b65872af7f701367225dc4c9ea799161e19594a7fbc6fa0e19bd2e667
+      src: rubygem-mongo-2.5.1-2.module+el8.1.0+3656+f80bfa1d.src.rpm
+      version: 0.3.0
+    - _class: ErratumPackage
+      arch: noarch
+      epoch: '0'
+      filename: rubygem-abrt-doc-0.3.0-4.module+el8.1.0+3656+f80bfa1d.noarch.rpm
+      md5sum: 7d714a33d672aaf9b8d975f446bdc5bd
+      name: rubygem-abrt-doc
+      reboot_suggested: false
+      release: 4.module+el8.1.0+3656+f80bfa1d
+      sha256sum: 4526c3514005042da89bd0884d0404b154ffba64b54112453269e4369b741d4c
+      src: rubygem-mongo-2.5.1-2.module+el8.1.0+3656+f80bfa1d.src.rpm
+      version: 0.3.0
+    - _class: ErratumPackage
+      arch: aarch64
+      epoch: '0'
+      filename: rubygem-bigdecimal-1.3.4-105.module+el8.1.0+3656+f80bfa1d.aarch64.rpm
+      md5sum: 6a4803b5aade70d2a3e36c462743446f
+      name: rubygem-bigdecimal
+      reboot_suggested: false
+      release: 105.module+el8.1.0+3656+f80bfa1d
+      sha256sum: 022fe1b132e52affa0879dbcc400ee000158f65f6f2959a0bb7772634f29846d
+      src: rubygem-mongo-2.5.1-2.module+el8.1.0+3656+f80bfa1d.src.rpm
+      version: 1.3.4
+    - _class: ErratumPackage
+      arch: aarch64
+      epoch: '0'
+      filename: rubygem-bigdecimal-debuginfo-1.3.4-105.module+el8.1.0+3656+f80bfa1d.aarch64.rpm
+      md5sum: d430fe0f1c0c7a34e6ee1db00c275a57
+      name: rubygem-bigdecimal-debuginfo
+      reboot_suggested: false
+      release: 105.module+el8.1.0+3656+f80bfa1d
+      sha256sum: 5c9eaae57ec4e9ac284150ce1eba6c192bb393d233ee6c1a0aafc2f7889bc3ca
+      src: rubygem-mongo-2.5.1-2.module+el8.1.0+3656+f80bfa1d.src.rpm
+      version: 1.3.4
+    - _class: ErratumPackage
+      arch: aarch64
+      epoch: '0'
+      filename: rubygem-bson-4.3.0-2.module+el8.1.0+3656+f80bfa1d.aarch64.rpm
+      md5sum: d170e6b397ae2f9a1d47eb6c7179014d
+      name: rubygem-bson
+      reboot_suggested: false
+      release: 2.module+el8.1.0+3656+f80bfa1d
+      sha256sum: 1b73e5284bcdc38f504eda5d4be5519d237b622ee2e96c4d341531fef99b370b
+      src: rubygem-mongo-2.5.1-2.module+el8.1.0+3656+f80bfa1d.src.rpm
+      version: 4.3.0
+    - _class: ErratumPackage
+      arch: SRPMS
+      epoch: '0'
+      filename: rubygem-bson-4.3.0-2.module+el8.1.0+3656+f80bfa1d.src.rpm
+      md5sum: aa443b78952f171bd930d7f2866a8bd0
+      name: rubygem-bson
+      reboot_suggested: false
+      release: 2.module+el8.1.0+3656+f80bfa1d
+      sha256sum: 8abe79db0675e5019fbdffd7aef41e9f09810aa30671c445b75dcce54028661a
+      src: rubygem-mongo-2.5.1-2.module+el8.1.0+3656+f80bfa1d.src.rpm
+      version: 4.3.0
+    - _class: ErratumPackage
+      arch: aarch64
+      epoch: '0'
+      filename: rubygem-bson-debuginfo-4.3.0-2.module+el8.1.0+3656+f80bfa1d.aarch64.rpm
+      md5sum: 8854990f398d52c9f8bf228961bb4116
+      name: rubygem-bson-debuginfo
+      reboot_suggested: false
+      release: 2.module+el8.1.0+3656+f80bfa1d
+      sha256sum: b2ce9ba47728b0fa4d8011a80c9c671cac774bb16414644d12b6d4a30f5c8855
+      src: rubygem-mongo-2.5.1-2.module+el8.1.0+3656+f80bfa1d.src.rpm
+      version: 4.3.0
+    - _class: ErratumPackage
+      arch: aarch64
+      epoch: '0'
+      filename: rubygem-bson-debugsource-4.3.0-2.module+el8.1.0+3656+f80bfa1d.aarch64.rpm
+      md5sum: c9bc6611615bd89437490eaad0f690aa
+      name: rubygem-bson-debugsource
+      reboot_suggested: false
+      release: 2.module+el8.1.0+3656+f80bfa1d
+      sha256sum: 3c2b0697d504100db0ee48440e008db57105205c81aaa28d443de2d6b96e9811
+      src: rubygem-mongo-2.5.1-2.module+el8.1.0+3656+f80bfa1d.src.rpm
+      version: 4.3.0
+    - _class: ErratumPackage
+      arch: noarch
+      epoch: '0'
+      filename: rubygem-bson-doc-4.3.0-2.module+el8.1.0+3656+f80bfa1d.noarch.rpm
+      md5sum: d5e07d87425397c127e32cda38937ec9
+      name: rubygem-bson-doc
+      reboot_suggested: false
+      release: 2.module+el8.1.0+3656+f80bfa1d
+      sha256sum: 9e2077a81214adffe1f0df18008e65f1ff10c65d61a11ef221b4ee2c94d4d842
+      src: rubygem-mongo-2.5.1-2.module+el8.1.0+3656+f80bfa1d.src.rpm
+      version: 4.3.0
+    - _class: ErratumPackage
+      arch: noarch
+      epoch: '0'
+      filename: rubygem-bundler-1.16.1-3.module+el8.1.0+3656+f80bfa1d.noarch.rpm
+      md5sum: adef4b585f2875cea6515a94bf8be2ba
+      name: rubygem-bundler
+      reboot_suggested: false
+      release: 3.module+el8.1.0+3656+f80bfa1d
+      sha256sum: fe344ebaa7887d3dc3695b8a5322f8507715d381ea265a7cf737960023471b06
+      src: rubygem-mongo-2.5.1-2.module+el8.1.0+3656+f80bfa1d.src.rpm
+      version: 1.16.1
+    - _class: ErratumPackage
+      arch: SRPMS
+      epoch: '0'
+      filename: rubygem-bundler-1.16.1-3.module+el8.1.0+3656+f80bfa1d.src.rpm
+      md5sum: 255642638b99991609b390a955768b2a
+      name: rubygem-bundler
+      reboot_suggested: false
+      release: 3.module+el8.1.0+3656+f80bfa1d
+      sha256sum: 32d5ee895ade306fd17a05184b728246cf423c093eeb27d9201f35b3e3c051b4
+      src: rubygem-mongo-2.5.1-2.module+el8.1.0+3656+f80bfa1d.src.rpm
+      version: 1.16.1
+    - _class: ErratumPackage
+      arch: noarch
+      epoch: '0'
+      filename: rubygem-bundler-doc-1.16.1-3.module+el8.1.0+3656+f80bfa1d.noarch.rpm
+      md5sum: b089a978e86c3dbfcc97ca1ba56e4d5e
+      name: rubygem-bundler-doc
+      reboot_suggested: false
+      release: 3.module+el8.1.0+3656+f80bfa1d
+      sha256sum: d507c993e4b5b576ac7a696b129a5236c08f23dc45ea5a6e37b105744831be08
+      src: rubygem-mongo-2.5.1-2.module+el8.1.0+3656+f80bfa1d.src.rpm
+      version: 1.16.1
+    - _class: ErratumPackage
+      arch: noarch
+      epoch: '0'
+      filename: rubygem-did_you_mean-1.2.0-105.module+el8.1.0+3656+f80bfa1d.noarch.rpm
+      md5sum: 11562927ab8bd761f5777fb251954631
+      name: rubygem-did_you_mean
+      reboot_suggested: false
+      release: 105.module+el8.1.0+3656+f80bfa1d
+      sha256sum: bb5bd5973be8aa064e1f7d692ec80b89b5668f7723ddcd08f29bd6e7896a63e3
+      src: rubygem-mongo-2.5.1-2.module+el8.1.0+3656+f80bfa1d.src.rpm
+      version: 1.2.0
+    - _class: ErratumPackage
+      arch: aarch64
+      epoch: '0'
+      filename: rubygem-io-console-0.4.6-105.module+el8.1.0+3656+f80bfa1d.aarch64.rpm
+      md5sum: 925401321396461caf9c981d5479bc4b
+      name: rubygem-io-console
+      reboot_suggested: false
+      release: 105.module+el8.1.0+3656+f80bfa1d
+      sha256sum: 35bc41f1b4832cbc4e21458e840dd34e97d58a17ca441b0ca33b763809a01163
+      src: rubygem-mongo-2.5.1-2.module+el8.1.0+3656+f80bfa1d.src.rpm
+      version: 0.4.6
+    - _class: ErratumPackage
+      arch: aarch64
+      epoch: '0'
+      filename: rubygem-io-console-debuginfo-0.4.6-105.module+el8.1.0+3656+f80bfa1d.aarch64.rpm
+      md5sum: 7d0d4e793685cb7481061700de523ffb
+      name: rubygem-io-console-debuginfo
+      reboot_suggested: false
+      release: 105.module+el8.1.0+3656+f80bfa1d
+      sha256sum: b4c69bd4ba9454735fc21e434dce2cbf976598f724b88500df7648fb8881d3c6
+      src: rubygem-mongo-2.5.1-2.module+el8.1.0+3656+f80bfa1d.src.rpm
+      version: 0.4.6
+    - _class: ErratumPackage
+      arch: aarch64
+      epoch: '0'
+      filename: rubygem-json-2.1.0-105.module+el8.1.0+3656+f80bfa1d.aarch64.rpm
+      md5sum: 68e8dce3c7b7898b11218c081e4e7a14
+      name: rubygem-json
+      reboot_suggested: false
+      release: 105.module+el8.1.0+3656+f80bfa1d
+      sha256sum: 2e919f273a3d6bd61a6af1a81032f0423e57d5ac70648b8ad4871ba4032ab6b6
+      src: rubygem-mongo-2.5.1-2.module+el8.1.0+3656+f80bfa1d.src.rpm
+      version: 2.1.0
+    - _class: ErratumPackage
+      arch: aarch64
+      epoch: '0'
+      filename: rubygem-json-debuginfo-2.1.0-105.module+el8.1.0+3656+f80bfa1d.aarch64.rpm
+      md5sum: ef2bdc915acf8080e88477235d0d479b
+      name: rubygem-json-debuginfo
+      reboot_suggested: false
+      release: 105.module+el8.1.0+3656+f80bfa1d
+      sha256sum: 2995e1b6aaadada0c2f48a461992d58019110c419fef179f2dd4102fab10b6ae
+      src: rubygem-mongo-2.5.1-2.module+el8.1.0+3656+f80bfa1d.src.rpm
+      version: 2.1.0
+    - _class: ErratumPackage
+      arch: noarch
+      epoch: '0'
+      filename: rubygem-minitest-5.10.3-105.module+el8.1.0+3656+f80bfa1d.noarch.rpm
+      md5sum: 93df8b3a09f80f449f5c0bd7792de82c
+      name: rubygem-minitest
+      reboot_suggested: false
+      release: 105.module+el8.1.0+3656+f80bfa1d
+      sha256sum: fdb2f2c36da88d7e4b493f248f092e561059a5a53764d3534961006e42b6b063
+      src: rubygem-mongo-2.5.1-2.module+el8.1.0+3656+f80bfa1d.src.rpm
+      version: 5.10.3
+    - _class: ErratumPackage
+      arch: noarch
+      epoch: '0'
+      filename: rubygem-mongo-2.5.1-2.module+el8.1.0+3656+f80bfa1d.noarch.rpm
+      md5sum: 849ed5b828db0f37a1c2edff58eeb363
+      name: rubygem-mongo
+      reboot_suggested: false
+      release: 2.module+el8.1.0+3656+f80bfa1d
+      sha256sum: 9b5c365e81f801d82f196b89b60184d6135ecd163611738cc07a8f75f1a9b466
+      src: rubygem-mongo-2.5.1-2.module+el8.1.0+3656+f80bfa1d.src.rpm
+      version: 2.5.1
+    - _class: ErratumPackage
+      arch: SRPMS
+      epoch: '0'
+      filename: rubygem-mongo-2.5.1-2.module+el8.1.0+3656+f80bfa1d.src.rpm
+      md5sum: 1561038e7132203944c9ca13d0617d65
+      name: rubygem-mongo
+      reboot_suggested: false
+      release: 2.module+el8.1.0+3656+f80bfa1d
+      sha256sum: 5b8d89427998167d5c2f9e7a546f7c5dde349f97463935bf40e06130e5383b63
+      src: rubygem-mongo-2.5.1-2.module+el8.1.0+3656+f80bfa1d.src.rpm
+      version: 2.5.1
+    - _class: ErratumPackage
+      arch: noarch
+      epoch: '0'
+      filename: rubygem-mongo-doc-2.5.1-2.module+el8.1.0+3656+f80bfa1d.noarch.rpm
+      md5sum: fa4a10ebdb5b964a2d10019b148981e9
+      name: rubygem-mongo-doc
+      reboot_suggested: false
+      release: 2.module+el8.1.0+3656+f80bfa1d
+      sha256sum: cba0a8b1b342a3a11801c21a9c403b4c028a290cf45c1589b16a191c7e8ba90f
+      src: rubygem-mongo-2.5.1-2.module+el8.1.0+3656+f80bfa1d.src.rpm
+      version: 2.5.1
+    - _class: ErratumPackage
+      arch: aarch64
+      epoch: '0'
+      filename: rubygem-mysql2-0.4.10-4.module+el8.1.0+3656+f80bfa1d.aarch64.rpm
+      md5sum: fb0b08e0dd09bbdb8abbefa62c96a485
+      name: rubygem-mysql2
+      reboot_suggested: false
+      release: 4.module+el8.1.0+3656+f80bfa1d
+      sha256sum: a3f9a7b63374f0637e2ef382c2a83c0be1855b9ca5b4e27ae0237c618a22f4ac
+      src: rubygem-mongo-2.5.1-2.module+el8.1.0+3656+f80bfa1d.src.rpm
+      version: 0.4.10
+    - _class: ErratumPackage
+      arch: SRPMS
+      epoch: '0'
+      filename: rubygem-mysql2-0.4.10-4.module+el8.1.0+3656+f80bfa1d.src.rpm
+      md5sum: 9e1cd68b55f6e11efe9967dda1f958ae
+      name: rubygem-mysql2
+      reboot_suggested: false
+      release: 4.module+el8.1.0+3656+f80bfa1d
+      sha256sum: 7bd7206950c3bdbd8c81073410e7912f0dc35fc319fb2ee084786e446056587a
+      src: rubygem-mongo-2.5.1-2.module+el8.1.0+3656+f80bfa1d.src.rpm
+      version: 0.4.10
+    - _class: ErratumPackage
+      arch: aarch64
+      epoch: '0'
+      filename: rubygem-mysql2-debuginfo-0.4.10-4.module+el8.1.0+3656+f80bfa1d.aarch64.rpm
+      md5sum: d6d907088e03041cdb89da19603cd55f
+      name: rubygem-mysql2-debuginfo
+      reboot_suggested: false
+      release: 4.module+el8.1.0+3656+f80bfa1d
+      sha256sum: 16aed670c0c33c0fedadcb1b58776d55868a550fb47f12bcae2c707106dc3cde
+      src: rubygem-mongo-2.5.1-2.module+el8.1.0+3656+f80bfa1d.src.rpm
+      version: 0.4.10
+    - _class: ErratumPackage
+      arch: aarch64
+      epoch: '0'
+      filename: rubygem-mysql2-debugsource-0.4.10-4.module+el8.1.0+3656+f80bfa1d.aarch64.rpm
+      md5sum: 1319f1bd44471c3a97daebbce749b8b2
+      name: rubygem-mysql2-debugsource
+      reboot_suggested: false
+      release: 4.module+el8.1.0+3656+f80bfa1d
+      sha256sum: 1e200eb70d5e31b1b0db27ab11ceff520fe4834f6ee7fda7b7e97ea6edc78f34
+      src: rubygem-mongo-2.5.1-2.module+el8.1.0+3656+f80bfa1d.src.rpm
+      version: 0.4.10
+    - _class: ErratumPackage
+      arch: noarch
+      epoch: '0'
+      filename: rubygem-mysql2-doc-0.4.10-4.module+el8.1.0+3656+f80bfa1d.noarch.rpm
+      md5sum: b58e5ec1fb18490197d60834e5709e80
+      name: rubygem-mysql2-doc
+      reboot_suggested: false
+      release: 4.module+el8.1.0+3656+f80bfa1d
+      sha256sum: 1d25f8d911a95b4abc5649e738ef1bd649ecf60f1d7fca5f444ec154765620d3
+      src: rubygem-mongo-2.5.1-2.module+el8.1.0+3656+f80bfa1d.src.rpm
+      version: 0.4.10
+    - _class: ErratumPackage
+      arch: noarch
+      epoch: '0'
+      filename: rubygem-net-telnet-0.1.1-105.module+el8.1.0+3656+f80bfa1d.noarch.rpm
+      md5sum: b2375afcc76507d6feccf12ff75fc49a
+      name: rubygem-net-telnet
+      reboot_suggested: false
+      release: 105.module+el8.1.0+3656+f80bfa1d
+      sha256sum: e28f21a6f4f141d65cc8bff6e40f179cec29d77ba0e7b7c01943dc23b68d1751
+      src: rubygem-mongo-2.5.1-2.module+el8.1.0+3656+f80bfa1d.src.rpm
+      version: 0.1.1
+    - _class: ErratumPackage
+      arch: aarch64
+      epoch: '0'
+      filename: rubygem-openssl-2.1.2-105.module+el8.1.0+3656+f80bfa1d.aarch64.rpm
+      md5sum: 3bc46292dc856337f224719bcbc90e04
+      name: rubygem-openssl
+      reboot_suggested: false
+      release: 105.module+el8.1.0+3656+f80bfa1d
+      sha256sum: e5d40af915af7950c4b98f0e07bd236208cafe1f0c89d9386906e4b7ea92d7ef
+      src: rubygem-mongo-2.5.1-2.module+el8.1.0+3656+f80bfa1d.src.rpm
+      version: 2.1.2
+    - _class: ErratumPackage
+      arch: aarch64
+      epoch: '0'
+      filename: rubygem-openssl-debuginfo-2.1.2-105.module+el8.1.0+3656+f80bfa1d.aarch64.rpm
+      md5sum: 665ea34213ead154cd216a0346998651
+      name: rubygem-openssl-debuginfo
+      reboot_suggested: false
+      release: 105.module+el8.1.0+3656+f80bfa1d
+      sha256sum: 646d0ae1d46b5efebfd7e72e1d91246f7e67400537c5a678586c3198abbba61c
+      src: rubygem-mongo-2.5.1-2.module+el8.1.0+3656+f80bfa1d.src.rpm
+      version: 2.1.2
+    - _class: ErratumPackage
+      arch: aarch64
+      epoch: '0'
+      filename: rubygem-pg-1.0.0-2.module+el8.1.0+3656+f80bfa1d.aarch64.rpm
+      md5sum: 716ca498d76bc7940acd81e1b1992b17
+      name: rubygem-pg
+      reboot_suggested: false
+      release: 2.module+el8.1.0+3656+f80bfa1d
+      sha256sum: 16739d6506dc67c579f3d06640538d1e19ca7830e4bda409337f46cf37eb1089
+      src: rubygem-mongo-2.5.1-2.module+el8.1.0+3656+f80bfa1d.src.rpm
+      version: 1.0.0
+    - _class: ErratumPackage
+      arch: SRPMS
+      epoch: '0'
+      filename: rubygem-pg-1.0.0-2.module+el8.1.0+3656+f80bfa1d.src.rpm
+      md5sum: a9bdc2dd5d271638750c1293a875ad77
+      name: rubygem-pg
+      reboot_suggested: false
+      release: 2.module+el8.1.0+3656+f80bfa1d
+      sha256sum: 5e71aa5e93b054478e1f399862d6c8030cd459fe8ff8f5369d5660779efded04
+      src: rubygem-mongo-2.5.1-2.module+el8.1.0+3656+f80bfa1d.src.rpm
+      version: 1.0.0
+    - _class: ErratumPackage
+      arch: aarch64
+      epoch: '0'
+      filename: rubygem-pg-debuginfo-1.0.0-2.module+el8.1.0+3656+f80bfa1d.aarch64.rpm
+      md5sum: 6223868954af3cdf27b4404860272516
+      name: rubygem-pg-debuginfo
+      reboot_suggested: false
+      release: 2.module+el8.1.0+3656+f80bfa1d
+      sha256sum: 7e793b6b49db7d3c1600075b0a675367ec5db392478cdaf2a30ab4b0f721e5a5
+      src: rubygem-mongo-2.5.1-2.module+el8.1.0+3656+f80bfa1d.src.rpm
+      version: 1.0.0
+    - _class: ErratumPackage
+      arch: aarch64
+      epoch: '0'
+      filename: rubygem-pg-debugsource-1.0.0-2.module+el8.1.0+3656+f80bfa1d.aarch64.rpm
+      md5sum: 7aae4ec71d5a06cbc988e02048ea8a26
+      name: rubygem-pg-debugsource
+      reboot_suggested: false
+      release: 2.module+el8.1.0+3656+f80bfa1d
+      sha256sum: e2ffd500c56946e787175ba71d282bbb866a47ee94dbf807a0499973f989afe0
+      src: rubygem-mongo-2.5.1-2.module+el8.1.0+3656+f80bfa1d.src.rpm
+      version: 1.0.0
+    - _class: ErratumPackage
+      arch: noarch
+      epoch: '0'
+      filename: rubygem-pg-doc-1.0.0-2.module+el8.1.0+3656+f80bfa1d.noarch.rpm
+      md5sum: 6a578f72ba96eca4938404a8449b5f16
+      name: rubygem-pg-doc
+      reboot_suggested: false
+      release: 2.module+el8.1.0+3656+f80bfa1d
+      sha256sum: 9a74af094119652d9ff29127d9aadd9b67a46feb0a0c3102687d43b638a53dce
+      src: rubygem-mongo-2.5.1-2.module+el8.1.0+3656+f80bfa1d.src.rpm
+      version: 1.0.0
+    - _class: ErratumPackage
+      arch: noarch
+      epoch: '0'
+      filename: rubygem-power_assert-1.1.1-105.module+el8.1.0+3656+f80bfa1d.noarch.rpm
+      md5sum: e87bc67208ce3eb03d3abc054017598b
+      name: rubygem-power_assert
+      reboot_suggested: false
+      release: 105.module+el8.1.0+3656+f80bfa1d
+      sha256sum: e907b442294a0f7e84cc8e5ac60839c702bae4ad198c208b2870eb0aa35864d1
+      src: rubygem-mongo-2.5.1-2.module+el8.1.0+3656+f80bfa1d.src.rpm
+      version: 1.1.1
+    - _class: ErratumPackage
+      arch: aarch64
+      epoch: '0'
+      filename: rubygem-psych-3.0.2-105.module+el8.1.0+3656+f80bfa1d.aarch64.rpm
+      md5sum: fc6b6bd3241f7e6f88c92195137a79ad
+      name: rubygem-psych
+      reboot_suggested: false
+      release: 105.module+el8.1.0+3656+f80bfa1d
+      sha256sum: ad3a54130ca09f14557065fb1d01cb63c37562523eb0a9b45e151ee04bd621e2
+      src: rubygem-mongo-2.5.1-2.module+el8.1.0+3656+f80bfa1d.src.rpm
+      version: 3.0.2
+    - _class: ErratumPackage
+      arch: aarch64
+      epoch: '0'
+      filename: rubygem-psych-debuginfo-3.0.2-105.module+el8.1.0+3656+f80bfa1d.aarch64.rpm
+      md5sum: 77ba0dfe031265c31b57f2b85e4d1a11
+      name: rubygem-psych-debuginfo
+      reboot_suggested: false
+      release: 105.module+el8.1.0+3656+f80bfa1d
+      sha256sum: 73209142d99bc550673d87128e7b7af373f0680f309a7e4834970706cfbfda32
+      src: rubygem-mongo-2.5.1-2.module+el8.1.0+3656+f80bfa1d.src.rpm
+      version: 3.0.2
+    - _class: ErratumPackage
+      arch: noarch
+      epoch: '0'
+      filename: rubygem-rake-12.3.0-105.module+el8.1.0+3656+f80bfa1d.noarch.rpm
+      md5sum: 0d536baf5e34db662ccfea564913a30d
+      name: rubygem-rake
+      reboot_suggested: false
+      release: 105.module+el8.1.0+3656+f80bfa1d
+      sha256sum: 36c8e13add7dccc90ccefacc2036da3637c0cf38da33c6379e5e759ec00301b5
+      src: rubygem-mongo-2.5.1-2.module+el8.1.0+3656+f80bfa1d.src.rpm
+      version: 12.3.0
+    - _class: ErratumPackage
+      arch: noarch
+      epoch: '0'
+      filename: rubygem-rdoc-6.0.1-105.module+el8.1.0+3656+f80bfa1d.noarch.rpm
+      md5sum: 2943e0d2c8a249abb6a405332cb85c12
+      name: rubygem-rdoc
+      reboot_suggested: false
+      release: 105.module+el8.1.0+3656+f80bfa1d
+      sha256sum: 5ee36835abbab4fc36ce732191ecb751f89020c92c03b4ed387c1171d4955819
+      src: rubygem-mongo-2.5.1-2.module+el8.1.0+3656+f80bfa1d.src.rpm
+      version: 6.0.1
+    - _class: ErratumPackage
+      arch: noarch
+      epoch: '0'
+      filename: rubygem-test-unit-3.2.7-105.module+el8.1.0+3656+f80bfa1d.noarch.rpm
+      md5sum: 1637e066d29aa755d864089dd1f8d1a3
+      name: rubygem-test-unit
+      reboot_suggested: false
+      release: 105.module+el8.1.0+3656+f80bfa1d
+      sha256sum: d4df4bad13e2cdeb9cbf022e4989ab940b0dced5b77d68a5ff694710c78d0da7
+      src: rubygem-mongo-2.5.1-2.module+el8.1.0+3656+f80bfa1d.src.rpm
+      version: 3.2.7
+    - _class: ErratumPackage
+      arch: noarch
+      epoch: '0'
+      filename: rubygem-xmlrpc-0.3.0-105.module+el8.1.0+3656+f80bfa1d.noarch.rpm
+      md5sum: d51d3fb7942200cc6b7e409eff96d734
+      name: rubygem-xmlrpc
+      reboot_suggested: false
+      release: 105.module+el8.1.0+3656+f80bfa1d
+      sha256sum: 0a245b8c8d2d4f07cf67ccedf9fd64707d2e737e729a75ef933e35a2d323993d
+      src: rubygem-mongo-2.5.1-2.module+el8.1.0+3656+f80bfa1d.src.rpm
+      version: 0.3.0
+    - _class: ErratumPackage
+      arch: noarch
+      epoch: '0'
+      filename: rubygems-2.7.6.2-105.module+el8.1.0+3656+f80bfa1d.noarch.rpm
+      md5sum: 9e86bdda0538344a6487fe5ffbeb7098
+      name: rubygems
+      reboot_suggested: false
+      release: 105.module+el8.1.0+3656+f80bfa1d
+      sha256sum: 9ef40ee367fc9edd93823856e0716e6a7ee7caebf48a67030e51269adb0cc952
+      src: rubygem-mongo-2.5.1-2.module+el8.1.0+3656+f80bfa1d.src.rpm
+      version: 2.7.6.2
+    - _class: ErratumPackage
+      arch: noarch
+      epoch: '0'
+      filename: rubygems-devel-2.7.6.2-105.module+el8.1.0+3656+f80bfa1d.noarch.rpm
+      md5sum: c7a349bb3056fd730a6828ab695c0531
+      name: rubygems-devel
+      reboot_suggested: false
+      release: 105.module+el8.1.0+3656+f80bfa1d
+      sha256sum: 0018c8abd50ddf6347d8b50a12d28e345cb1e963a825a177ad295cc86fc8406e
+      src: rubygem-mongo-2.5.1-2.module+el8.1.0+3656+f80bfa1d.src.rpm
+      version: 2.7.6.2
+    short: ''
+  - _class: ErratumPackageCollection
+    module:
+      _class: ErratumModule
+      arch: ppc64le
+      context: cdc1202b
+      name: ruby
+      stream: '2.5'
+      version: '8010020190711131821'
+    name: RHBA-2019:3384-ruby-2.5-cdc1202b-ppc64le
+    packages:
+    - _class: ErratumPackage
+      arch: ppc64le
+      epoch: '0'
+      filename: ruby-2.5.5-105.module+el8.1.0+3656+f80bfa1d.ppc64le.rpm
+      md5sum: 7fbba11cfca3b2ed81a73a46a4953ead
+      name: ruby
+      reboot_suggested: false
+      release: 105.module+el8.1.0+3656+f80bfa1d
+      sha256sum: c74db6d318fd1400bcf867c219c48b3d33e06dedf6771424e2e6057860f12169
+      src: rubygem-mongo-2.5.1-2.module+el8.1.0+3656+f80bfa1d.src.rpm
+      version: 2.5.5
+    - _class: ErratumPackage
+      arch: SRPMS
+      epoch: '0'
+      filename: ruby-2.5.5-105.module+el8.1.0+3656+f80bfa1d.src.rpm
+      md5sum: 026b049a21504fc773244164a2d0ff12
+      name: ruby
+      reboot_suggested: false
+      release: 105.module+el8.1.0+3656+f80bfa1d
+      sha256sum: 2edef90b7b9cf7222d932258d8978e4c7c41bf6eeffdfd5032b01d02e6d50e6d
+      src: rubygem-mongo-2.5.1-2.module+el8.1.0+3656+f80bfa1d.src.rpm
+      version: 2.5.5
+    - _class: ErratumPackage
+      arch: ppc64le
+      epoch: '0'
+      filename: ruby-debuginfo-2.5.5-105.module+el8.1.0+3656+f80bfa1d.ppc64le.rpm
+      md5sum: d02b41e1858462c1e6fe6a5e6633bb8f
+      name: ruby-debuginfo
+      reboot_suggested: false
+      release: 105.module+el8.1.0+3656+f80bfa1d
+      sha256sum: de5ff2eca35416bc8775a4326861b225c9ebe155984980d4c06b3581e8ba2769
+      src: rubygem-mongo-2.5.1-2.module+el8.1.0+3656+f80bfa1d.src.rpm
+      version: 2.5.5
+    - _class: ErratumPackage
+      arch: ppc64le
+      epoch: '0'
+      filename: ruby-debugsource-2.5.5-105.module+el8.1.0+3656+f80bfa1d.ppc64le.rpm
+      md5sum: 4a33fb72a9c92da48887249d899af2ad
+      name: ruby-debugsource
+      reboot_suggested: false
+      release: 105.module+el8.1.0+3656+f80bfa1d
+      sha256sum: cc0d5ccfa187722cb048b41d62698c4bd355c99d3e4bcf2b654fe7012b395a55
+      src: rubygem-mongo-2.5.1-2.module+el8.1.0+3656+f80bfa1d.src.rpm
+      version: 2.5.5
+    - _class: ErratumPackage
+      arch: ppc64le
+      epoch: '0'
+      filename: ruby-devel-2.5.5-105.module+el8.1.0+3656+f80bfa1d.ppc64le.rpm
+      md5sum: 9b444be378849dc5c59e428e47fd22b9
+      name: ruby-devel
+      reboot_suggested: false
+      release: 105.module+el8.1.0+3656+f80bfa1d
+      sha256sum: ef87fc6118e639352ef98967f20728898f52f719f2a769b3264d4eb1fa003c1c
+      src: rubygem-mongo-2.5.1-2.module+el8.1.0+3656+f80bfa1d.src.rpm
+      version: 2.5.5
+    - _class: ErratumPackage
+      arch: noarch
+      epoch: '0'
+      filename: ruby-doc-2.5.5-105.module+el8.1.0+3656+f80bfa1d.noarch.rpm
+      md5sum: 4542696784ee298fdbe88e6159a46a80
+      name: ruby-doc
+      reboot_suggested: false
+      release: 105.module+el8.1.0+3656+f80bfa1d
+      sha256sum: c543f6373a753dde041cc6a6e649e16ec7d4b4260b5b06f6aa62cb3ff5d9c720
+      src: rubygem-mongo-2.5.1-2.module+el8.1.0+3656+f80bfa1d.src.rpm
+      version: 2.5.5
+    - _class: ErratumPackage
+      arch: noarch
+      epoch: '0'
+      filename: ruby-irb-2.5.5-105.module+el8.1.0+3656+f80bfa1d.noarch.rpm
+      md5sum: 5611cb614525baf20774849e9019c25e
+      name: ruby-irb
+      reboot_suggested: false
+      release: 105.module+el8.1.0+3656+f80bfa1d
+      sha256sum: 9d6c163678783908a6a6488cc9277a54aba730d93489b0c55294d8ec48606507
+      src: rubygem-mongo-2.5.1-2.module+el8.1.0+3656+f80bfa1d.src.rpm
+      version: 2.5.5
+    - _class: ErratumPackage
+      arch: ppc64le
+      epoch: '0'
+      filename: ruby-libs-2.5.5-105.module+el8.1.0+3656+f80bfa1d.ppc64le.rpm
+      md5sum: c65f19654f8956648309db6dd2e17247
+      name: ruby-libs
+      reboot_suggested: false
+      release: 105.module+el8.1.0+3656+f80bfa1d
+      sha256sum: 280f3be1f49b818bc774121c2be0f806f1c5c1d024869d9048834f841933685c
+      src: rubygem-mongo-2.5.1-2.module+el8.1.0+3656+f80bfa1d.src.rpm
+      version: 2.5.5
+    - _class: ErratumPackage
+      arch: ppc64le
+      epoch: '0'
+      filename: ruby-libs-debuginfo-2.5.5-105.module+el8.1.0+3656+f80bfa1d.ppc64le.rpm
+      md5sum: 96bde21c8d4d7db5bcefe52c56060592
+      name: ruby-libs-debuginfo
+      reboot_suggested: false
+      release: 105.module+el8.1.0+3656+f80bfa1d
+      sha256sum: 9de6c0790fff8c1bb96ab95141a5d7011b39d6527b78e8ac1b5a6e062be8e751
+      src: rubygem-mongo-2.5.1-2.module+el8.1.0+3656+f80bfa1d.src.rpm
+      version: 2.5.5
+    - _class: ErratumPackage
+      arch: noarch
+      epoch: '0'
+      filename: rubygem-abrt-0.3.0-4.module+el8.1.0+3656+f80bfa1d.noarch.rpm
+      md5sum: 02ddde5ae4c9f4d7563cfd21f13d2a88
+      name: rubygem-abrt
+      reboot_suggested: false
+      release: 4.module+el8.1.0+3656+f80bfa1d
+      sha256sum: 2579312600c5f242ff8edbf3b44b3d444962429ad40c17a28ce16500c798d860
+      src: rubygem-mongo-2.5.1-2.module+el8.1.0+3656+f80bfa1d.src.rpm
+      version: 0.3.0
+    - _class: ErratumPackage
+      arch: SRPMS
+      epoch: '0'
+      filename: rubygem-abrt-0.3.0-4.module+el8.1.0+3656+f80bfa1d.src.rpm
+      md5sum: 42a0e559c2bfc475d454cd406ab50331
+      name: rubygem-abrt
+      reboot_suggested: false
+      release: 4.module+el8.1.0+3656+f80bfa1d
+      sha256sum: d92c862b65872af7f701367225dc4c9ea799161e19594a7fbc6fa0e19bd2e667
+      src: rubygem-mongo-2.5.1-2.module+el8.1.0+3656+f80bfa1d.src.rpm
+      version: 0.3.0
+    - _class: ErratumPackage
+      arch: noarch
+      epoch: '0'
+      filename: rubygem-abrt-doc-0.3.0-4.module+el8.1.0+3656+f80bfa1d.noarch.rpm
+      md5sum: 7d714a33d672aaf9b8d975f446bdc5bd
+      name: rubygem-abrt-doc
+      reboot_suggested: false
+      release: 4.module+el8.1.0+3656+f80bfa1d
+      sha256sum: 4526c3514005042da89bd0884d0404b154ffba64b54112453269e4369b741d4c
+      src: rubygem-mongo-2.5.1-2.module+el8.1.0+3656+f80bfa1d.src.rpm
+      version: 0.3.0
+    - _class: ErratumPackage
+      arch: ppc64le
+      epoch: '0'
+      filename: rubygem-bigdecimal-1.3.4-105.module+el8.1.0+3656+f80bfa1d.ppc64le.rpm
+      md5sum: 3eeae3ab8f385e570a43610ac25e71d1
+      name: rubygem-bigdecimal
+      reboot_suggested: false
+      release: 105.module+el8.1.0+3656+f80bfa1d
+      sha256sum: 1d144b170887fb59b55b549e2b17f87531090d18622251746b073ade72c7d2ae
+      src: rubygem-mongo-2.5.1-2.module+el8.1.0+3656+f80bfa1d.src.rpm
+      version: 1.3.4
+    - _class: ErratumPackage
+      arch: ppc64le
+      epoch: '0'
+      filename: rubygem-bigdecimal-debuginfo-1.3.4-105.module+el8.1.0+3656+f80bfa1d.ppc64le.rpm
+      md5sum: bb86b86c10e3c9e7cae64479195370cd
+      name: rubygem-bigdecimal-debuginfo
+      reboot_suggested: false
+      release: 105.module+el8.1.0+3656+f80bfa1d
+      sha256sum: 7f528325fe8a7cba96a986b57a94b30389ebe9d263a890afb143497dd567f1ec
+      src: rubygem-mongo-2.5.1-2.module+el8.1.0+3656+f80bfa1d.src.rpm
+      version: 1.3.4
+    - _class: ErratumPackage
+      arch: ppc64le
+      epoch: '0'
+      filename: rubygem-bson-4.3.0-2.module+el8.1.0+3656+f80bfa1d.ppc64le.rpm
+      md5sum: 53d7e3f35f8cfe655f1273f71fd1dac0
+      name: rubygem-bson
+      reboot_suggested: false
+      release: 2.module+el8.1.0+3656+f80bfa1d
+      sha256sum: d8df99841eab3a987776905d4062a402881c346c48033cdda2e539ba15313324
+      src: rubygem-mongo-2.5.1-2.module+el8.1.0+3656+f80bfa1d.src.rpm
+      version: 4.3.0
+    - _class: ErratumPackage
+      arch: SRPMS
+      epoch: '0'
+      filename: rubygem-bson-4.3.0-2.module+el8.1.0+3656+f80bfa1d.src.rpm
+      md5sum: aa443b78952f171bd930d7f2866a8bd0
+      name: rubygem-bson
+      reboot_suggested: false
+      release: 2.module+el8.1.0+3656+f80bfa1d
+      sha256sum: 8abe79db0675e5019fbdffd7aef41e9f09810aa30671c445b75dcce54028661a
+      src: rubygem-mongo-2.5.1-2.module+el8.1.0+3656+f80bfa1d.src.rpm
+      version: 4.3.0
+    - _class: ErratumPackage
+      arch: ppc64le
+      epoch: '0'
+      filename: rubygem-bson-debuginfo-4.3.0-2.module+el8.1.0+3656+f80bfa1d.ppc64le.rpm
+      md5sum: f876476fd9a559854430cbb8b62f5e89
+      name: rubygem-bson-debuginfo
+      reboot_suggested: false
+      release: 2.module+el8.1.0+3656+f80bfa1d
+      sha256sum: 53f4b4a1fe0758570ce2407f49dd1081f3451b75cb8cf5956cfd345c3d8298c9
+      src: rubygem-mongo-2.5.1-2.module+el8.1.0+3656+f80bfa1d.src.rpm
+      version: 4.3.0
+    - _class: ErratumPackage
+      arch: ppc64le
+      epoch: '0'
+      filename: rubygem-bson-debugsource-4.3.0-2.module+el8.1.0+3656+f80bfa1d.ppc64le.rpm
+      md5sum: c8644450009e2aad24e6bba49bf7ac2b
+      name: rubygem-bson-debugsource
+      reboot_suggested: false
+      release: 2.module+el8.1.0+3656+f80bfa1d
+      sha256sum: 3dbb54e91a58506495d390d302a6c02239877c5fff147065fb12b2df9bc7a3c0
+      src: rubygem-mongo-2.5.1-2.module+el8.1.0+3656+f80bfa1d.src.rpm
+      version: 4.3.0
+    - _class: ErratumPackage
+      arch: noarch
+      epoch: '0'
+      filename: rubygem-bson-doc-4.3.0-2.module+el8.1.0+3656+f80bfa1d.noarch.rpm
+      md5sum: d5e07d87425397c127e32cda38937ec9
+      name: rubygem-bson-doc
+      reboot_suggested: false
+      release: 2.module+el8.1.0+3656+f80bfa1d
+      sha256sum: 9e2077a81214adffe1f0df18008e65f1ff10c65d61a11ef221b4ee2c94d4d842
+      src: rubygem-mongo-2.5.1-2.module+el8.1.0+3656+f80bfa1d.src.rpm
+      version: 4.3.0
+    - _class: ErratumPackage
+      arch: noarch
+      epoch: '0'
+      filename: rubygem-bundler-1.16.1-3.module+el8.1.0+3656+f80bfa1d.noarch.rpm
+      md5sum: adef4b585f2875cea6515a94bf8be2ba
+      name: rubygem-bundler
+      reboot_suggested: false
+      release: 3.module+el8.1.0+3656+f80bfa1d
+      sha256sum: fe344ebaa7887d3dc3695b8a5322f8507715d381ea265a7cf737960023471b06
+      src: rubygem-mongo-2.5.1-2.module+el8.1.0+3656+f80bfa1d.src.rpm
+      version: 1.16.1
+    - _class: ErratumPackage
+      arch: SRPMS
+      epoch: '0'
+      filename: rubygem-bundler-1.16.1-3.module+el8.1.0+3656+f80bfa1d.src.rpm
+      md5sum: 255642638b99991609b390a955768b2a
+      name: rubygem-bundler
+      reboot_suggested: false
+      release: 3.module+el8.1.0+3656+f80bfa1d
+      sha256sum: 32d5ee895ade306fd17a05184b728246cf423c093eeb27d9201f35b3e3c051b4
+      src: rubygem-mongo-2.5.1-2.module+el8.1.0+3656+f80bfa1d.src.rpm
+      version: 1.16.1
+    - _class: ErratumPackage
+      arch: noarch
+      epoch: '0'
+      filename: rubygem-bundler-doc-1.16.1-3.module+el8.1.0+3656+f80bfa1d.noarch.rpm
+      md5sum: b089a978e86c3dbfcc97ca1ba56e4d5e
+      name: rubygem-bundler-doc
+      reboot_suggested: false
+      release: 3.module+el8.1.0+3656+f80bfa1d
+      sha256sum: d507c993e4b5b576ac7a696b129a5236c08f23dc45ea5a6e37b105744831be08
+      src: rubygem-mongo-2.5.1-2.module+el8.1.0+3656+f80bfa1d.src.rpm
+      version: 1.16.1
+    - _class: ErratumPackage
+      arch: noarch
+      epoch: '0'
+      filename: rubygem-did_you_mean-1.2.0-105.module+el8.1.0+3656+f80bfa1d.noarch.rpm
+      md5sum: 11562927ab8bd761f5777fb251954631
+      name: rubygem-did_you_mean
+      reboot_suggested: false
+      release: 105.module+el8.1.0+3656+f80bfa1d
+      sha256sum: bb5bd5973be8aa064e1f7d692ec80b89b5668f7723ddcd08f29bd6e7896a63e3
+      src: rubygem-mongo-2.5.1-2.module+el8.1.0+3656+f80bfa1d.src.rpm
+      version: 1.2.0
+    - _class: ErratumPackage
+      arch: ppc64le
+      epoch: '0'
+      filename: rubygem-io-console-0.4.6-105.module+el8.1.0+3656+f80bfa1d.ppc64le.rpm
+      md5sum: 7422f684cbb3de209208852f354c1307
+      name: rubygem-io-console
+      reboot_suggested: false
+      release: 105.module+el8.1.0+3656+f80bfa1d
+      sha256sum: 32a36114cc56eb1875e500dca374924379521aeb86ae3c7c63384173fd222cae
+      src: rubygem-mongo-2.5.1-2.module+el8.1.0+3656+f80bfa1d.src.rpm
+      version: 0.4.6
+    - _class: ErratumPackage
+      arch: ppc64le
+      epoch: '0'
+      filename: rubygem-io-console-debuginfo-0.4.6-105.module+el8.1.0+3656+f80bfa1d.ppc64le.rpm
+      md5sum: 6dac97f9c7d5dc40379e386c5718834b
+      name: rubygem-io-console-debuginfo
+      reboot_suggested: false
+      release: 105.module+el8.1.0+3656+f80bfa1d
+      sha256sum: a00936bf6ed75c4d5326e9285b3b4595153b2fd1cb62c8dfc0b296f87e994fec
+      src: rubygem-mongo-2.5.1-2.module+el8.1.0+3656+f80bfa1d.src.rpm
+      version: 0.4.6
+    - _class: ErratumPackage
+      arch: ppc64le
+      epoch: '0'
+      filename: rubygem-json-2.1.0-105.module+el8.1.0+3656+f80bfa1d.ppc64le.rpm
+      md5sum: cf1f743f0b30a3881e0dbaa07d149ea9
+      name: rubygem-json
+      reboot_suggested: false
+      release: 105.module+el8.1.0+3656+f80bfa1d
+      sha256sum: dfdda6252bc2295e375c597a8e0312b7c456d9129df5a34e0705633cd352db8c
+      src: rubygem-mongo-2.5.1-2.module+el8.1.0+3656+f80bfa1d.src.rpm
+      version: 2.1.0
+    - _class: ErratumPackage
+      arch: ppc64le
+      epoch: '0'
+      filename: rubygem-json-debuginfo-2.1.0-105.module+el8.1.0+3656+f80bfa1d.ppc64le.rpm
+      md5sum: e65fd5e62836fb2f37c33f9e40bfc102
+      name: rubygem-json-debuginfo
+      reboot_suggested: false
+      release: 105.module+el8.1.0+3656+f80bfa1d
+      sha256sum: ca9f78d5d96e08d93642d7bfe51331efcf44e2535f690bf6497459a8490ab02f
+      src: rubygem-mongo-2.5.1-2.module+el8.1.0+3656+f80bfa1d.src.rpm
+      version: 2.1.0
+    - _class: ErratumPackage
+      arch: noarch
+      epoch: '0'
+      filename: rubygem-minitest-5.10.3-105.module+el8.1.0+3656+f80bfa1d.noarch.rpm
+      md5sum: 93df8b3a09f80f449f5c0bd7792de82c
+      name: rubygem-minitest
+      reboot_suggested: false
+      release: 105.module+el8.1.0+3656+f80bfa1d
+      sha256sum: fdb2f2c36da88d7e4b493f248f092e561059a5a53764d3534961006e42b6b063
+      src: rubygem-mongo-2.5.1-2.module+el8.1.0+3656+f80bfa1d.src.rpm
+      version: 5.10.3
+    - _class: ErratumPackage
+      arch: noarch
+      epoch: '0'
+      filename: rubygem-mongo-2.5.1-2.module+el8.1.0+3656+f80bfa1d.noarch.rpm
+      md5sum: 849ed5b828db0f37a1c2edff58eeb363
+      name: rubygem-mongo
+      reboot_suggested: false
+      release: 2.module+el8.1.0+3656+f80bfa1d
+      sha256sum: 9b5c365e81f801d82f196b89b60184d6135ecd163611738cc07a8f75f1a9b466
+      src: rubygem-mongo-2.5.1-2.module+el8.1.0+3656+f80bfa1d.src.rpm
+      version: 2.5.1
+    - _class: ErratumPackage
+      arch: SRPMS
+      epoch: '0'
+      filename: rubygem-mongo-2.5.1-2.module+el8.1.0+3656+f80bfa1d.src.rpm
+      md5sum: 1561038e7132203944c9ca13d0617d65
+      name: rubygem-mongo
+      reboot_suggested: false
+      release: 2.module+el8.1.0+3656+f80bfa1d
+      sha256sum: 5b8d89427998167d5c2f9e7a546f7c5dde349f97463935bf40e06130e5383b63
+      src: rubygem-mongo-2.5.1-2.module+el8.1.0+3656+f80bfa1d.src.rpm
+      version: 2.5.1
+    - _class: ErratumPackage
+      arch: noarch
+      epoch: '0'
+      filename: rubygem-mongo-doc-2.5.1-2.module+el8.1.0+3656+f80bfa1d.noarch.rpm
+      md5sum: fa4a10ebdb5b964a2d10019b148981e9
+      name: rubygem-mongo-doc
+      reboot_suggested: false
+      release: 2.module+el8.1.0+3656+f80bfa1d
+      sha256sum: cba0a8b1b342a3a11801c21a9c403b4c028a290cf45c1589b16a191c7e8ba90f
+      src: rubygem-mongo-2.5.1-2.module+el8.1.0+3656+f80bfa1d.src.rpm
+      version: 2.5.1
+    - _class: ErratumPackage
+      arch: ppc64le
+      epoch: '0'
+      filename: rubygem-mysql2-0.4.10-4.module+el8.1.0+3656+f80bfa1d.ppc64le.rpm
+      md5sum: 2976b470faab9b998a92550a78e9d119
+      name: rubygem-mysql2
+      reboot_suggested: false
+      release: 4.module+el8.1.0+3656+f80bfa1d
+      sha256sum: b309b41e65b72b14ab507870c5799c74e8020dd21492532e1713b300cdddf5ed
+      src: rubygem-mongo-2.5.1-2.module+el8.1.0+3656+f80bfa1d.src.rpm
+      version: 0.4.10
+    - _class: ErratumPackage
+      arch: SRPMS
+      epoch: '0'
+      filename: rubygem-mysql2-0.4.10-4.module+el8.1.0+3656+f80bfa1d.src.rpm
+      md5sum: 9e1cd68b55f6e11efe9967dda1f958ae
+      name: rubygem-mysql2
+      reboot_suggested: false
+      release: 4.module+el8.1.0+3656+f80bfa1d
+      sha256sum: 7bd7206950c3bdbd8c81073410e7912f0dc35fc319fb2ee084786e446056587a
+      src: rubygem-mongo-2.5.1-2.module+el8.1.0+3656+f80bfa1d.src.rpm
+      version: 0.4.10
+    - _class: ErratumPackage
+      arch: ppc64le
+      epoch: '0'
+      filename: rubygem-mysql2-debuginfo-0.4.10-4.module+el8.1.0+3656+f80bfa1d.ppc64le.rpm
+      md5sum: 80540d5b8cd602f1f92b1cddd61f5800
+      name: rubygem-mysql2-debuginfo
+      reboot_suggested: false
+      release: 4.module+el8.1.0+3656+f80bfa1d
+      sha256sum: 260286051a27b415ee1ef8477b22f7f2be4a86eb7bf55a141ba81bf116fcfe07
+      src: rubygem-mongo-2.5.1-2.module+el8.1.0+3656+f80bfa1d.src.rpm
+      version: 0.4.10
+    - _class: ErratumPackage
+      arch: ppc64le
+      epoch: '0'
+      filename: rubygem-mysql2-debugsource-0.4.10-4.module+el8.1.0+3656+f80bfa1d.ppc64le.rpm
+      md5sum: 835f19932a71e6fb6e8e20dba00ea212
+      name: rubygem-mysql2-debugsource
+      reboot_suggested: false
+      release: 4.module+el8.1.0+3656+f80bfa1d
+      sha256sum: c280a8a9e4c4d8aeeb40d3e415a4c53921138b7a558fd55fc8328ead3fa6ffa5
+      src: rubygem-mongo-2.5.1-2.module+el8.1.0+3656+f80bfa1d.src.rpm
+      version: 0.4.10
+    - _class: ErratumPackage
+      arch: noarch
+      epoch: '0'
+      filename: rubygem-mysql2-doc-0.4.10-4.module+el8.1.0+3656+f80bfa1d.noarch.rpm
+      md5sum: b58e5ec1fb18490197d60834e5709e80
+      name: rubygem-mysql2-doc
+      reboot_suggested: false
+      release: 4.module+el8.1.0+3656+f80bfa1d
+      sha256sum: 1d25f8d911a95b4abc5649e738ef1bd649ecf60f1d7fca5f444ec154765620d3
+      src: rubygem-mongo-2.5.1-2.module+el8.1.0+3656+f80bfa1d.src.rpm
+      version: 0.4.10
+    - _class: ErratumPackage
+      arch: noarch
+      epoch: '0'
+      filename: rubygem-net-telnet-0.1.1-105.module+el8.1.0+3656+f80bfa1d.noarch.rpm
+      md5sum: b2375afcc76507d6feccf12ff75fc49a
+      name: rubygem-net-telnet
+      reboot_suggested: false
+      release: 105.module+el8.1.0+3656+f80bfa1d
+      sha256sum: e28f21a6f4f141d65cc8bff6e40f179cec29d77ba0e7b7c01943dc23b68d1751
+      src: rubygem-mongo-2.5.1-2.module+el8.1.0+3656+f80bfa1d.src.rpm
+      version: 0.1.1
+    - _class: ErratumPackage
+      arch: ppc64le
+      epoch: '0'
+      filename: rubygem-openssl-2.1.2-105.module+el8.1.0+3656+f80bfa1d.ppc64le.rpm
+      md5sum: 14025094cca7b59104a1d72883f07b2e
+      name: rubygem-openssl
+      reboot_suggested: false
+      release: 105.module+el8.1.0+3656+f80bfa1d
+      sha256sum: b0c825b2dfc8f815f57ec5e0fd153a176331ec1c100a12907f6f6e56f0fee332
+      src: rubygem-mongo-2.5.1-2.module+el8.1.0+3656+f80bfa1d.src.rpm
+      version: 2.1.2
+    - _class: ErratumPackage
+      arch: ppc64le
+      epoch: '0'
+      filename: rubygem-openssl-debuginfo-2.1.2-105.module+el8.1.0+3656+f80bfa1d.ppc64le.rpm
+      md5sum: 2a33daa07a524ab86d4b31b8b0c46c9c
+      name: rubygem-openssl-debuginfo
+      reboot_suggested: false
+      release: 105.module+el8.1.0+3656+f80bfa1d
+      sha256sum: 7c0f395ca0cae7ac4da151f50d19d4be93c890cdbcae84629b691d270d3d94d2
+      src: rubygem-mongo-2.5.1-2.module+el8.1.0+3656+f80bfa1d.src.rpm
+      version: 2.1.2
+    - _class: ErratumPackage
+      arch: ppc64le
+      epoch: '0'
+      filename: rubygem-pg-1.0.0-2.module+el8.1.0+3656+f80bfa1d.ppc64le.rpm
+      md5sum: bd592bec41f953e13ecfab6a1b80599c
+      name: rubygem-pg
+      reboot_suggested: false
+      release: 2.module+el8.1.0+3656+f80bfa1d
+      sha256sum: 9f5ab6effa0a333c0703fee81e65b99749c4c0f506a03de764f81f738ec6acaf
+      src: rubygem-mongo-2.5.1-2.module+el8.1.0+3656+f80bfa1d.src.rpm
+      version: 1.0.0
+    - _class: ErratumPackage
+      arch: SRPMS
+      epoch: '0'
+      filename: rubygem-pg-1.0.0-2.module+el8.1.0+3656+f80bfa1d.src.rpm
+      md5sum: a9bdc2dd5d271638750c1293a875ad77
+      name: rubygem-pg
+      reboot_suggested: false
+      release: 2.module+el8.1.0+3656+f80bfa1d
+      sha256sum: 5e71aa5e93b054478e1f399862d6c8030cd459fe8ff8f5369d5660779efded04
+      src: rubygem-mongo-2.5.1-2.module+el8.1.0+3656+f80bfa1d.src.rpm
+      version: 1.0.0
+    - _class: ErratumPackage
+      arch: ppc64le
+      epoch: '0'
+      filename: rubygem-pg-debuginfo-1.0.0-2.module+el8.1.0+3656+f80bfa1d.ppc64le.rpm
+      md5sum: dbb75a8e74e1f3c5b10e3c80891a4725
+      name: rubygem-pg-debuginfo
+      reboot_suggested: false
+      release: 2.module+el8.1.0+3656+f80bfa1d
+      sha256sum: 6b79a8c14be9dee26ef47cd301b7941303964288b2d4e440d56f34220903062f
+      src: rubygem-mongo-2.5.1-2.module+el8.1.0+3656+f80bfa1d.src.rpm
+      version: 1.0.0
+    - _class: ErratumPackage
+      arch: ppc64le
+      epoch: '0'
+      filename: rubygem-pg-debugsource-1.0.0-2.module+el8.1.0+3656+f80bfa1d.ppc64le.rpm
+      md5sum: 788ccd81311033e4c1eee5a228625d73
+      name: rubygem-pg-debugsource
+      reboot_suggested: false
+      release: 2.module+el8.1.0+3656+f80bfa1d
+      sha256sum: 25575aa839f3603fd0ee3fc1269c4299afd183ad545f46871ff5a5428b5634c8
+      src: rubygem-mongo-2.5.1-2.module+el8.1.0+3656+f80bfa1d.src.rpm
+      version: 1.0.0
+    - _class: ErratumPackage
+      arch: noarch
+      epoch: '0'
+      filename: rubygem-pg-doc-1.0.0-2.module+el8.1.0+3656+f80bfa1d.noarch.rpm
+      md5sum: 6a578f72ba96eca4938404a8449b5f16
+      name: rubygem-pg-doc
+      reboot_suggested: false
+      release: 2.module+el8.1.0+3656+f80bfa1d
+      sha256sum: 9a74af094119652d9ff29127d9aadd9b67a46feb0a0c3102687d43b638a53dce
+      src: rubygem-mongo-2.5.1-2.module+el8.1.0+3656+f80bfa1d.src.rpm
+      version: 1.0.0
+    - _class: ErratumPackage
+      arch: noarch
+      epoch: '0'
+      filename: rubygem-power_assert-1.1.1-105.module+el8.1.0+3656+f80bfa1d.noarch.rpm
+      md5sum: e87bc67208ce3eb03d3abc054017598b
+      name: rubygem-power_assert
+      reboot_suggested: false
+      release: 105.module+el8.1.0+3656+f80bfa1d
+      sha256sum: e907b442294a0f7e84cc8e5ac60839c702bae4ad198c208b2870eb0aa35864d1
+      src: rubygem-mongo-2.5.1-2.module+el8.1.0+3656+f80bfa1d.src.rpm
+      version: 1.1.1
+    - _class: ErratumPackage
+      arch: ppc64le
+      epoch: '0'
+      filename: rubygem-psych-3.0.2-105.module+el8.1.0+3656+f80bfa1d.ppc64le.rpm
+      md5sum: 1f902bab4f863581e02477561cf233f8
+      name: rubygem-psych
+      reboot_suggested: false
+      release: 105.module+el8.1.0+3656+f80bfa1d
+      sha256sum: deba3587ad5277f79c0e7cb7e4cf5d9aab32a84b3dca313124e94609a3f2cd36
+      src: rubygem-mongo-2.5.1-2.module+el8.1.0+3656+f80bfa1d.src.rpm
+      version: 3.0.2
+    - _class: ErratumPackage
+      arch: ppc64le
+      epoch: '0'
+      filename: rubygem-psych-debuginfo-3.0.2-105.module+el8.1.0+3656+f80bfa1d.ppc64le.rpm
+      md5sum: 19f78c650e4e50568224182a8923a496
+      name: rubygem-psych-debuginfo
+      reboot_suggested: false
+      release: 105.module+el8.1.0+3656+f80bfa1d
+      sha256sum: 02efd9869be4901e1f7d5fa26923d4508448c8c97d8f77e9d452d031de1c811e
+      src: rubygem-mongo-2.5.1-2.module+el8.1.0+3656+f80bfa1d.src.rpm
+      version: 3.0.2
+    - _class: ErratumPackage
+      arch: noarch
+      epoch: '0'
+      filename: rubygem-rake-12.3.0-105.module+el8.1.0+3656+f80bfa1d.noarch.rpm
+      md5sum: 0d536baf5e34db662ccfea564913a30d
+      name: rubygem-rake
+      reboot_suggested: false
+      release: 105.module+el8.1.0+3656+f80bfa1d
+      sha256sum: 36c8e13add7dccc90ccefacc2036da3637c0cf38da33c6379e5e759ec00301b5
+      src: rubygem-mongo-2.5.1-2.module+el8.1.0+3656+f80bfa1d.src.rpm
+      version: 12.3.0
+    - _class: ErratumPackage
+      arch: noarch
+      epoch: '0'
+      filename: rubygem-rdoc-6.0.1-105.module+el8.1.0+3656+f80bfa1d.noarch.rpm
+      md5sum: 2943e0d2c8a249abb6a405332cb85c12
+      name: rubygem-rdoc
+      reboot_suggested: false
+      release: 105.module+el8.1.0+3656+f80bfa1d
+      sha256sum: 5ee36835abbab4fc36ce732191ecb751f89020c92c03b4ed387c1171d4955819
+      src: rubygem-mongo-2.5.1-2.module+el8.1.0+3656+f80bfa1d.src.rpm
+      version: 6.0.1
+    - _class: ErratumPackage
+      arch: noarch
+      epoch: '0'
+      filename: rubygem-test-unit-3.2.7-105.module+el8.1.0+3656+f80bfa1d.noarch.rpm
+      md5sum: 1637e066d29aa755d864089dd1f8d1a3
+      name: rubygem-test-unit
+      reboot_suggested: false
+      release: 105.module+el8.1.0+3656+f80bfa1d
+      sha256sum: d4df4bad13e2cdeb9cbf022e4989ab940b0dced5b77d68a5ff694710c78d0da7
+      src: rubygem-mongo-2.5.1-2.module+el8.1.0+3656+f80bfa1d.src.rpm
+      version: 3.2.7
+    - _class: ErratumPackage
+      arch: noarch
+      epoch: '0'
+      filename: rubygem-xmlrpc-0.3.0-105.module+el8.1.0+3656+f80bfa1d.noarch.rpm
+      md5sum: d51d3fb7942200cc6b7e409eff96d734
+      name: rubygem-xmlrpc
+      reboot_suggested: false
+      release: 105.module+el8.1.0+3656+f80bfa1d
+      sha256sum: 0a245b8c8d2d4f07cf67ccedf9fd64707d2e737e729a75ef933e35a2d323993d
+      src: rubygem-mongo-2.5.1-2.module+el8.1.0+3656+f80bfa1d.src.rpm
+      version: 0.3.0
+    - _class: ErratumPackage
+      arch: noarch
+      epoch: '0'
+      filename: rubygems-2.7.6.2-105.module+el8.1.0+3656+f80bfa1d.noarch.rpm
+      md5sum: 9e86bdda0538344a6487fe5ffbeb7098
+      name: rubygems
+      reboot_suggested: false
+      release: 105.module+el8.1.0+3656+f80bfa1d
+      sha256sum: 9ef40ee367fc9edd93823856e0716e6a7ee7caebf48a67030e51269adb0cc952
+      src: rubygem-mongo-2.5.1-2.module+el8.1.0+3656+f80bfa1d.src.rpm
+      version: 2.7.6.2
+    - _class: ErratumPackage
+      arch: noarch
+      epoch: '0'
+      filename: rubygems-devel-2.7.6.2-105.module+el8.1.0+3656+f80bfa1d.noarch.rpm
+      md5sum: c7a349bb3056fd730a6828ab695c0531
+      name: rubygems-devel
+      reboot_suggested: false
+      release: 105.module+el8.1.0+3656+f80bfa1d
+      sha256sum: 0018c8abd50ddf6347d8b50a12d28e345cb1e963a825a177ad295cc86fc8406e
+      src: rubygem-mongo-2.5.1-2.module+el8.1.0+3656+f80bfa1d.src.rpm
+      version: 2.7.6.2
+    short: ''
+  - _class: ErratumPackageCollection
+    module:
+      _class: ErratumModule
+      arch: s390x
+      context: cdc1202b
+      name: ruby
+      stream: '2.5'
+      version: '8010020190711131821'
+    name: RHBA-2019:3384-ruby-2.5-cdc1202b-s390x
+    packages:
+    - _class: ErratumPackage
+      arch: s390x
+      epoch: '0'
+      filename: ruby-2.5.5-105.module+el8.1.0+3656+f80bfa1d.s390x.rpm
+      md5sum: 50580c7b6b561af7ece067d4fc529a59
+      name: ruby
+      reboot_suggested: false
+      release: 105.module+el8.1.0+3656+f80bfa1d
+      sha256sum: 073fc5273a19ad8471b296aea8614966c4de04a470c1419176cdc3b0c9c00e6c
+      src: rubygem-mongo-2.5.1-2.module+el8.1.0+3656+f80bfa1d.src.rpm
+      version: 2.5.5
+    - _class: ErratumPackage
+      arch: SRPMS
+      epoch: '0'
+      filename: ruby-2.5.5-105.module+el8.1.0+3656+f80bfa1d.src.rpm
+      md5sum: 026b049a21504fc773244164a2d0ff12
+      name: ruby
+      reboot_suggested: false
+      release: 105.module+el8.1.0+3656+f80bfa1d
+      sha256sum: 2edef90b7b9cf7222d932258d8978e4c7c41bf6eeffdfd5032b01d02e6d50e6d
+      src: rubygem-mongo-2.5.1-2.module+el8.1.0+3656+f80bfa1d.src.rpm
+      version: 2.5.5
+    - _class: ErratumPackage
+      arch: s390x
+      epoch: '0'
+      filename: ruby-debuginfo-2.5.5-105.module+el8.1.0+3656+f80bfa1d.s390x.rpm
+      md5sum: 40effb8e14b00209745d96934e83006c
+      name: ruby-debuginfo
+      reboot_suggested: false
+      release: 105.module+el8.1.0+3656+f80bfa1d
+      sha256sum: 1c9e32448990a6d7b3fecc9843b7968da6c02736f533da619a295323b2c24f04
+      src: rubygem-mongo-2.5.1-2.module+el8.1.0+3656+f80bfa1d.src.rpm
+      version: 2.5.5
+    - _class: ErratumPackage
+      arch: s390x
+      epoch: '0'
+      filename: ruby-debugsource-2.5.5-105.module+el8.1.0+3656+f80bfa1d.s390x.rpm
+      md5sum: a5eb50924a0142f83e44f3c30e03aba3
+      name: ruby-debugsource
+      reboot_suggested: false
+      release: 105.module+el8.1.0+3656+f80bfa1d
+      sha256sum: 5044c21a164d200333b3e0a88c14f320c60be552197dca03083966904df8ff34
+      src: rubygem-mongo-2.5.1-2.module+el8.1.0+3656+f80bfa1d.src.rpm
+      version: 2.5.5
+    - _class: ErratumPackage
+      arch: s390x
+      epoch: '0'
+      filename: ruby-devel-2.5.5-105.module+el8.1.0+3656+f80bfa1d.s390x.rpm
+      md5sum: 60e1711ed5ca8d8c66cddd125c0a2bb6
+      name: ruby-devel
+      reboot_suggested: false
+      release: 105.module+el8.1.0+3656+f80bfa1d
+      sha256sum: 4652464d7faf52197a54d4f6a6b0ab3ac60618428d79475433c080eef8a123aa
+      src: rubygem-mongo-2.5.1-2.module+el8.1.0+3656+f80bfa1d.src.rpm
+      version: 2.5.5
+    - _class: ErratumPackage
+      arch: noarch
+      epoch: '0'
+      filename: ruby-doc-2.5.5-105.module+el8.1.0+3656+f80bfa1d.noarch.rpm
+      md5sum: 4542696784ee298fdbe88e6159a46a80
+      name: ruby-doc
+      reboot_suggested: false
+      release: 105.module+el8.1.0+3656+f80bfa1d
+      sha256sum: c543f6373a753dde041cc6a6e649e16ec7d4b4260b5b06f6aa62cb3ff5d9c720
+      src: rubygem-mongo-2.5.1-2.module+el8.1.0+3656+f80bfa1d.src.rpm
+      version: 2.5.5
+    - _class: ErratumPackage
+      arch: noarch
+      epoch: '0'
+      filename: ruby-irb-2.5.5-105.module+el8.1.0+3656+f80bfa1d.noarch.rpm
+      md5sum: 5611cb614525baf20774849e9019c25e
+      name: ruby-irb
+      reboot_suggested: false
+      release: 105.module+el8.1.0+3656+f80bfa1d
+      sha256sum: 9d6c163678783908a6a6488cc9277a54aba730d93489b0c55294d8ec48606507
+      src: rubygem-mongo-2.5.1-2.module+el8.1.0+3656+f80bfa1d.src.rpm
+      version: 2.5.5
+    - _class: ErratumPackage
+      arch: s390x
+      epoch: '0'
+      filename: ruby-libs-2.5.5-105.module+el8.1.0+3656+f80bfa1d.s390x.rpm
+      md5sum: 0af8846e067f63329a3a9c9241f85c5b
+      name: ruby-libs
+      reboot_suggested: false
+      release: 105.module+el8.1.0+3656+f80bfa1d
+      sha256sum: 24ada355b8f98ecfc9517629d1affd58d3b04083692f16caa659b2149cb3d021
+      src: rubygem-mongo-2.5.1-2.module+el8.1.0+3656+f80bfa1d.src.rpm
+      version: 2.5.5
+    - _class: ErratumPackage
+      arch: s390x
+      epoch: '0'
+      filename: ruby-libs-debuginfo-2.5.5-105.module+el8.1.0+3656+f80bfa1d.s390x.rpm
+      md5sum: 473d01a99ce7474a0ba3d702a69052bb
+      name: ruby-libs-debuginfo
+      reboot_suggested: false
+      release: 105.module+el8.1.0+3656+f80bfa1d
+      sha256sum: e6be3fba6aa6ff495d5152cad1e79e927ac6fb421192aca8e7c6af52a8ebad4f
+      src: rubygem-mongo-2.5.1-2.module+el8.1.0+3656+f80bfa1d.src.rpm
+      version: 2.5.5
+    - _class: ErratumPackage
+      arch: noarch
+      epoch: '0'
+      filename: rubygem-abrt-0.3.0-4.module+el8.1.0+3656+f80bfa1d.noarch.rpm
+      md5sum: 02ddde5ae4c9f4d7563cfd21f13d2a88
+      name: rubygem-abrt
+      reboot_suggested: false
+      release: 4.module+el8.1.0+3656+f80bfa1d
+      sha256sum: 2579312600c5f242ff8edbf3b44b3d444962429ad40c17a28ce16500c798d860
+      src: rubygem-mongo-2.5.1-2.module+el8.1.0+3656+f80bfa1d.src.rpm
+      version: 0.3.0
+    - _class: ErratumPackage
+      arch: SRPMS
+      epoch: '0'
+      filename: rubygem-abrt-0.3.0-4.module+el8.1.0+3656+f80bfa1d.src.rpm
+      md5sum: 42a0e559c2bfc475d454cd406ab50331
+      name: rubygem-abrt
+      reboot_suggested: false
+      release: 4.module+el8.1.0+3656+f80bfa1d
+      sha256sum: d92c862b65872af7f701367225dc4c9ea799161e19594a7fbc6fa0e19bd2e667
+      src: rubygem-mongo-2.5.1-2.module+el8.1.0+3656+f80bfa1d.src.rpm
+      version: 0.3.0
+    - _class: ErratumPackage
+      arch: noarch
+      epoch: '0'
+      filename: rubygem-abrt-doc-0.3.0-4.module+el8.1.0+3656+f80bfa1d.noarch.rpm
+      md5sum: 7d714a33d672aaf9b8d975f446bdc5bd
+      name: rubygem-abrt-doc
+      reboot_suggested: false
+      release: 4.module+el8.1.0+3656+f80bfa1d
+      sha256sum: 4526c3514005042da89bd0884d0404b154ffba64b54112453269e4369b741d4c
+      src: rubygem-mongo-2.5.1-2.module+el8.1.0+3656+f80bfa1d.src.rpm
+      version: 0.3.0
+    - _class: ErratumPackage
+      arch: s390x
+      epoch: '0'
+      filename: rubygem-bigdecimal-1.3.4-105.module+el8.1.0+3656+f80bfa1d.s390x.rpm
+      md5sum: a5cdde4f03f4730f02ce1c70f63a6481
+      name: rubygem-bigdecimal
+      reboot_suggested: false
+      release: 105.module+el8.1.0+3656+f80bfa1d
+      sha256sum: b94251a5369f394015c981ab396f51973432bfcf44dfba8a19969aec690a2c88
+      src: rubygem-mongo-2.5.1-2.module+el8.1.0+3656+f80bfa1d.src.rpm
+      version: 1.3.4
+    - _class: ErratumPackage
+      arch: s390x
+      epoch: '0'
+      filename: rubygem-bigdecimal-debuginfo-1.3.4-105.module+el8.1.0+3656+f80bfa1d.s390x.rpm
+      md5sum: 64f047423fdda7d2ad82b46ccbd568d6
+      name: rubygem-bigdecimal-debuginfo
+      reboot_suggested: false
+      release: 105.module+el8.1.0+3656+f80bfa1d
+      sha256sum: 012a890d40a57e6240f6b89ca1d1a88fb0c627717607cecd8c50820e673027ec
+      src: rubygem-mongo-2.5.1-2.module+el8.1.0+3656+f80bfa1d.src.rpm
+      version: 1.3.4
+    - _class: ErratumPackage
+      arch: s390x
+      epoch: '0'
+      filename: rubygem-bson-4.3.0-2.module+el8.1.0+3656+f80bfa1d.s390x.rpm
+      md5sum: aa304689dc880badd5fa596d81a6f74e
+      name: rubygem-bson
+      reboot_suggested: false
+      release: 2.module+el8.1.0+3656+f80bfa1d
+      sha256sum: ee9cf16ad55b0d21ad9b89f47908fe5e1064cbe5f3078f7abf864aa0e9751b90
+      src: rubygem-mongo-2.5.1-2.module+el8.1.0+3656+f80bfa1d.src.rpm
+      version: 4.3.0
+    - _class: ErratumPackage
+      arch: SRPMS
+      epoch: '0'
+      filename: rubygem-bson-4.3.0-2.module+el8.1.0+3656+f80bfa1d.src.rpm
+      md5sum: aa443b78952f171bd930d7f2866a8bd0
+      name: rubygem-bson
+      reboot_suggested: false
+      release: 2.module+el8.1.0+3656+f80bfa1d
+      sha256sum: 8abe79db0675e5019fbdffd7aef41e9f09810aa30671c445b75dcce54028661a
+      src: rubygem-mongo-2.5.1-2.module+el8.1.0+3656+f80bfa1d.src.rpm
+      version: 4.3.0
+    - _class: ErratumPackage
+      arch: s390x
+      epoch: '0'
+      filename: rubygem-bson-debuginfo-4.3.0-2.module+el8.1.0+3656+f80bfa1d.s390x.rpm
+      md5sum: 4e777a6fec0ffc3e55aab22359070c6b
+      name: rubygem-bson-debuginfo
+      reboot_suggested: false
+      release: 2.module+el8.1.0+3656+f80bfa1d
+      sha256sum: 754a12a567429e355f39249fea46cd9f7f6aae3d93df97edb8ab4e8fa6e469be
+      src: rubygem-mongo-2.5.1-2.module+el8.1.0+3656+f80bfa1d.src.rpm
+      version: 4.3.0
+    - _class: ErratumPackage
+      arch: s390x
+      epoch: '0'
+      filename: rubygem-bson-debugsource-4.3.0-2.module+el8.1.0+3656+f80bfa1d.s390x.rpm
+      md5sum: 6779a8bd4e951b1ffbf4af5a4a845290
+      name: rubygem-bson-debugsource
+      reboot_suggested: false
+      release: 2.module+el8.1.0+3656+f80bfa1d
+      sha256sum: dcc61407d9c6f5ce2a2681585a576bb022d8cb35124f875e62cf679c6842978b
+      src: rubygem-mongo-2.5.1-2.module+el8.1.0+3656+f80bfa1d.src.rpm
+      version: 4.3.0
+    - _class: ErratumPackage
+      arch: noarch
+      epoch: '0'
+      filename: rubygem-bson-doc-4.3.0-2.module+el8.1.0+3656+f80bfa1d.noarch.rpm
+      md5sum: d5e07d87425397c127e32cda38937ec9
+      name: rubygem-bson-doc
+      reboot_suggested: false
+      release: 2.module+el8.1.0+3656+f80bfa1d
+      sha256sum: 9e2077a81214adffe1f0df18008e65f1ff10c65d61a11ef221b4ee2c94d4d842
+      src: rubygem-mongo-2.5.1-2.module+el8.1.0+3656+f80bfa1d.src.rpm
+      version: 4.3.0
+    - _class: ErratumPackage
+      arch: noarch
+      epoch: '0'
+      filename: rubygem-bundler-1.16.1-3.module+el8.1.0+3656+f80bfa1d.noarch.rpm
+      md5sum: adef4b585f2875cea6515a94bf8be2ba
+      name: rubygem-bundler
+      reboot_suggested: false
+      release: 3.module+el8.1.0+3656+f80bfa1d
+      sha256sum: fe344ebaa7887d3dc3695b8a5322f8507715d381ea265a7cf737960023471b06
+      src: rubygem-mongo-2.5.1-2.module+el8.1.0+3656+f80bfa1d.src.rpm
+      version: 1.16.1
+    - _class: ErratumPackage
+      arch: SRPMS
+      epoch: '0'
+      filename: rubygem-bundler-1.16.1-3.module+el8.1.0+3656+f80bfa1d.src.rpm
+      md5sum: 255642638b99991609b390a955768b2a
+      name: rubygem-bundler
+      reboot_suggested: false
+      release: 3.module+el8.1.0+3656+f80bfa1d
+      sha256sum: 32d5ee895ade306fd17a05184b728246cf423c093eeb27d9201f35b3e3c051b4
+      src: rubygem-mongo-2.5.1-2.module+el8.1.0+3656+f80bfa1d.src.rpm
+      version: 1.16.1
+    - _class: ErratumPackage
+      arch: noarch
+      epoch: '0'
+      filename: rubygem-bundler-doc-1.16.1-3.module+el8.1.0+3656+f80bfa1d.noarch.rpm
+      md5sum: b089a978e86c3dbfcc97ca1ba56e4d5e
+      name: rubygem-bundler-doc
+      reboot_suggested: false
+      release: 3.module+el8.1.0+3656+f80bfa1d
+      sha256sum: d507c993e4b5b576ac7a696b129a5236c08f23dc45ea5a6e37b105744831be08
+      src: rubygem-mongo-2.5.1-2.module+el8.1.0+3656+f80bfa1d.src.rpm
+      version: 1.16.1
+    - _class: ErratumPackage
+      arch: noarch
+      epoch: '0'
+      filename: rubygem-did_you_mean-1.2.0-105.module+el8.1.0+3656+f80bfa1d.noarch.rpm
+      md5sum: 11562927ab8bd761f5777fb251954631
+      name: rubygem-did_you_mean
+      reboot_suggested: false
+      release: 105.module+el8.1.0+3656+f80bfa1d
+      sha256sum: bb5bd5973be8aa064e1f7d692ec80b89b5668f7723ddcd08f29bd6e7896a63e3
+      src: rubygem-mongo-2.5.1-2.module+el8.1.0+3656+f80bfa1d.src.rpm
+      version: 1.2.0
+    - _class: ErratumPackage
+      arch: s390x
+      epoch: '0'
+      filename: rubygem-io-console-0.4.6-105.module+el8.1.0+3656+f80bfa1d.s390x.rpm
+      md5sum: b80548822e5fc5ac9cbd1820ffa5e2a6
+      name: rubygem-io-console
+      reboot_suggested: false
+      release: 105.module+el8.1.0+3656+f80bfa1d
+      sha256sum: bd0dc1edae49f0f3ce63b77a7ec21fcca876a8aa29b0c3773fb38328ed4d566e
+      src: rubygem-mongo-2.5.1-2.module+el8.1.0+3656+f80bfa1d.src.rpm
+      version: 0.4.6
+    - _class: ErratumPackage
+      arch: s390x
+      epoch: '0'
+      filename: rubygem-io-console-debuginfo-0.4.6-105.module+el8.1.0+3656+f80bfa1d.s390x.rpm
+      md5sum: faae0ba0ecb4a81e8e3d98d8ca7c195a
+      name: rubygem-io-console-debuginfo
+      reboot_suggested: false
+      release: 105.module+el8.1.0+3656+f80bfa1d
+      sha256sum: 36bbf053ea425ddda362cd528d49bf01fa6898936a8e0338b243e9e0f3e66cd1
+      src: rubygem-mongo-2.5.1-2.module+el8.1.0+3656+f80bfa1d.src.rpm
+      version: 0.4.6
+    - _class: ErratumPackage
+      arch: s390x
+      epoch: '0'
+      filename: rubygem-json-2.1.0-105.module+el8.1.0+3656+f80bfa1d.s390x.rpm
+      md5sum: 0c6399f03dcdf7c4b02f9d75fe2c7efb
+      name: rubygem-json
+      reboot_suggested: false
+      release: 105.module+el8.1.0+3656+f80bfa1d
+      sha256sum: eb14b26d869b2aafa8417c2121357805edfa8956d43b1522797ca020f7cb2b1f
+      src: rubygem-mongo-2.5.1-2.module+el8.1.0+3656+f80bfa1d.src.rpm
+      version: 2.1.0
+    - _class: ErratumPackage
+      arch: s390x
+      epoch: '0'
+      filename: rubygem-json-debuginfo-2.1.0-105.module+el8.1.0+3656+f80bfa1d.s390x.rpm
+      md5sum: e1424ee8bdb040a032ad899dd80f3759
+      name: rubygem-json-debuginfo
+      reboot_suggested: false
+      release: 105.module+el8.1.0+3656+f80bfa1d
+      sha256sum: 1ab45a53b1fe20af331a5fdcc4139796c8c02e0932d6fe1c83382e43aaf6a440
+      src: rubygem-mongo-2.5.1-2.module+el8.1.0+3656+f80bfa1d.src.rpm
+      version: 2.1.0
+    - _class: ErratumPackage
+      arch: noarch
+      epoch: '0'
+      filename: rubygem-minitest-5.10.3-105.module+el8.1.0+3656+f80bfa1d.noarch.rpm
+      md5sum: 93df8b3a09f80f449f5c0bd7792de82c
+      name: rubygem-minitest
+      reboot_suggested: false
+      release: 105.module+el8.1.0+3656+f80bfa1d
+      sha256sum: fdb2f2c36da88d7e4b493f248f092e561059a5a53764d3534961006e42b6b063
+      src: rubygem-mongo-2.5.1-2.module+el8.1.0+3656+f80bfa1d.src.rpm
+      version: 5.10.3
+    - _class: ErratumPackage
+      arch: noarch
+      epoch: '0'
+      filename: rubygem-mongo-2.5.1-2.module+el8.1.0+3656+f80bfa1d.noarch.rpm
+      md5sum: 849ed5b828db0f37a1c2edff58eeb363
+      name: rubygem-mongo
+      reboot_suggested: false
+      release: 2.module+el8.1.0+3656+f80bfa1d
+      sha256sum: 9b5c365e81f801d82f196b89b60184d6135ecd163611738cc07a8f75f1a9b466
+      src: rubygem-mongo-2.5.1-2.module+el8.1.0+3656+f80bfa1d.src.rpm
+      version: 2.5.1
+    - _class: ErratumPackage
+      arch: SRPMS
+      epoch: '0'
+      filename: rubygem-mongo-2.5.1-2.module+el8.1.0+3656+f80bfa1d.src.rpm
+      md5sum: 1561038e7132203944c9ca13d0617d65
+      name: rubygem-mongo
+      reboot_suggested: false
+      release: 2.module+el8.1.0+3656+f80bfa1d
+      sha256sum: 5b8d89427998167d5c2f9e7a546f7c5dde349f97463935bf40e06130e5383b63
+      src: rubygem-mongo-2.5.1-2.module+el8.1.0+3656+f80bfa1d.src.rpm
+      version: 2.5.1
+    - _class: ErratumPackage
+      arch: noarch
+      epoch: '0'
+      filename: rubygem-mongo-doc-2.5.1-2.module+el8.1.0+3656+f80bfa1d.noarch.rpm
+      md5sum: fa4a10ebdb5b964a2d10019b148981e9
+      name: rubygem-mongo-doc
+      reboot_suggested: false
+      release: 2.module+el8.1.0+3656+f80bfa1d
+      sha256sum: cba0a8b1b342a3a11801c21a9c403b4c028a290cf45c1589b16a191c7e8ba90f
+      src: rubygem-mongo-2.5.1-2.module+el8.1.0+3656+f80bfa1d.src.rpm
+      version: 2.5.1
+    - _class: ErratumPackage
+      arch: s390x
+      epoch: '0'
+      filename: rubygem-mysql2-0.4.10-4.module+el8.1.0+3656+f80bfa1d.s390x.rpm
+      md5sum: 0b5d2cbd8d5f514d4c0c990c31155498
+      name: rubygem-mysql2
+      reboot_suggested: false
+      release: 4.module+el8.1.0+3656+f80bfa1d
+      sha256sum: 2e90ff14aeb937067a3ac735a66fa80c2eb00886fb476434772f66cb4faf954b
+      src: rubygem-mongo-2.5.1-2.module+el8.1.0+3656+f80bfa1d.src.rpm
+      version: 0.4.10
+    - _class: ErratumPackage
+      arch: SRPMS
+      epoch: '0'
+      filename: rubygem-mysql2-0.4.10-4.module+el8.1.0+3656+f80bfa1d.src.rpm
+      md5sum: 9e1cd68b55f6e11efe9967dda1f958ae
+      name: rubygem-mysql2
+      reboot_suggested: false
+      release: 4.module+el8.1.0+3656+f80bfa1d
+      sha256sum: 7bd7206950c3bdbd8c81073410e7912f0dc35fc319fb2ee084786e446056587a
+      src: rubygem-mongo-2.5.1-2.module+el8.1.0+3656+f80bfa1d.src.rpm
+      version: 0.4.10
+    - _class: ErratumPackage
+      arch: s390x
+      epoch: '0'
+      filename: rubygem-mysql2-debuginfo-0.4.10-4.module+el8.1.0+3656+f80bfa1d.s390x.rpm
+      md5sum: 21ffd4f26ff8651d29ac51a0176e6f69
+      name: rubygem-mysql2-debuginfo
+      reboot_suggested: false
+      release: 4.module+el8.1.0+3656+f80bfa1d
+      sha256sum: d58c41cc8c32a5a0806ec4bc4e09347f7510ce2f3e0f506851590ba26fb8fc96
+      src: rubygem-mongo-2.5.1-2.module+el8.1.0+3656+f80bfa1d.src.rpm
+      version: 0.4.10
+    - _class: ErratumPackage
+      arch: s390x
+      epoch: '0'
+      filename: rubygem-mysql2-debugsource-0.4.10-4.module+el8.1.0+3656+f80bfa1d.s390x.rpm
+      md5sum: d3cea3259520aaa35645ab0b95234d08
+      name: rubygem-mysql2-debugsource
+      reboot_suggested: false
+      release: 4.module+el8.1.0+3656+f80bfa1d
+      sha256sum: 8441b837fda175718f6ded1ce82e5ef8ae5532460e9390451b0ecdcdb9aed6e9
+      src: rubygem-mongo-2.5.1-2.module+el8.1.0+3656+f80bfa1d.src.rpm
+      version: 0.4.10
+    - _class: ErratumPackage
+      arch: noarch
+      epoch: '0'
+      filename: rubygem-mysql2-doc-0.4.10-4.module+el8.1.0+3656+f80bfa1d.noarch.rpm
+      md5sum: b58e5ec1fb18490197d60834e5709e80
+      name: rubygem-mysql2-doc
+      reboot_suggested: false
+      release: 4.module+el8.1.0+3656+f80bfa1d
+      sha256sum: 1d25f8d911a95b4abc5649e738ef1bd649ecf60f1d7fca5f444ec154765620d3
+      src: rubygem-mongo-2.5.1-2.module+el8.1.0+3656+f80bfa1d.src.rpm
+      version: 0.4.10
+    - _class: ErratumPackage
+      arch: noarch
+      epoch: '0'
+      filename: rubygem-net-telnet-0.1.1-105.module+el8.1.0+3656+f80bfa1d.noarch.rpm
+      md5sum: b2375afcc76507d6feccf12ff75fc49a
+      name: rubygem-net-telnet
+      reboot_suggested: false
+      release: 105.module+el8.1.0+3656+f80bfa1d
+      sha256sum: e28f21a6f4f141d65cc8bff6e40f179cec29d77ba0e7b7c01943dc23b68d1751
+      src: rubygem-mongo-2.5.1-2.module+el8.1.0+3656+f80bfa1d.src.rpm
+      version: 0.1.1
+    - _class: ErratumPackage
+      arch: s390x
+      epoch: '0'
+      filename: rubygem-openssl-2.1.2-105.module+el8.1.0+3656+f80bfa1d.s390x.rpm
+      md5sum: fbf3f9ab2d485228d388e503e9c7c432
+      name: rubygem-openssl
+      reboot_suggested: false
+      release: 105.module+el8.1.0+3656+f80bfa1d
+      sha256sum: 4257e40953514e92279d2966c227e0c7ee94b75a2ad71e9f3db25ae1cca42e48
+      src: rubygem-mongo-2.5.1-2.module+el8.1.0+3656+f80bfa1d.src.rpm
+      version: 2.1.2
+    - _class: ErratumPackage
+      arch: s390x
+      epoch: '0'
+      filename: rubygem-openssl-debuginfo-2.1.2-105.module+el8.1.0+3656+f80bfa1d.s390x.rpm
+      md5sum: f112b4e3504d9ff930fea8afd4b39a42
+      name: rubygem-openssl-debuginfo
+      reboot_suggested: false
+      release: 105.module+el8.1.0+3656+f80bfa1d
+      sha256sum: ed148c9ff89587280d5dfd8b96bc68d5512222b47ad961ebd2938ff00757c6ab
+      src: rubygem-mongo-2.5.1-2.module+el8.1.0+3656+f80bfa1d.src.rpm
+      version: 2.1.2
+    - _class: ErratumPackage
+      arch: s390x
+      epoch: '0'
+      filename: rubygem-pg-1.0.0-2.module+el8.1.0+3656+f80bfa1d.s390x.rpm
+      md5sum: a958fdf022d065308d5766e443e96fe9
+      name: rubygem-pg
+      reboot_suggested: false
+      release: 2.module+el8.1.0+3656+f80bfa1d
+      sha256sum: f6260fc572346745bba3fd5b88975123079b14bffbd77e0926f371c692e364bc
+      src: rubygem-mongo-2.5.1-2.module+el8.1.0+3656+f80bfa1d.src.rpm
+      version: 1.0.0
+    - _class: ErratumPackage
+      arch: SRPMS
+      epoch: '0'
+      filename: rubygem-pg-1.0.0-2.module+el8.1.0+3656+f80bfa1d.src.rpm
+      md5sum: a9bdc2dd5d271638750c1293a875ad77
+      name: rubygem-pg
+      reboot_suggested: false
+      release: 2.module+el8.1.0+3656+f80bfa1d
+      sha256sum: 5e71aa5e93b054478e1f399862d6c8030cd459fe8ff8f5369d5660779efded04
+      src: rubygem-mongo-2.5.1-2.module+el8.1.0+3656+f80bfa1d.src.rpm
+      version: 1.0.0
+    - _class: ErratumPackage
+      arch: s390x
+      epoch: '0'
+      filename: rubygem-pg-debuginfo-1.0.0-2.module+el8.1.0+3656+f80bfa1d.s390x.rpm
+      md5sum: 652a4afd8f7e47699c076abee0a46731
+      name: rubygem-pg-debuginfo
+      reboot_suggested: false
+      release: 2.module+el8.1.0+3656+f80bfa1d
+      sha256sum: 745c21c3ea83a3c8c129d9a33e19d7eb36ffb77b471355dae24ccadd7ae0707a
+      src: rubygem-mongo-2.5.1-2.module+el8.1.0+3656+f80bfa1d.src.rpm
+      version: 1.0.0
+    - _class: ErratumPackage
+      arch: s390x
+      epoch: '0'
+      filename: rubygem-pg-debugsource-1.0.0-2.module+el8.1.0+3656+f80bfa1d.s390x.rpm
+      md5sum: 379f61b177b784d9ede8aa49b5cd159e
+      name: rubygem-pg-debugsource
+      reboot_suggested: false
+      release: 2.module+el8.1.0+3656+f80bfa1d
+      sha256sum: de1bb7e42c36ecfe95c360895c2b600ffb198ae0f9fea14c0e928e188a2af0c7
+      src: rubygem-mongo-2.5.1-2.module+el8.1.0+3656+f80bfa1d.src.rpm
+      version: 1.0.0
+    - _class: ErratumPackage
+      arch: noarch
+      epoch: '0'
+      filename: rubygem-pg-doc-1.0.0-2.module+el8.1.0+3656+f80bfa1d.noarch.rpm
+      md5sum: 6a578f72ba96eca4938404a8449b5f16
+      name: rubygem-pg-doc
+      reboot_suggested: false
+      release: 2.module+el8.1.0+3656+f80bfa1d
+      sha256sum: 9a74af094119652d9ff29127d9aadd9b67a46feb0a0c3102687d43b638a53dce
+      src: rubygem-mongo-2.5.1-2.module+el8.1.0+3656+f80bfa1d.src.rpm
+      version: 1.0.0
+    - _class: ErratumPackage
+      arch: noarch
+      epoch: '0'
+      filename: rubygem-power_assert-1.1.1-105.module+el8.1.0+3656+f80bfa1d.noarch.rpm
+      md5sum: e87bc67208ce3eb03d3abc054017598b
+      name: rubygem-power_assert
+      reboot_suggested: false
+      release: 105.module+el8.1.0+3656+f80bfa1d
+      sha256sum: e907b442294a0f7e84cc8e5ac60839c702bae4ad198c208b2870eb0aa35864d1
+      src: rubygem-mongo-2.5.1-2.module+el8.1.0+3656+f80bfa1d.src.rpm
+      version: 1.1.1
+    - _class: ErratumPackage
+      arch: s390x
+      epoch: '0'
+      filename: rubygem-psych-3.0.2-105.module+el8.1.0+3656+f80bfa1d.s390x.rpm
+      md5sum: 37e22f5bfb3025d733fb149615d3216d
+      name: rubygem-psych
+      reboot_suggested: false
+      release: 105.module+el8.1.0+3656+f80bfa1d
+      sha256sum: bb020505e50022404d61584d25d62928876402c46d394de4a4a7646d5be2a47c
+      src: rubygem-mongo-2.5.1-2.module+el8.1.0+3656+f80bfa1d.src.rpm
+      version: 3.0.2
+    - _class: ErratumPackage
+      arch: s390x
+      epoch: '0'
+      filename: rubygem-psych-debuginfo-3.0.2-105.module+el8.1.0+3656+f80bfa1d.s390x.rpm
+      md5sum: 5e6d7acc352bf7231c785f5bf2092e84
+      name: rubygem-psych-debuginfo
+      reboot_suggested: false
+      release: 105.module+el8.1.0+3656+f80bfa1d
+      sha256sum: 3390e0fd856a657383cd1cbcfb09d5b61462b1c716a0c2d6e6576af8f74f4967
+      src: rubygem-mongo-2.5.1-2.module+el8.1.0+3656+f80bfa1d.src.rpm
+      version: 3.0.2
+    - _class: ErratumPackage
+      arch: noarch
+      epoch: '0'
+      filename: rubygem-rake-12.3.0-105.module+el8.1.0+3656+f80bfa1d.noarch.rpm
+      md5sum: 0d536baf5e34db662ccfea564913a30d
+      name: rubygem-rake
+      reboot_suggested: false
+      release: 105.module+el8.1.0+3656+f80bfa1d
+      sha256sum: 36c8e13add7dccc90ccefacc2036da3637c0cf38da33c6379e5e759ec00301b5
+      src: rubygem-mongo-2.5.1-2.module+el8.1.0+3656+f80bfa1d.src.rpm
+      version: 12.3.0
+    - _class: ErratumPackage
+      arch: noarch
+      epoch: '0'
+      filename: rubygem-rdoc-6.0.1-105.module+el8.1.0+3656+f80bfa1d.noarch.rpm
+      md5sum: 2943e0d2c8a249abb6a405332cb85c12
+      name: rubygem-rdoc
+      reboot_suggested: false
+      release: 105.module+el8.1.0+3656+f80bfa1d
+      sha256sum: 5ee36835abbab4fc36ce732191ecb751f89020c92c03b4ed387c1171d4955819
+      src: rubygem-mongo-2.5.1-2.module+el8.1.0+3656+f80bfa1d.src.rpm
+      version: 6.0.1
+    - _class: ErratumPackage
+      arch: noarch
+      epoch: '0'
+      filename: rubygem-test-unit-3.2.7-105.module+el8.1.0+3656+f80bfa1d.noarch.rpm
+      md5sum: 1637e066d29aa755d864089dd1f8d1a3
+      name: rubygem-test-unit
+      reboot_suggested: false
+      release: 105.module+el8.1.0+3656+f80bfa1d
+      sha256sum: d4df4bad13e2cdeb9cbf022e4989ab940b0dced5b77d68a5ff694710c78d0da7
+      src: rubygem-mongo-2.5.1-2.module+el8.1.0+3656+f80bfa1d.src.rpm
+      version: 3.2.7
+    - _class: ErratumPackage
+      arch: noarch
+      epoch: '0'
+      filename: rubygem-xmlrpc-0.3.0-105.module+el8.1.0+3656+f80bfa1d.noarch.rpm
+      md5sum: d51d3fb7942200cc6b7e409eff96d734
+      name: rubygem-xmlrpc
+      reboot_suggested: false
+      release: 105.module+el8.1.0+3656+f80bfa1d
+      sha256sum: 0a245b8c8d2d4f07cf67ccedf9fd64707d2e737e729a75ef933e35a2d323993d
+      src: rubygem-mongo-2.5.1-2.module+el8.1.0+3656+f80bfa1d.src.rpm
+      version: 0.3.0
+    - _class: ErratumPackage
+      arch: noarch
+      epoch: '0'
+      filename: rubygems-2.7.6.2-105.module+el8.1.0+3656+f80bfa1d.noarch.rpm
+      md5sum: 9e86bdda0538344a6487fe5ffbeb7098
+      name: rubygems
+      reboot_suggested: false
+      release: 105.module+el8.1.0+3656+f80bfa1d
+      sha256sum: 9ef40ee367fc9edd93823856e0716e6a7ee7caebf48a67030e51269adb0cc952
+      src: rubygem-mongo-2.5.1-2.module+el8.1.0+3656+f80bfa1d.src.rpm
+      version: 2.7.6.2
+    - _class: ErratumPackage
+      arch: noarch
+      epoch: '0'
+      filename: rubygems-devel-2.7.6.2-105.module+el8.1.0+3656+f80bfa1d.noarch.rpm
+      md5sum: c7a349bb3056fd730a6828ab695c0531
+      name: rubygems-devel
+      reboot_suggested: false
+      release: 105.module+el8.1.0+3656+f80bfa1d
+      sha256sum: 0018c8abd50ddf6347d8b50a12d28e345cb1e963a825a177ad295cc86fc8406e
+      src: rubygem-mongo-2.5.1-2.module+el8.1.0+3656+f80bfa1d.src.rpm
+      version: 2.7.6.2
+    short: ''
+  pushcount: '5'
+  reboot_suggested: false
+  references:
+  - _class: ErratumReference
+    href: https://access.redhat.com/errata/RHBA-2019:3384
+    id: RHBA-2019:3384
+    title: RHBA-2019:3384
+    type: self
+  - _class: ErratumReference
+    href: https://bugzilla.redhat.com/show_bug.cgi?id=1719647
+    id: '1719647'
+    title: rdoc gzipped javascript pages are not the same across multilib
+    type: bugzilla
+  - _class: ErratumReference
+    href: https://access.redhat.com/security/cve/CVE-2019-8320
+    id: CVE-2019-8320
+    title: CVE-2019-8320
+    type: cve
+  - _class: ErratumReference
+    href: https://access.redhat.com/security/cve/CVE-2019-8321
+    id: CVE-2019-8321
+    title: CVE-2019-8321
+    type: cve
+  - _class: ErratumReference
+    href: https://access.redhat.com/security/cve/CVE-2019-8322
+    id: CVE-2019-8322
+    title: CVE-2019-8322
+    type: cve
+  - _class: ErratumReference
+    href: https://access.redhat.com/security/cve/CVE-2019-8323
+    id: CVE-2019-8323
+    title: CVE-2019-8323
+    type: cve
+  - _class: ErratumReference
+    href: https://access.redhat.com/security/cve/CVE-2019-8325
+    id: CVE-2019-8325
+    title: CVE-2019-8325
+    type: cve
+  - _class: ErratumReference
+    href: https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/8.1_release_notes/
+    id: ref_0
+    title: other_reference_0
+    type: other
+  release: '0'
+  repository_memberships:
+  - all-rpm-content
+  - dest1
+  rights: Copyright 2019 Red Hat Inc
+  severity: None
+  solution: 'Before applying this update, make sure all previously released errata
+
+    relevant to your system have been applied.
+
+
+    For details on how to apply this update, refer to:
+
+
+    https://access.redhat.com/articles/11258'
+  status: final
+  summary: An update for the ruby:2.5 module is now available for Red Hat Enterprise
+    Linux 8.
+  title: ruby:2.5 bug fix and enhancement update
+  type: bugfix
+  unit_id: (hidden)
+  updated: 2019-11-05 17:38:23 UTC
+  version: '5'
+- _class: ErratumUnit
+  content_types:
+  - rpm
+  description: 'The sudo packages contain the sudo utility which allows system administrators
+    to provide certain users with the permission to execute privileged commands, which
+    are used for system management purposes, without having to log in as root.
+
+
+    Security Fix(es):
+
+
+    * sudo: Stack based buffer overflow when pwfeedback is enabled (CVE-2019-18634)
+
+
+    For more details about the security issue(s), including the impact, a CVSS score,
+    acknowledgments, and other related information, refer to the CVE page(s) listed
+    in the References section.'
+  from_: release-engineering@redhat.com
+  id: RHSA-2020:0509
+  issued: 2020-02-13 19:00:11 UTC
+  pkglist:
+  - _class: ErratumPackageCollection
+    name: RHSA-2020:0509
+    packages:
+    - _class: ErratumPackage
+      arch: ppc64le
+      epoch: '0'
+      filename: sudo-1.8.25p1-4.el8_0.3.ppc64le.rpm
+      md5sum: 0d56f302617696d3511e71e1669e62c0
+      name: sudo
+      reboot_suggested: false
+      release: 4.el8_0.3
+      sha256sum: 31c4f73af90c6d267cc5281c59e4a93ae3557b2253d9a8e3fef55f3cafca6e54
+      src: sudo-1.8.25p1-4.el8_0.3.src.rpm
+      version: 1.8.25p1
+    - _class: ErratumPackage
+      arch: SRPMS
+      epoch: '0'
+      filename: sudo-1.8.25p1-4.el8_0.3.src.rpm
+      md5sum: f94ab3724b498e3faeab643fe2a67c9c
+      name: sudo
+      reboot_suggested: false
+      release: 4.el8_0.3
+      sha256sum: 10d7724302a60d0d2ca890fc7834b8143df55ba1ce0176469ea634ac4ab7aa28
+      src: sudo-1.8.25p1-4.el8_0.3.src.rpm
+      version: 1.8.25p1
+    - _class: ErratumPackage
+      arch: x86_64
+      epoch: '0'
+      filename: sudo-1.8.25p1-4.el8_0.3.x86_64.rpm
+      md5sum: 25e9470c4fe96034fe1d7525c04b5d8e
+      name: sudo
+      reboot_suggested: false
+      release: 4.el8_0.3
+      sha256sum: 593f872c1869f7beb963c8df2945fc691a1d999945c8c45c6bc7e02731fa016f
+      src: sudo-1.8.25p1-4.el8_0.3.src.rpm
+      version: 1.8.25p1
+    - _class: ErratumPackage
+      arch: ppc64le
+      epoch: '0'
+      filename: sudo-debuginfo-1.8.25p1-4.el8_0.3.ppc64le.rpm
+      md5sum: e242826fb38f487502cdc1f1a06991d2
+      name: sudo-debuginfo
+      reboot_suggested: false
+      release: 4.el8_0.3
+      sha256sum: 04db0c39efb31518ff79bf98d1c27256d46cdc72b967a5b2094a6efec3166df2
+      src: sudo-1.8.25p1-4.el8_0.3.src.rpm
+      version: 1.8.25p1
+    - _class: ErratumPackage
+      arch: x86_64
+      epoch: '0'
+      filename: sudo-debuginfo-1.8.25p1-4.el8_0.3.x86_64.rpm
+      md5sum: 91126f02975c06015880d6ea99cb2760
+      name: sudo-debuginfo
+      reboot_suggested: false
+      release: 4.el8_0.3
+      sha256sum: 1b7d3a7613236ffea7c4553eb9dea69fc19557005ac3a059d7e83efc08c5b754
+      src: sudo-1.8.25p1-4.el8_0.3.src.rpm
+      version: 1.8.25p1
+    - _class: ErratumPackage
+      arch: ppc64le
+      epoch: '0'
+      filename: sudo-debugsource-1.8.25p1-4.el8_0.3.ppc64le.rpm
+      md5sum: d6da7e2e3d9efe050fef2e8d047682be
+      name: sudo-debugsource
+      reboot_suggested: true
+      release: 4.el8_0.3
+      sha256sum: 355cbb9dc348b17782cff57120391685d6a1f6884facc54fac4b7fb54abeffba
+      src: sudo-1.8.25p1-4.el8_0.3.src.rpm
+      version: 1.8.25p1
+    - _class: ErratumPackage
+      arch: x86_64
+      epoch: '0'
+      filename: sudo-debugsource-1.8.25p1-4.el8_0.3.x86_64.rpm
+      md5sum: 6b0967941c0caf626c073dc7da0272b6
+      name: sudo-debugsource
+      reboot_suggested: false
+      release: 4.el8_0.3
+      sha256sum: 43e318fa49e4df685ea0d5f0925a00a336236b2e20f27f9365c39a48102c2cf6
+      src: sudo-1.8.25p1-4.el8_0.3.src.rpm
+      version: 1.8.25p1
+    short: ''
+  pushcount: '3'
+  reboot_suggested: false
+  references:
+  - _class: ErratumReference
+    href: https://access.redhat.com/errata/RHSA-2020:0509
+    type: self
+  - _class: ErratumReference
+    href: https://bugzilla.redhat.com/show_bug.cgi?id=1796944
+    id: '1796944'
+    title: 'CVE-2019-18634 sudo: Stack based buffer overflow when pwfeedback is enabled'
+    type: bugzilla
+  - _class: ErratumReference
+    href: https://www.redhat.com/security/data/cve/CVE-2019-18634.html
+    id: CVE-2019-18634
+    title: CVE-2019-18634
+    type: cve
+  - _class: ErratumReference
+    href: https://access.redhat.com/security/updates/classification/#important
+    id: classification
+    title: important
+    type: other
+  release: '0'
+  repository_memberships:
+  - all-rpm-content
+  - dest1
+  rights: Copyright 2020 Red Hat Inc
+  severity: Important
+  solution: 'For details on how to apply this update, which includes the changes described
+    in this advisory, refer to:
+
+
+    https://access.redhat.com/articles/11258'
+  status: final
+  summary: 'An update for sudo is now available for Red Hat Enterprise Linux 8.0 Update
+    Services for SAP Solutions.
+
+
+    Red Hat Product Security has rated this update as having a security impact of
+    Important. A Common Vulnerability Scoring System (CVSS) base score, which gives
+    a detailed severity rating, is available for each vulnerability from the CVE link(s)
+    in the References section.'
+  title: 'Important: sudo security update'
+  type: security
+  unit_id: (hidden)
+  updated: 2020-02-13 19:00:11 UTC
+  version: '3'
+- _class: FileUnit
+  cdn_path: /content/origin/files/sha256/31/315f5bdb76d078c43b8ac0064e4a0164612b1fce77c869345bfc94c75894edd3/some-file.txt
+  description: ''
+  path: some-file.txt
+  repository_memberships:
+  - iso-dest2
+  sha256sum: 315f5bdb76d078c43b8ac0064e4a0164612b1fce77c869345bfc94c75894edd3
+  size: 13
+  unit_id: (hidden)
+  version: 1.2.3
+- _class: FileUnit
+  cdn_path: /content/origin/files/sha256/d8/d8301c5f72f16455dbc300f3d1bef8972424255caad103cc6c7ba7dc92d90ca8/test.txt
+  path: test.txt
+  repository_memberships:
+  - iso-dest1
+  - iso-dest2
+  sha256sum: d8301c5f72f16455dbc300f3d1bef8972424255caad103cc6c7ba7dc92d90ca8
+  size: 33
+  unit_id: (hidden)
+- _class: FileUnit
+  cdn_path: /content/origin/files/sha256/db/db68c8a70f8383de71c107dca5fcfe53b1132186d1a6681d9ee3f4eea724fabb/some-iso
+  description: My wonderful ISO
+  display_order: 3.0
+  path: some-iso
+  repository_memberships:
+  - iso-dest2
+  sha256sum: db68c8a70f8383de71c107dca5fcfe53b1132186d1a6681d9ee3f4eea724fabb
+  size: 46
+  unit_id: (hidden)
+- _class: ModulemdDefaultsUnit
+  name: afterburn
+  profiles:
+    rolling:
+    - default
+  repo_id: dest1
+  repository_memberships:
+  - dest1
+  stream: rolling
+  unit_id: (hidden)
+- _class: ModulemdDefaultsUnit
+  name: ant
+  profiles:
+    '1.10':
+    - default
+  repo_id: dest1
+  repository_memberships:
+  - dest1
+  unit_id: (hidden)
+- _class: ModulemdDefaultsUnit
+  name: askalono-cli
+  profiles:
+    rolling:
+    - default
+  repo_id: dest1
+  repository_memberships:
+  - dest1
+  stream: rolling
+  unit_id: (hidden)
+- _class: ModulemdDefaultsUnit
+  name: avocado
+  profiles:
+    52lts:
+    - default
+    69lts:
+    - default
+    latest:
+    - default
+  repo_id: dest1
+  repository_memberships:
+  - dest1
+  stream: 52lts
+  unit_id: (hidden)
+- _class: ModulemdDefaultsUnit
+  name: bat
+  profiles:
+    latest:
+    - default
+  repo_id: dest1
+  repository_memberships:
+  - dest1
+  stream: latest
+  unit_id: (hidden)
+- _class: ModulemdDefaultsUnit
+  name: cbindgen
+  profiles:
+    rolling:
+    - default
+  repo_id: dest1
+  repository_memberships:
+  - dest1
+  stream: rolling
+  unit_id: (hidden)
+- _class: ModulemdDefaultsUnit
+  name: django
+  profiles:
+    '1.6':
+    - default
+  repo_id: dest1
+  repository_memberships:
+  - dest1
+  unit_id: (hidden)
+- _class: ModulemdDefaultsUnit
+  name: dwm
+  profiles:
+    '6.0':
+    - default
+    '6.1':
+    - default
+    '6.2':
+    - default
+    latest:
+    - default
+  repo_id: dest1
+  repository_memberships:
+  - dest1
+  stream: '6.1'
+  unit_id: (hidden)
+- _class: ModulemdDefaultsUnit
+  name: fd-find
+  profiles:
+    rolling:
+    - default
+  repo_id: dest1
+  repository_memberships:
+  - dest1
+  stream: rolling
+  unit_id: (hidden)
+- _class: ModulemdDefaultsUnit
+  name: ffsend
+  profiles:
+    latest:
+    - default
+  repo_id: dest1
+  repository_memberships:
+  - dest1
+  stream: latest
+  unit_id: (hidden)
+- _class: ModulemdDefaultsUnit
+  name: ghc
+  profiles:
+    '8.4':
+    - default
+    '8.6':
+    - default
+    '8.8':
+    - default
+  repo_id: dest1
+  repository_memberships:
+  - dest1
+  unit_id: (hidden)
+- _class: ModulemdDefaultsUnit
+  name: gimp
+  profiles:
+    '2.10':
+    - default
+  repo_id: dest1
+  repository_memberships:
+  - dest1
+  unit_id: (hidden)
+- _class: ModulemdDefaultsUnit
+  name: heatseeker
+  profiles:
+    latest:
+    - default
+  repo_id: dest1
+  repository_memberships:
+  - dest1
+  stream: latest
+  unit_id: (hidden)
+- _class: ModulemdDefaultsUnit
+  name: hyperfine
+  profiles:
+    latest:
+    - default
+  repo_id: dest1
+  repository_memberships:
+  - dest1
+  stream: latest
+  unit_id: (hidden)
+- _class: ModulemdDefaultsUnit
+  name: jmc
+  profiles:
+    latest:
+    - default
+  repo_id: dest1
+  repository_memberships:
+  - dest1
+  unit_id: (hidden)
+- _class: ModulemdDefaultsUnit
+  name: lsd
+  profiles:
+    rolling:
+    - default
+  repo_id: dest1
+  repository_memberships:
+  - dest1
+  stream: rolling
+  unit_id: (hidden)
+- _class: ModulemdDefaultsUnit
+  name: mariadb
+  profiles:
+    '10.1':
+    - server
+    '10.2':
+    - server
+    '10.3':
+    - server
+    '10.4':
+    - server
+  repo_id: dest1
+  repository_memberships:
+  - dest1
+  unit_id: (hidden)
+- _class: ModulemdDefaultsUnit
+  name: minetest
+  profiles:
+    '5':
+    - client
+  repo_id: dest1
+  repository_memberships:
+  - dest1
+  unit_id: (hidden)
+- _class: ModulemdDefaultsUnit
+  name: nest
+  profiles:
+    2.16.0:
+    - default
+    2.18.0:
+    - default
+  repo_id: dest1
+  repository_memberships:
+  - dest1
+  unit_id: (hidden)
+- _class: ModulemdDefaultsUnit
+  name: nodejs
+  profiles:
+    '10':
+    - default
+    '11':
+    - default
+    '8':
+    - default
+  repo_id: dest1
+  repository_memberships:
+  - dest1
+  unit_id: (hidden)
+- _class: ModulemdDefaultsUnit
+  name: pretty-git-prompt
+  profiles:
+    rolling:
+    - default
+  repo_id: dest1
+  repository_memberships:
+  - dest1
+  stream: rolling
+  unit_id: (hidden)
+- _class: ModulemdDefaultsUnit
+  name: reviewboard
+  profiles:
+    '2.5':
+    - default
+    '3.0':
+    - default
+  repo_id: dest1
+  repository_memberships:
+  - dest1
+  unit_id: (hidden)
+- _class: ModulemdDefaultsUnit
+  name: sd
+  profiles:
+    rolling:
+    - default
+  repo_id: dest1
+  repository_memberships:
+  - dest1
+  stream: rolling
+  unit_id: (hidden)
+- _class: ModulemdDefaultsUnit
+  name: silver
+  profiles:
+    rolling:
+    - default
+  repo_id: dest1
+  repository_memberships:
+  - dest1
+  stream: rolling
+  unit_id: (hidden)
+- _class: ModulemdDefaultsUnit
+  name: skim
+  profiles:
+    rolling:
+    - default
+  repo_id: dest1
+  repository_memberships:
+  - dest1
+  stream: rolling
+  unit_id: (hidden)
+- _class: ModulemdDefaultsUnit
+  name: stratis
+  profiles:
+    '1':
+    - default
+  repo_id: dest1
+  repository_memberships:
+  - dest1
+  stream: '1'
+  unit_id: (hidden)
+- _class: ModulemdDefaultsUnit
+  name: tokei
+  profiles:
+    rolling:
+    - default
+  repo_id: dest1
+  repository_memberships:
+  - dest1
+  stream: rolling
+  unit_id: (hidden)
+- _class: ModulemdDefaultsUnit
+  name: zola
+  profiles:
+    rolling:
+    - default
+  repo_id: dest1
+  repository_memberships:
+  - dest1
+  stream: rolling
+  unit_id: (hidden)
+- _class: ModulemdUnit
+  arch: x86_64
+  artifacts:
+  - ReviewBoard-0:3.0.15-1.module_f29+4698+c4b8fe8e.noarch
+  - ReviewBoard-0:3.0.15-1.module_f29+4698+c4b8fe8e.src
+  - python-asana-0:0.7.0-3.module_f29+3074+f1a28b49.src
+  - python-django-braces-0:1.12.0-3.module_f29+3074+f1a28b49.src
+  - python-django-cors-headers-0:1.1.0-1.module_f29+3074+f1a28b49.src
+  - python-django-evolution-1:0.7.7-13.module_f29+3074+f1a28b49.src
+  - python-django-haystack-0:2.4.1-13.module_f29+3074+f1a28b49.src
+  - python-django-haystack-docs-0:2.4.1-13.module_f29+3074+f1a28b49.noarch
+  - python-django-multiselectfield-0:0.1.3-10.module_f29+3074+f1a28b49.src
+  - python-django-oauth-toolkit-0:0.9.0-3.module_f29+3074+f1a28b49.src
+  - python-django-pipeline-0:1.6.14-2.module_f29+3074+f1a28b49.src
+  - python-djblets-0:1.0.12-1.module_f29+4698+c4b8fe8e.src
+  - python-jwt-0:1.6.4-2.2.module_f29+3074+f1a28b49.src
+  - python-oauthlib-0:1.0.3-6.module_f29+3074+f1a28b49.src
+  - python-publicsuffix-0:1.1.0-7.1.module_f29+3074+f1a28b49.src
+  - python-pymdown-extensions-0:3.5-5.module_f29+3074+f1a28b49.src
+  - python-requests-oauthlib-0:0.8.0-7.module_f29+3074+f1a28b49.src
+  - python2-asana-0:0.7.0-3.module_f29+3074+f1a28b49.noarch
+  - python2-django-braces-0:1.12.0-3.module_f29+3074+f1a28b49.noarch
+  - python2-django-cors-headers-0:1.1.0-1.module_f29+3074+f1a28b49.noarch
+  - python2-django-evolution-1:0.7.7-13.module_f29+3074+f1a28b49.noarch
+  - python2-django-haystack-0:2.4.1-13.module_f29+3074+f1a28b49.noarch
+  - python2-django-multiselectfield-0:0.1.3-10.module_f29+3074+f1a28b49.noarch
+  - python2-django-oauth-toolkit-0:0.9.0-3.module_f29+3074+f1a28b49.noarch
+  - python2-django-pipeline-0:1.6.14-2.module_f29+3074+f1a28b49.noarch
+  - python2-djblets-0:1.0.12-1.module_f29+4698+c4b8fe8e.noarch
+  - python2-jwt-0:1.6.4-2.2.module_f29+3074+f1a28b49.noarch
+  - python2-oauthlib-0:1.0.3-6.module_f29+3074+f1a28b49.noarch
+  - python2-publicsuffix-0:1.1.0-7.1.module_f29+3074+f1a28b49.noarch
+  - python2-pymdown-extensions-0:3.5-5.module_f29+3074+f1a28b49.noarch
+  - python2-requests-oauthlib-0:0.8.0-7.module_f29+3074+f1a28b49.noarch
+  - python3-django-cors-headers-0:1.1.0-1.module_f29+3074+f1a28b49.noarch
+  - python3-jwt-0:1.6.4-2.2.module_f29+3074+f1a28b49.noarch
+  - python3-oauthlib-0:1.0.3-6.module_f29+3074+f1a28b49.noarch
+  - python3-publicsuffix-0:1.1.0-7.1.module_f29+3074+f1a28b49.noarch
+  - python3-requests-oauthlib-0:0.8.0-7.module_f29+3074+f1a28b49.noarch
+  context: 083bce86
+  dependencies:
+  - _class: ModulemdDependency
+    name: django
+    stream: '1.6'
+  name: reviewboard
+  profiles:
+    default:
+      rpms:
+      - ReviewBoard
+    server:
+      rpms:
+      - ReviewBoard
+  repository_memberships:
+  - dest1
+  stream: '3.0'
+  unit_id: (hidden)
+  version: 2920190612150956
+- _class: ModulemdUnit
+  arch: x86_64
+  artifacts:
+  - afterburn-0:4.1.2-1.module_f29+5199+bbb16d9a.x86_64
+  - afterburn-debuginfo-0:4.1.2-1.module_f29+5199+bbb16d9a.x86_64
+  - afterburn-dracut-0:4.1.2-1.module_f29+5199+bbb16d9a.x86_64
+  - rust-afterburn-0:4.1.2-1.module_f29+5199+bbb16d9a.src
+  - rust-afterburn-debugsource-0:4.1.2-1.module_f29+5199+bbb16d9a.x86_64
+  context: c5ebb199
+  dependencies: []
+  name: afterburn
+  profiles:
+    default:
+      rpms:
+      - afterburn
+  repository_memberships:
+  - dest1
+  stream: rolling
+  unit_id: (hidden)
+  version: 2920190724160424
+- _class: ModulemdUnit
+  arch: x86_64
+  artifacts:
+  - ant-0:1.10.5-3.module_f28+4207+d722d224.noarch
+  - ant-0:1.10.5-3.module_f28+4207+d722d224.src
+  - ant-antlr-0:1.10.5-3.module_f28+4207+d722d224.noarch
+  - ant-apache-bcel-0:1.10.5-3.module_f28+4207+d722d224.noarch
+  - ant-apache-bsf-0:1.10.5-3.module_f28+4207+d722d224.noarch
+  - ant-apache-log4j-0:1.10.5-3.module_f28+4207+d722d224.noarch
+  - ant-apache-oro-0:1.10.5-3.module_f28+4207+d722d224.noarch
+  - ant-apache-regexp-0:1.10.5-3.module_f28+4207+d722d224.noarch
+  - ant-apache-resolver-0:1.10.5-3.module_f28+4207+d722d224.noarch
+  - ant-apache-xalan2-0:1.10.5-3.module_f28+4207+d722d224.noarch
+  - ant-commons-logging-0:1.10.5-3.module_f28+4207+d722d224.noarch
+  - ant-commons-net-0:1.10.5-3.module_f28+4207+d722d224.noarch
+  - ant-javamail-0:1.10.5-3.module_f28+4207+d722d224.noarch
+  - ant-jdepend-0:1.10.5-3.module_f28+4207+d722d224.noarch
+  - ant-jmf-0:1.10.5-3.module_f28+4207+d722d224.noarch
+  - ant-jsch-0:1.10.5-3.module_f28+4207+d722d224.noarch
+  - ant-junit-0:1.10.5-3.module_f28+4207+d722d224.noarch
+  - ant-junit5-0:1.10.5-3.module_f28+4207+d722d224.noarch
+  - ant-lib-0:1.10.5-3.module_f28+4207+d722d224.noarch
+  - ant-swing-0:1.10.5-3.module_f28+4207+d722d224.noarch
+  - ant-testutil-0:1.10.5-3.module_f28+4207+d722d224.noarch
+  - ant-xz-0:1.10.5-3.module_f28+4207+d722d224.noarch
+  - antlr-0:2.7.7-56.module_f28+3872+5b76729e.src
+  - antlr-C++-doc-0:2.7.7-56.module_f28+3872+5b76729e.noarch
+  - antlr-tool-0:2.7.7-56.module_f28+3872+5b76729e.noarch
+  - apache-commons-logging-0:1.2-13.module_f28+3872+5b76729e.noarch
+  - apache-commons-logging-0:1.2-13.module_f28+3872+5b76729e.src
+  - apache-commons-net-0:3.6-3.module_f28+3872+5b76729e.noarch
+  - apache-commons-net-0:3.6-3.module_f28+3872+5b76729e.src
+  - bcel-0:6.2-2.module_f28+3872+5b76729e.noarch
+  - bcel-0:6.2-2.module_f28+3872+5b76729e.src
+  - bsf-0:2.4.0-30.module_f28+3872+5b76729e.noarch
+  - bsf-0:2.4.0-30.module_f28+3872+5b76729e.src
+  - hamcrest-0:1.3-23.module_f28+3872+5b76729e.noarch
+  - hamcrest-0:1.3-23.module_f28+3872+5b76729e.src
+  - hamcrest-core-0:1.3-23.module_f28+3872+5b76729e.noarch
+  - jakarta-oro-0:2.0.8-23.module_f28+3872+5b76729e.noarch
+  - jakarta-oro-0:2.0.8-23.module_f28+3872+5b76729e.src
+  - javamail-0:1.5.2-7.module_f28+3872+5b76729e.noarch
+  - javamail-0:1.5.2-7.module_f28+3872+5b76729e.src
+  - jdepend-0:2.9.1-18.module_f28+3872+5b76729e.noarch
+  - jdepend-0:2.9.1-18.module_f28+3872+5b76729e.src
+  - jsch-0:0.1.54-7.module_f28+3872+5b76729e.noarch
+  - jsch-0:0.1.54-7.module_f28+3872+5b76729e.src
+  - junit-1:4.12-9.module_f28+3872+5b76729e.noarch
+  - junit-1:4.12-9.module_f28+3872+5b76729e.src
+  - junit5-0:5.4.0-1.module_f28+3873+06cd63fa.noarch
+  - junit5-0:5.4.0-1.module_f28+3873+06cd63fa.src
+  - jzlib-0:1.1.3-8.module_f28+3872+5b76729e.noarch
+  - jzlib-0:1.1.3-8.module_f28+3872+5b76729e.src
+  - log4j12-0:1.2.17-22.module_f28+3872+5b76729e.noarch
+  - log4j12-0:1.2.17-22.module_f28+3872+5b76729e.src
+  - opentest4j-0:1.1.1-1.module_f28+3873+06cd63fa.noarch
+  - opentest4j-0:1.1.1-1.module_f28+3873+06cd63fa.src
+  - python2-antlr-0:2.7.7-56.module_f28+3872+5b76729e.noarch
+  - regexp-1:1.5-26.module_f28+3872+5b76729e.noarch
+  - regexp-1:1.5-26.module_f28+3872+5b76729e.src
+  - univocity-parsers-0:2.5.5-5.module_f28+3873+06cd63fa.noarch
+  - univocity-parsers-0:2.5.5-5.module_f28+3873+06cd63fa.src
+  - xalan-j2-0:2.7.1-38.module_f28+3872+5b76729e.noarch
+  - xalan-j2-0:2.7.1-38.module_f28+3872+5b76729e.src
+  - xerces-j2-0:2.11.0-34.module_f28+3872+5b76729e.noarch
+  - xerces-j2-0:2.11.0-34.module_f28+3872+5b76729e.src
+  - xml-commons-apis-0:1.4.01-25.module_f28+3872+5b76729e.noarch
+  - xml-commons-apis-0:1.4.01-25.module_f28+3872+5b76729e.src
+  - xml-commons-resolver-0:1.2-26.module_f28+3872+5b76729e.noarch
+  - xml-commons-resolver-0:1.2-26.module_f28+3872+5b76729e.src
+  - xz-java-0:1.8-2.module_f28+3872+5b76729e.noarch
+  - xz-java-0:1.8-2.module_f28+3872+5b76729e.src
+  context: 819b5873
+  dependencies: []
+  name: ant
+  profiles:
+    default:
+      rpms:
+      - ant
+  repository_memberships:
+  - dest1
+  stream: '1.10'
+  unit_id: (hidden)
+  version: 2820190507144406
+- _class: ModulemdUnit
+  arch: x86_64
+  artifacts:
+  - askalono-cli-0:0.3.0-2.module_f29+5146+528cc3aa.x86_64
+  - askalono-cli-debuginfo-0:0.3.0-2.module_f29+5146+528cc3aa.x86_64
+  - rust-askalono-cli-0:0.3.0-2.module_f29+5146+528cc3aa.src
+  - rust-askalono-cli-debugsource-0:0.3.0-2.module_f29+5146+528cc3aa.x86_64
+  context: c5ebb199
+  dependencies: []
+  name: askalono-cli
+  profiles:
+    default:
+      rpms:
+      - askalono-cli
+  repository_memberships:
+  - dest1
+  stream: rolling
+  unit_id: (hidden)
+  version: 2920190721090701
+- _class: ModulemdUnit
+  arch: x86_64
+  artifacts:
+  - bat-0:0.11.0-3.module_f29+5047+0e01e54b.x86_64
+  - bat-debuginfo-0:0.11.0-3.module_f29+5047+0e01e54b.x86_64
+  - rust-bat-0:0.11.0-3.module_f29+5047+0e01e54b.src
+  - rust-bat-debugsource-0:0.11.0-3.module_f29+5047+0e01e54b.x86_64
+  context: c5ebb199
+  dependencies: []
+  name: bat
+  profiles:
+    default:
+      rpms:
+      - bat
+  repository_memberships:
+  - dest1
+  stream: latest
+  unit_id: (hidden)
+  version: 2920190714171319
+- _class: ModulemdUnit
+  arch: x86_64
+  artifacts:
+  - byteman-0:4.0.5-1.module_2517+4757d934.noarch
+  - byteman-0:4.0.5-1.module_2517+4757d934.src
+  - byteman-bmunit-0:4.0.5-1.module_2517+4757d934.noarch
+  - byteman-dtest-0:4.0.5-1.module_2517+4757d934.noarch
+  - byteman-rulecheck-maven-plugin-0:4.0.5-1.module_2517+4757d934.noarch
+  - objectweb-asm-0:7.0-2.module_2517+4757d934.noarch
+  - objectweb-asm-0:7.0-2.module_2517+4757d934.src
+  context: 6c81f848
+  dependencies: []
+  name: byteman
+  profiles:
+    default:
+      rpms:
+      - byteman
+  repository_memberships:
+  - dest1
+  stream: byteman
+  unit_id: (hidden)
+  version: 20181123145910
+- _class: ModulemdUnit
+  arch: x86_64
+  artifacts:
+  - c-ares-0:1.15.0-3.module_f29+3904+fe551d18.src
+  - c-ares-0:1.15.0-3.module_f29+3904+fe551d18.x86_64
+  - c-ares-debuginfo-0:1.15.0-3.module_f29+3904+fe551d18.x86_64
+  - c-ares-debugsource-0:1.15.0-3.module_f29+3904+fe551d18.x86_64
+  - c-ares-devel-0:1.15.0-3.module_f29+3904+fe551d18.x86_64
+  - http-parser-0:2.9.2-1.module_f29+4062+460da852.src
+  - http-parser-0:2.9.2-1.module_f29+4062+460da852.x86_64
+  - http-parser-debuginfo-0:2.9.2-1.module_f29+4062+460da852.x86_64
+  - http-parser-debugsource-0:2.9.2-1.module_f29+4062+460da852.x86_64
+  - http-parser-devel-0:2.9.2-1.module_f29+4062+460da852.x86_64
+  - libnghttp2-0:1.38.0-1.module_f29+4062+460da852.x86_64
+  - libnghttp2-debuginfo-0:1.38.0-1.module_f29+4062+460da852.x86_64
+  - libnghttp2-devel-0:1.38.0-1.module_f29+4062+460da852.x86_64
+  - libuv-1:1.28.0-1.module_f29+4062+460da852.src
+  - libuv-1:1.28.0-1.module_f29+4062+460da852.x86_64
+  - libuv-debuginfo-1:1.28.0-1.module_f29+4062+460da852.x86_64
+  - libuv-debugsource-1:1.28.0-1.module_f29+4062+460da852.x86_64
+  - libuv-devel-1:1.28.0-1.module_f29+4062+460da852.x86_64
+  - libuv-static-1:1.28.0-1.module_f29+4062+460da852.x86_64
+  - nghttp2-0:1.38.0-1.module_f29+4062+460da852.src
+  - nghttp2-0:1.38.0-1.module_f29+4062+460da852.x86_64
+  - nghttp2-debuginfo-0:1.38.0-1.module_f29+4062+460da852.x86_64
+  - nghttp2-debugsource-0:1.38.0-1.module_f29+4062+460da852.x86_64
+  - nodejs-1:11.14.0-2.module_f29+4062+460da852.src
+  - nodejs-1:11.14.0-2.module_f29+4062+460da852.x86_64
+  - nodejs-debuginfo-1:11.14.0-2.module_f29+4062+460da852.x86_64
+  - nodejs-debugsource-1:11.14.0-2.module_f29+4062+460da852.x86_64
+  - nodejs-devel-1:11.14.0-2.module_f29+4062+460da852.x86_64
+  - nodejs-docs-1:11.14.0-2.module_f29+4062+460da852.noarch
+  - nodejs-libs-1:11.14.0-2.module_f29+4062+460da852.x86_64
+  - nodejs-libs-debuginfo-1:11.14.0-2.module_f29+4062+460da852.x86_64
+  - npm-1:6.7.0-1.11.14.0.2.module_f29+4062+460da852.x86_64
+  - v8-devel-1:7.0.276.38-2.module_f29+4062+460da852.x86_64
+  context: 6c81f848
+  dependencies: []
+  name: nodejs
+  profiles:
+    default:
+      rpms:
+      - nodejs
+      - npm
+    development:
+      rpms:
+      - nodejs
+      - nodejs-devel
+      - npm
+    minimal:
+      rpms:
+      - nodejs
+  repository_memberships:
+  - dest1
+  stream: '11'
+  unit_id: (hidden)
+  version: 2920190424132604
+- _class: ModulemdUnit
+  arch: x86_64
+  artifacts:
+  - c-ares-0:1.15.0-3.module_f29+3973+0f3d85d2.src
+  - c-ares-0:1.15.0-3.module_f29+3973+0f3d85d2.x86_64
+  - c-ares-debuginfo-0:1.15.0-3.module_f29+3973+0f3d85d2.x86_64
+  - c-ares-debugsource-0:1.15.0-3.module_f29+3973+0f3d85d2.x86_64
+  - c-ares-devel-0:1.15.0-3.module_f29+3973+0f3d85d2.x86_64
+  - http-parser-0:2.9.2-1.module_f29+3973+0f3d85d2.src
+  - http-parser-0:2.9.2-1.module_f29+3973+0f3d85d2.x86_64
+  - http-parser-debuginfo-0:2.9.2-1.module_f29+3973+0f3d85d2.x86_64
+  - http-parser-debugsource-0:2.9.2-1.module_f29+3973+0f3d85d2.x86_64
+  - http-parser-devel-0:2.9.2-1.module_f29+3973+0f3d85d2.x86_64
+  - libnghttp2-0:1.38.0-1.module_f29+3973+0f3d85d2.x86_64
+  - libnghttp2-debuginfo-0:1.38.0-1.module_f29+3973+0f3d85d2.x86_64
+  - libnghttp2-devel-0:1.38.0-1.module_f29+3973+0f3d85d2.x86_64
+  - libuv-1:1.27.0-1.module_f29+3973+0f3d85d2.src
+  - libuv-1:1.27.0-1.module_f29+3973+0f3d85d2.x86_64
+  - libuv-debuginfo-1:1.27.0-1.module_f29+3973+0f3d85d2.x86_64
+  - libuv-debugsource-1:1.27.0-1.module_f29+3973+0f3d85d2.x86_64
+  - libuv-devel-1:1.27.0-1.module_f29+3973+0f3d85d2.x86_64
+  - libuv-static-1:1.27.0-1.module_f29+3973+0f3d85d2.x86_64
+  - nghttp2-0:1.38.0-1.module_f29+3973+0f3d85d2.src
+  - nghttp2-0:1.38.0-1.module_f29+3973+0f3d85d2.x86_64
+  - nghttp2-debuginfo-0:1.38.0-1.module_f29+3973+0f3d85d2.x86_64
+  - nghttp2-debugsource-0:1.38.0-1.module_f29+3973+0f3d85d2.x86_64
+  - nodejs-1:8.16.0-1.module_f29+3973+0f3d85d2.src
+  - nodejs-1:8.16.0-1.module_f29+3973+0f3d85d2.x86_64
+  - nodejs-debuginfo-1:8.16.0-1.module_f29+3973+0f3d85d2.x86_64
+  - nodejs-debugsource-1:8.16.0-1.module_f29+3973+0f3d85d2.x86_64
+  - nodejs-devel-1:8.16.0-1.module_f29+3973+0f3d85d2.x86_64
+  - nodejs-docs-1:8.16.0-1.module_f29+3973+0f3d85d2.noarch
+  - npm-1:6.4.1-1.8.16.0.1.module_f29+3973+0f3d85d2.x86_64
+  context: 6c81f848
+  dependencies: []
+  name: nodejs
+  profiles:
+    default:
+      rpms:
+      - nodejs
+      - npm
+    development:
+      rpms:
+      - nodejs
+      - nodejs-devel
+      - npm
+    minimal:
+      rpms:
+      - nodejs
+  repository_memberships:
+  - dest1
+  stream: '8'
+  unit_id: (hidden)
+  version: 2920190423151514
+- _class: ModulemdUnit
+  arch: x86_64
+  artifacts:
+  - c-ares-0:1.15.0-4.module_f29+5261+6b332ff4.src
+  - c-ares-0:1.15.0-4.module_f29+5261+6b332ff4.x86_64
+  - c-ares-debuginfo-0:1.15.0-4.module_f29+5261+6b332ff4.x86_64
+  - c-ares-debugsource-0:1.15.0-4.module_f29+5261+6b332ff4.x86_64
+  - c-ares-devel-0:1.15.0-4.module_f29+5261+6b332ff4.x86_64
+  - libnghttp2-0:1.39.2-1.module_f29+5950+7595ea0f.x86_64
+  - libnghttp2-debuginfo-0:1.39.2-1.module_f29+5950+7595ea0f.x86_64
+  - libnghttp2-devel-0:1.39.2-1.module_f29+5950+7595ea0f.x86_64
+  - libuv-1:1.31.0-0.module_f29+5978+645d6d80.src
+  - libuv-1:1.31.0-0.module_f29+5978+645d6d80.x86_64
+  - libuv-debuginfo-1:1.31.0-0.module_f29+5978+645d6d80.x86_64
+  - libuv-debugsource-1:1.31.0-0.module_f29+5978+645d6d80.x86_64
+  - libuv-devel-1:1.31.0-0.module_f29+5978+645d6d80.x86_64
+  - libuv-static-1:1.31.0-0.module_f29+5978+645d6d80.x86_64
+  - nghttp2-0:1.39.2-1.module_f29+5950+7595ea0f.src
+  - nghttp2-0:1.39.2-1.module_f29+5950+7595ea0f.x86_64
+  - nghttp2-debuginfo-0:1.39.2-1.module_f29+5950+7595ea0f.x86_64
+  - nghttp2-debugsource-0:1.39.2-1.module_f29+5950+7595ea0f.x86_64
+  - nodejs-1:12.10.0-1.fc29.src
+  - nodejs-1:12.10.0-1.fc29.x86_64
+  - nodejs-debuginfo-1:12.10.0-1.fc29.x86_64
+  - nodejs-debugsource-1:12.10.0-1.fc29.x86_64
+  - nodejs-devel-1:12.10.0-1.fc29.x86_64
+  - nodejs-docs-1:12.10.0-1.fc29.noarch
+  - nodejs-libs-1:12.10.0-1.fc29.x86_64
+  - nodejs-libs-debuginfo-1:12.10.0-1.fc29.x86_64
+  - npm-1:6.10.3-1.12.10.0.1.fc29.x86_64
+  - v8-devel-2:7.6.303.29-1.12.10.0.1.fc29.x86_64
+  context: 6c81f848
+  dependencies: []
+  name: nodejs
+  profiles:
+    default:
+      rpms:
+      - nodejs
+      - npm
+    development:
+      rpms:
+      - nodejs
+      - nodejs-devel
+      - npm
+    minimal:
+      rpms:
+      - nodejs
+  repository_memberships:
+  - dest1
+  stream: '12'
+  unit_id: (hidden)
+  version: 2920190905142236
+- _class: ModulemdUnit
+  arch: x86_64
+  artifacts:
+  - cbindgen-0:0.8.7-1.module_f29+4276+b3f4a155.x86_64
+  - cbindgen-debuginfo-0:0.8.7-1.module_f29+4276+b3f4a155.x86_64
+  - rust-cbindgen-0:0.8.7-1.module_f29+4276+b3f4a155.src
+  - rust-cbindgen-debugsource-0:0.8.7-1.module_f29+4276+b3f4a155.x86_64
+  context: b8a06959
+  dependencies: []
+  name: cbindgen
+  profiles:
+    default:
+      rpms:
+      - cbindgen
+  repository_memberships:
+  - dest1
+  stream: rolling
+  unit_id: (hidden)
+  version: 2920190515070043
+- _class: ModulemdUnit
+  arch: x86_64
+  artifacts:
+  - community-mysql-0:8.0.17-2.module_f29+6047+dcfd13cb.src
+  - community-mysql-0:8.0.17-2.module_f29+6047+dcfd13cb.x86_64
+  - community-mysql-common-0:8.0.17-2.module_f29+6047+dcfd13cb.x86_64
+  - community-mysql-debuginfo-0:8.0.17-2.module_f29+6047+dcfd13cb.x86_64
+  - community-mysql-debugsource-0:8.0.17-2.module_f29+6047+dcfd13cb.x86_64
+  - community-mysql-devel-0:8.0.17-2.module_f29+6047+dcfd13cb.x86_64
+  - community-mysql-devel-debuginfo-0:8.0.17-2.module_f29+6047+dcfd13cb.x86_64
+  - community-mysql-errmsg-0:8.0.17-2.module_f29+6047+dcfd13cb.x86_64
+  - community-mysql-libs-0:8.0.17-2.module_f29+6047+dcfd13cb.x86_64
+  - community-mysql-libs-debuginfo-0:8.0.17-2.module_f29+6047+dcfd13cb.x86_64
+  - community-mysql-server-0:8.0.17-2.module_f29+6047+dcfd13cb.x86_64
+  - community-mysql-server-debuginfo-0:8.0.17-2.module_f29+6047+dcfd13cb.x86_64
+  - community-mysql-test-0:8.0.17-2.module_f29+6047+dcfd13cb.x86_64
+  - community-mysql-test-debuginfo-0:8.0.17-2.module_f29+6047+dcfd13cb.x86_64
+  context: 6c81f848
+  dependencies: []
+  name: mysql
+  profiles:
+    client:
+      description: Client.
+      rpms:
+      - community-mysql
+    devel:
+      description: Devel package.
+      rpms:
+      - community-mysql-devel
+    server:
+      description: Base server.
+      rpms:
+      - community-mysql-server
+  repository_memberships:
+  - dest1
+  stream: '8.0'
+  unit_id: (hidden)
+  version: 2920190823234131
+- _class: ModulemdUnit
+  arch: x86_64
+  artifacts:
+  - conmon-2:1.12.6-1.git2f0cb0d.module_f29+3064+a0dd0d52.x86_64
+  - conmon-debuginfo-2:1.12.6-1.git2f0cb0d.module_f29+3064+a0dd0d52.x86_64
+  - cri-o-2:1.12.6-1.git2f0cb0d.module_f29+3064+a0dd0d52.src
+  - cri-o-2:1.12.6-1.git2f0cb0d.module_f29+3064+a0dd0d52.x86_64
+  - cri-o-debuginfo-2:1.12.6-1.git2f0cb0d.module_f29+3064+a0dd0d52.x86_64
+  - cri-o-debugsource-2:1.12.6-1.git2f0cb0d.module_f29+3064+a0dd0d52.x86_64
+  - cri-tools-0:1.12.0-1.gite4dff19.module_f29+3064+a0dd0d52.src
+  - cri-tools-0:1.12.0-1.gite4dff19.module_f29+3064+a0dd0d52.x86_64
+  - cri-tools-debuginfo-0:1.12.0-1.gite4dff19.module_f29+3064+a0dd0d52.x86_64
+  - cri-tools-debugsource-0:1.12.0-1.gite4dff19.module_f29+3064+a0dd0d52.x86_64
+  context: 6c81f848
+  dependencies: []
+  name: cri-o
+  profiles:
+    default:
+      rpms:
+      - cri-o
+      - cri-tools
+  repository_memberships:
+  - dest1
+  stream: '1.12'
+  unit_id: (hidden)
+  version: 2920190221143213
+- _class: ModulemdUnit
+  arch: x86_64
+  artifacts:
+  - conmon-2:1.13.0-1.gite8a2525.module_f29+3066+eba77a73.x86_64
+  - conmon-debuginfo-2:1.13.0-1.gite8a2525.module_f29+3066+eba77a73.x86_64
+  - cri-o-2:1.13.0-1.gite8a2525.module_f29+3066+eba77a73.src
+  - cri-o-2:1.13.0-1.gite8a2525.module_f29+3066+eba77a73.x86_64
+  - cri-o-debuginfo-2:1.13.0-1.gite8a2525.module_f29+3066+eba77a73.x86_64
+  - cri-o-debugsource-2:1.13.0-1.gite8a2525.module_f29+3066+eba77a73.x86_64
+  - cri-tools-0:1.13.0-1.gitc06001f.module_f29+3066+eba77a73.src
+  - cri-tools-0:1.13.0-1.gitc06001f.module_f29+3066+eba77a73.x86_64
+  - cri-tools-debuginfo-0:1.13.0-1.gitc06001f.module_f29+3066+eba77a73.x86_64
+  - cri-tools-debugsource-0:1.13.0-1.gitc06001f.module_f29+3066+eba77a73.x86_64
+  context: 6c81f848
+  dependencies: []
+  name: cri-o
+  profiles:
+    default:
+      rpms:
+      - cri-o
+      - cri-tools
+  repository_memberships:
+  - dest1
+  stream: '1.13'
+  unit_id: (hidden)
+  version: 2920190221162713
+- _class: ModulemdUnit
+  arch: x86_64
+  artifacts:
+  - directory-maven-plugin-0:0.3.1-1.module_f29+2697+412960d8.noarch
+  - directory-maven-plugin-0:0.3.1-1.module_f29+2697+412960d8.src
+  - directory-maven-plugin-javadoc-0:0.3.1-1.module_f29+2697+412960d8.noarch
+  - ee4j-parent-0:1.0.1-1.module_f29+2697+412960d8.noarch
+  - ee4j-parent-0:1.0.1-1.module_f29+2697+412960d8.src
+  - jaf-0:1.2.1-2.module_f29+2697+412960d8.noarch
+  - jaf-0:1.2.1-2.module_f29+2697+412960d8.src
+  - jaf-javadoc-0:1.2.1-2.module_f29+2697+412960d8.noarch
+  - javamail-0:1.6.3-3.module_f29+2697+412960d8.noarch
+  - javamail-0:1.6.3-3.module_f29+2697+412960d8.src
+  - jmc-0:7.1.0-1.20190304hg8115549a88aa.module_f29+3757+b8cc3351.src
+  - jmc-0:7.1.0-1.20190304hg8115549a88aa.module_f29+3757+b8cc3351.x86_64
+  - jmc-core-0:7.1.0-0.20190304hg8115549a88aa.module_f29+3630+31d75dca.noarch
+  - jmc-core-0:7.1.0-0.20190304hg8115549a88aa.module_f29+3630+31d75dca.src
+  - jmc-core-javadoc-0:7.1.0-0.20190304hg8115549a88aa.module_f29+3630+31d75dca.noarch
+  - owasp-java-encoder-0:1.2.2-1.module_f29+2697+412960d8.noarch
+  - owasp-java-encoder-0:1.2.2-1.module_f29+2697+412960d8.src
+  - owasp-java-encoder-javadoc-0:1.2.2-1.module_f29+2697+412960d8.noarch
+  context: 6c81f848
+  dependencies: []
+  name: jmc
+  profiles:
+    core:
+      rpms:
+      - jmc-core
+    default:
+      rpms:
+      - jmc
+  repository_memberships:
+  - dest1
+  stream: latest
+  unit_id: (hidden)
+  version: 2920190326162720
+- _class: ModulemdUnit
+  arch: x86_64
+  artifacts:
+  - dwm-0:6.2-2.20190202gitcb3f58a.module_f29+2801+4fab5094.src
+  - dwm-0:6.2-2.20190202gitcb3f58a.module_f29+2801+4fab5094.x86_64
+  - dwm-debuginfo-0:6.2-2.20190202gitcb3f58a.module_f29+2801+4fab5094.x86_64
+  - dwm-debugsource-0:6.2-2.20190202gitcb3f58a.module_f29+2801+4fab5094.x86_64
+  - dwm-user-0:6.2-2.20190202gitcb3f58a.module_f29+2801+4fab5094.x86_64
+  context: 6c81f848
+  dependencies: []
+  name: dwm
+  profiles:
+    default:
+      description: The minimal, distribution-compiled dwm binary.
+      rpms:
+      - dwm
+    user:
+      description: Includes distribution-compiled dwm as well as a helper script to
+        apply user patches and configuration, dwm-user.
+      rpms:
+      - dwm
+      - dwm-user
+  repository_memberships:
+  - dest1
+  stream: latest
+  unit_id: (hidden)
+  version: 2920190206214037
+- _class: ModulemdUnit
+  arch: x86_64
+  artifacts:
+  - dwm-0:6.2-2.module_f29+2798+2c5389fb.src
+  - dwm-0:6.2-2.module_f29+2798+2c5389fb.x86_64
+  - dwm-debuginfo-0:6.2-2.module_f29+2798+2c5389fb.x86_64
+  - dwm-debugsource-0:6.2-2.module_f29+2798+2c5389fb.x86_64
+  - dwm-user-0:6.2-2.module_f29+2798+2c5389fb.x86_64
+  context: 6c81f848
+  dependencies: []
+  name: dwm
+  profiles:
+    default:
+      description: The minimal, distribution-compiled dwm binary.
+      rpms:
+      - dwm
+    user:
+      description: Includes distribution-compiled dwm as well as a helper script to
+        apply user patches and configuration, dwm-user.
+      rpms:
+      - dwm
+      - dwm-user
+  repository_memberships:
+  - dest1
+  stream: '6.2'
+  unit_id: (hidden)
+  version: 2920190206214000
+- _class: ModulemdUnit
+  arch: x86_64
+  artifacts:
+  - exa-0:0.9.0-2.module_f29+5148+365725fe.x86_64
+  - exa-debuginfo-0:0.9.0-2.module_f29+5148+365725fe.x86_64
+  - rust-exa-0:0.9.0-2.module_f29+5148+365725fe.src
+  - rust-exa-debugsource-0:0.9.0-2.module_f29+5148+365725fe.x86_64
+  context: c5ebb199
+  dependencies: []
+  name: exa
+  profiles:
+    default:
+      rpms:
+      - exa
+  repository_memberships:
+  - dest1
+  stream: latest
+  unit_id: (hidden)
+  version: 2920190721165838
+- _class: ModulemdUnit
+  arch: x86_64
+  artifacts:
+  - fd-find-0:7.3.0-3.module_f29+5178+ee7fe7af.x86_64
+  - fd-find-debuginfo-0:7.3.0-3.module_f29+5178+ee7fe7af.x86_64
+  - rust-fd-find-0:7.3.0-3.module_f29+5178+ee7fe7af.src
+  - rust-fd-find-debugsource-0:7.3.0-3.module_f29+5178+ee7fe7af.x86_64
+  context: c5ebb199
+  dependencies: []
+  name: fd-find
+  profiles:
+    default:
+      rpms:
+      - fd-find
+  repository_memberships:
+  - dest1
+  stream: rolling
+  unit_id: (hidden)
+  version: 2920190722174030
+- _class: ModulemdUnit
+  arch: x86_64
+  artifacts:
+  - ffsend-0:0.2.49-1.module_f29+4928+fc4c8ecf.x86_64
+  - ffsend-debuginfo-0:0.2.49-1.module_f29+4928+fc4c8ecf.x86_64
+  - rust-ffsend-0:0.2.49-1.module_f29+4928+fc4c8ecf.src
+  - rust-ffsend-debugsource-0:0.2.49-1.module_f29+4928+fc4c8ecf.x86_64
+  context: c5ebb199
+  dependencies: []
+  name: ffsend
+  profiles:
+    default:
+      rpms:
+      - ffsend
+  repository_memberships:
+  - dest1
+  stream: latest
+  unit_id: (hidden)
+  version: 2920190630105436
+- _class: ModulemdUnit
+  arch: x86_64
+  artifacts:
+  - fish-0:3.0.2-1.module_f29+3043+ebee6ce1.src
+  - fish-0:3.0.2-1.module_f29+3043+ebee6ce1.x86_64
+  - fish-debuginfo-0:3.0.2-1.module_f29+3043+ebee6ce1.x86_64
+  - fish-debugsource-0:3.0.2-1.module_f29+3043+ebee6ce1.x86_64
+  context: 139e1eeb
+  dependencies: []
+  name: fish
+  profiles:
+    default:
+      rpms:
+      - fish
+  repository_memberships:
+  - dest1
+  stream: '3'
+  unit_id: (hidden)
+  version: 2920190219150858
+- _class: ModulemdUnit
+  arch: x86_64
+  artifacts:
+  - galera-0:25.3.26-3.module_f29+6002+926b7197.src
+  - galera-0:25.3.26-3.module_f29+6002+926b7197.x86_64
+  - galera-debuginfo-0:25.3.26-3.module_f29+6002+926b7197.x86_64
+  - galera-debugsource-0:25.3.26-3.module_f29+6002+926b7197.x86_64
+  - mariadb-3:10.3.17-1.module_f29+6002+926b7197.src
+  - mariadb-3:10.3.17-1.module_f29+6002+926b7197.x86_64
+  - mariadb-backup-3:10.3.17-1.module_f29+6002+926b7197.x86_64
+  - mariadb-backup-debuginfo-3:10.3.17-1.module_f29+6002+926b7197.x86_64
+  - mariadb-bench-3:10.3.17-1.module_f29+6002+926b7197.x86_64
+  - mariadb-common-3:10.3.17-1.module_f29+6002+926b7197.x86_64
+  - mariadb-connect-engine-3:10.3.17-1.module_f29+6002+926b7197.x86_64
+  - mariadb-connect-engine-debuginfo-3:10.3.17-1.module_f29+6002+926b7197.x86_64
+  - mariadb-cracklib-password-check-3:10.3.17-1.module_f29+6002+926b7197.x86_64
+  - mariadb-cracklib-password-check-debuginfo-3:10.3.17-1.module_f29+6002+926b7197.x86_64
+  - mariadb-debuginfo-3:10.3.17-1.module_f29+6002+926b7197.x86_64
+  - mariadb-debugsource-3:10.3.17-1.module_f29+6002+926b7197.x86_64
+  - mariadb-devel-3:10.3.17-1.module_f29+6002+926b7197.x86_64
+  - mariadb-embedded-3:10.3.17-1.module_f29+6002+926b7197.x86_64
+  - mariadb-embedded-debuginfo-3:10.3.17-1.module_f29+6002+926b7197.x86_64
+  - mariadb-embedded-devel-3:10.3.17-1.module_f29+6002+926b7197.x86_64
+  - mariadb-errmsg-3:10.3.17-1.module_f29+6002+926b7197.x86_64
+  - mariadb-gssapi-server-3:10.3.17-1.module_f29+6002+926b7197.x86_64
+  - mariadb-gssapi-server-debuginfo-3:10.3.17-1.module_f29+6002+926b7197.x86_64
+  - mariadb-oqgraph-engine-3:10.3.17-1.module_f29+6002+926b7197.x86_64
+  - mariadb-oqgraph-engine-debuginfo-3:10.3.17-1.module_f29+6002+926b7197.x86_64
+  - mariadb-rocksdb-engine-3:10.3.17-1.module_f29+6002+926b7197.x86_64
+  - mariadb-rocksdb-engine-debuginfo-3:10.3.17-1.module_f29+6002+926b7197.x86_64
+  - mariadb-server-3:10.3.17-1.module_f29+6002+926b7197.x86_64
+  - mariadb-server-debuginfo-3:10.3.17-1.module_f29+6002+926b7197.x86_64
+  - mariadb-server-galera-3:10.3.17-1.module_f29+6002+926b7197.x86_64
+  - mariadb-server-utils-3:10.3.17-1.module_f29+6002+926b7197.x86_64
+  - mariadb-server-utils-debuginfo-3:10.3.17-1.module_f29+6002+926b7197.x86_64
+  - mariadb-sphinx-engine-3:10.3.17-1.module_f29+6002+926b7197.x86_64
+  - mariadb-sphinx-engine-debuginfo-3:10.3.17-1.module_f29+6002+926b7197.x86_64
+  - mariadb-test-3:10.3.17-1.module_f29+6002+926b7197.x86_64
+  - mariadb-test-debuginfo-3:10.3.17-1.module_f29+6002+926b7197.x86_64
+  - mariadb-tokudb-engine-3:10.3.17-1.module_f29+6002+926b7197.x86_64
+  - mariadb-tokudb-engine-debuginfo-3:10.3.17-1.module_f29+6002+926b7197.x86_64
+  context: 6c81f848
+  dependencies: []
+  name: mariadb
+  profiles:
+    client:
+      description: Client.
+      rpms:
+      - mariadb
+    devel:
+      description: Devel package.
+      rpms:
+      - mariadb-devel
+    galera:
+      description: Server plus replication engine.
+      rpms:
+      - galera
+      - mariadb-server
+      - mariadb-server-galera
+    server:
+      description: Base server.
+      rpms:
+      - mariadb-server
+  repository_memberships:
+  - dest1
+  stream: '10.3'
+  unit_id: (hidden)
+  version: 2920190822121056
+- _class: ModulemdUnit
+  arch: x86_64
+  artifacts:
+  - galera-0:26.4.2-1.module_f29+4778+4759b9ea.src
+  - galera-0:26.4.2-1.module_f29+4778+4759b9ea.x86_64
+  - galera-debuginfo-0:26.4.2-1.module_f29+4778+4759b9ea.x86_64
+  - galera-debugsource-0:26.4.2-1.module_f29+4778+4759b9ea.x86_64
+  - mariadb-3:10.4.7-1.module_f29+6030+ff6cd690.src
+  - mariadb-3:10.4.7-1.module_f29+6030+ff6cd690.x86_64
+  - mariadb-backup-3:10.4.7-1.module_f29+6030+ff6cd690.x86_64
+  - mariadb-backup-debuginfo-3:10.4.7-1.module_f29+6030+ff6cd690.x86_64
+  - mariadb-bench-3:10.4.7-1.module_f29+6030+ff6cd690.x86_64
+  - mariadb-common-3:10.4.7-1.module_f29+6030+ff6cd690.x86_64
+  - mariadb-connect-engine-3:10.4.7-1.module_f29+6030+ff6cd690.x86_64
+  - mariadb-connect-engine-debuginfo-3:10.4.7-1.module_f29+6030+ff6cd690.x86_64
+  - mariadb-cracklib-password-check-3:10.4.7-1.module_f29+6030+ff6cd690.x86_64
+  - mariadb-cracklib-password-check-debuginfo-3:10.4.7-1.module_f29+6030+ff6cd690.x86_64
+  - mariadb-debuginfo-3:10.4.7-1.module_f29+6030+ff6cd690.x86_64
+  - mariadb-debugsource-3:10.4.7-1.module_f29+6030+ff6cd690.x86_64
+  - mariadb-devel-3:10.4.7-1.module_f29+6030+ff6cd690.x86_64
+  - mariadb-embedded-3:10.4.7-1.module_f29+6030+ff6cd690.x86_64
+  - mariadb-embedded-debuginfo-3:10.4.7-1.module_f29+6030+ff6cd690.x86_64
+  - mariadb-embedded-devel-3:10.4.7-1.module_f29+6030+ff6cd690.x86_64
+  - mariadb-errmsg-3:10.4.7-1.module_f29+6030+ff6cd690.x86_64
+  - mariadb-gssapi-server-3:10.4.7-1.module_f29+6030+ff6cd690.x86_64
+  - mariadb-gssapi-server-debuginfo-3:10.4.7-1.module_f29+6030+ff6cd690.x86_64
+  - mariadb-libs-3:10.4.7-1.module_f29+6030+ff6cd690.x86_64
+  - mariadb-libs-debuginfo-3:10.4.7-1.module_f29+6030+ff6cd690.x86_64
+  - mariadb-oqgraph-engine-3:10.4.7-1.module_f29+6030+ff6cd690.x86_64
+  - mariadb-oqgraph-engine-debuginfo-3:10.4.7-1.module_f29+6030+ff6cd690.x86_64
+  - mariadb-rocksdb-engine-3:10.4.7-1.module_f29+6030+ff6cd690.x86_64
+  - mariadb-rocksdb-engine-debuginfo-3:10.4.7-1.module_f29+6030+ff6cd690.x86_64
+  - mariadb-server-3:10.4.7-1.module_f29+6030+ff6cd690.x86_64
+  - mariadb-server-debuginfo-3:10.4.7-1.module_f29+6030+ff6cd690.x86_64
+  - mariadb-server-galera-3:10.4.7-1.module_f29+6030+ff6cd690.x86_64
+  - mariadb-server-utils-3:10.4.7-1.module_f29+6030+ff6cd690.x86_64
+  - mariadb-server-utils-debuginfo-3:10.4.7-1.module_f29+6030+ff6cd690.x86_64
+  - mariadb-sphinx-engine-3:10.4.7-1.module_f29+6030+ff6cd690.x86_64
+  - mariadb-sphinx-engine-debuginfo-3:10.4.7-1.module_f29+6030+ff6cd690.x86_64
+  - mariadb-test-3:10.4.7-1.module_f29+6030+ff6cd690.x86_64
+  - mariadb-test-debuginfo-3:10.4.7-1.module_f29+6030+ff6cd690.x86_64
+  - mariadb-tokudb-engine-3:10.4.7-1.module_f29+6030+ff6cd690.x86_64
+  - mariadb-tokudb-engine-debuginfo-3:10.4.7-1.module_f29+6030+ff6cd690.x86_64
+  context: 6c81f848
+  dependencies: []
+  name: mariadb
+  profiles:
+    client:
+      description: Client.
+      rpms:
+      - mariadb
+    devel:
+      description: Devel package.
+      rpms:
+      - mariadb-devel
+    galera:
+      description: Server plus replication engine.
+      rpms:
+      - mariadb-server
+      - mariadb-server-galera
+    server:
+      description: Base server.
+      rpms:
+      - mariadb-server
+  repository_memberships:
+  - dest1
+  stream: '10.4'
+  unit_id: (hidden)
+  version: 2920190823111416
+- _class: ModulemdUnit
+  arch: x86_64
+  artifacts:
+  - ghc-0:8.4.4-74.module_f29+3450+8a0162f2.src
+  - ghc-0:8.4.4-74.module_f29+3450+8a0162f2.x86_64
+  - ghc-Cabal-0:2.2.0.1-74.module_f29+3450+8a0162f2.x86_64
+  - ghc-Cabal-devel-0:2.2.0.1-74.module_f29+3450+8a0162f2.x86_64
+  - ghc-array-0:0.5.2.0-74.module_f29+3450+8a0162f2.x86_64
+  - ghc-array-devel-0:0.5.2.0-74.module_f29+3450+8a0162f2.x86_64
+  - ghc-base-0:4.11.1.0-74.module_f29+3450+8a0162f2.x86_64
+  - ghc-base-debuginfo-0:4.11.1.0-74.module_f29+3450+8a0162f2.x86_64
+  - ghc-base-devel-0:4.11.1.0-74.module_f29+3450+8a0162f2.x86_64
+  - ghc-binary-0:0.8.5.1-74.module_f29+3450+8a0162f2.x86_64
+  - ghc-binary-devel-0:0.8.5.1-74.module_f29+3450+8a0162f2.x86_64
+  - ghc-bytestring-0:0.10.8.2-74.module_f29+3450+8a0162f2.x86_64
+  - ghc-bytestring-devel-0:0.10.8.2-74.module_f29+3450+8a0162f2.x86_64
+  - ghc-compiler-0:8.4.4-74.module_f29+3450+8a0162f2.x86_64
+  - ghc-compiler-debuginfo-0:8.4.4-74.module_f29+3450+8a0162f2.x86_64
+  - ghc-containers-0:0.5.11.0-74.module_f29+3450+8a0162f2.x86_64
+  - ghc-containers-devel-0:0.5.11.0-74.module_f29+3450+8a0162f2.x86_64
+  - ghc-debuginfo-0:8.4.4-74.module_f29+3450+8a0162f2.x86_64
+  - ghc-debugsource-0:8.4.4-74.module_f29+3450+8a0162f2.x86_64
+  - ghc-deepseq-0:1.4.3.0-74.module_f29+3450+8a0162f2.x86_64
+  - ghc-deepseq-devel-0:1.4.3.0-74.module_f29+3450+8a0162f2.x86_64
+  - ghc-directory-0:1.3.1.5-74.module_f29+3450+8a0162f2.x86_64
+  - ghc-directory-devel-0:1.3.1.5-74.module_f29+3450+8a0162f2.x86_64
+  - ghc-doc-cron-0:8.4.4-74.module_f29+3450+8a0162f2.noarch
+  - ghc-filepath-0:1.4.2-74.module_f29+3450+8a0162f2.x86_64
+  - ghc-filepath-devel-0:1.4.2-74.module_f29+3450+8a0162f2.x86_64
+  - ghc-ghc-0:8.4.4-74.module_f29+3450+8a0162f2.x86_64
+  - ghc-ghc-boot-0:8.4.4-74.module_f29+3450+8a0162f2.x86_64
+  - ghc-ghc-boot-devel-0:8.4.4-74.module_f29+3450+8a0162f2.x86_64
+  - ghc-ghc-boot-th-0:8.4.4-74.module_f29+3450+8a0162f2.x86_64
+  - ghc-ghc-boot-th-devel-0:8.4.4-74.module_f29+3450+8a0162f2.x86_64
+  - ghc-ghc-compact-0:0.1.0.0-74.module_f29+3450+8a0162f2.x86_64
+  - ghc-ghc-compact-devel-0:0.1.0.0-74.module_f29+3450+8a0162f2.x86_64
+  - ghc-ghc-devel-0:8.4.4-74.module_f29+3450+8a0162f2.x86_64
+  - ghc-ghci-0:8.4.4-74.module_f29+3450+8a0162f2.x86_64
+  - ghc-ghci-devel-0:8.4.4-74.module_f29+3450+8a0162f2.x86_64
+  - ghc-haskeline-0:0.7.4.2-74.module_f29+3450+8a0162f2.x86_64
+  - ghc-haskeline-devel-0:0.7.4.2-74.module_f29+3450+8a0162f2.x86_64
+  - ghc-hpc-0:0.6.0.3-74.module_f29+3450+8a0162f2.x86_64
+  - ghc-hpc-devel-0:0.6.0.3-74.module_f29+3450+8a0162f2.x86_64
+  - ghc-libraries-0:8.4.4-74.module_f29+3450+8a0162f2.x86_64
+  - ghc-manual-0:8.4.4-74.module_f29+3450+8a0162f2.noarch
+  - ghc-mtl-0:2.2.2-74.module_f29+3450+8a0162f2.x86_64
+  - ghc-mtl-devel-0:2.2.2-74.module_f29+3450+8a0162f2.x86_64
+  - ghc-parsec-0:3.1.13.0-74.module_f29+3450+8a0162f2.x86_64
+  - ghc-parsec-devel-0:3.1.13.0-74.module_f29+3450+8a0162f2.x86_64
+  - ghc-pretty-0:1.1.3.6-74.module_f29+3450+8a0162f2.x86_64
+  - ghc-pretty-devel-0:1.1.3.6-74.module_f29+3450+8a0162f2.x86_64
+  - ghc-process-0:1.6.3.0-74.module_f29+3450+8a0162f2.x86_64
+  - ghc-process-devel-0:1.6.3.0-74.module_f29+3450+8a0162f2.x86_64
+  - ghc-stm-0:2.4.5.1-74.module_f29+3450+8a0162f2.x86_64
+  - ghc-stm-devel-0:2.4.5.1-74.module_f29+3450+8a0162f2.x86_64
+  - ghc-template-haskell-0:2.13.0.0-74.module_f29+3450+8a0162f2.x86_64
+  - ghc-template-haskell-devel-0:2.13.0.0-74.module_f29+3450+8a0162f2.x86_64
+  - ghc-terminfo-0:0.4.1.1-74.module_f29+3450+8a0162f2.x86_64
+  - ghc-terminfo-devel-0:0.4.1.1-74.module_f29+3450+8a0162f2.x86_64
+  - ghc-text-0:1.2.3.1-74.module_f29+3450+8a0162f2.x86_64
+  - ghc-text-devel-0:1.2.3.1-74.module_f29+3450+8a0162f2.x86_64
+  - ghc-time-0:1.8.0.2-74.module_f29+3450+8a0162f2.x86_64
+  - ghc-time-devel-0:1.8.0.2-74.module_f29+3450+8a0162f2.x86_64
+  - ghc-transformers-0:0.5.5.0-74.module_f29+3450+8a0162f2.x86_64
+  - ghc-transformers-devel-0:0.5.5.0-74.module_f29+3450+8a0162f2.x86_64
+  - ghc-unix-0:2.7.2.2-74.module_f29+3450+8a0162f2.x86_64
+  - ghc-unix-devel-0:2.7.2.2-74.module_f29+3450+8a0162f2.x86_64
+  - ghc-xhtml-0:3000.2.2.1-74.module_f29+3450+8a0162f2.x86_64
+  - ghc-xhtml-devel-0:3000.2.2.1-74.module_f29+3450+8a0162f2.x86_64
+  context: 6c81f848
+  dependencies: []
+  name: ghc
+  profiles:
+    default:
+      description: standard installation
+      rpms:
+      - ghc
+    minimal:
+      description: just compiler and base
+      rpms:
+      - ghc-base-devel
+    small:
+      description: compiler with main core libs
+      rpms:
+      - ghc-libraries
+  repository_memberships:
+  - dest1
+  stream: '8.4'
+  unit_id: (hidden)
+  version: 2920190305053459
+- _class: ModulemdUnit
+  arch: x86_64
+  artifacts:
+  - ghc-0:8.6.5-79.module_f29+4093+7b5e633d.src
+  - ghc-0:8.6.5-79.module_f29+4093+7b5e633d.x86_64
+  - ghc-Cabal-0:2.4.0.1-79.module_f29+4093+7b5e633d.x86_64
+  - ghc-Cabal-devel-0:2.4.0.1-79.module_f29+4093+7b5e633d.x86_64
+  - ghc-array-0:0.5.3.0-79.module_f29+4093+7b5e633d.x86_64
+  - ghc-array-devel-0:0.5.3.0-79.module_f29+4093+7b5e633d.x86_64
+  - ghc-base-0:4.12.0.0-79.module_f29+4093+7b5e633d.x86_64
+  - ghc-base-debuginfo-0:4.12.0.0-79.module_f29+4093+7b5e633d.x86_64
+  - ghc-base-devel-0:4.12.0.0-79.module_f29+4093+7b5e633d.x86_64
+  - ghc-binary-0:0.8.6.0-79.module_f29+4093+7b5e633d.x86_64
+  - ghc-binary-devel-0:0.8.6.0-79.module_f29+4093+7b5e633d.x86_64
+  - ghc-bytestring-0:0.10.8.2-79.module_f29+4093+7b5e633d.x86_64
+  - ghc-bytestring-devel-0:0.10.8.2-79.module_f29+4093+7b5e633d.x86_64
+  - ghc-compiler-0:8.6.5-79.module_f29+4093+7b5e633d.x86_64
+  - ghc-compiler-debuginfo-0:8.6.5-79.module_f29+4093+7b5e633d.x86_64
+  - ghc-containers-0:0.6.0.1-79.module_f29+4093+7b5e633d.x86_64
+  - ghc-containers-devel-0:0.6.0.1-79.module_f29+4093+7b5e633d.x86_64
+  - ghc-debuginfo-0:8.6.5-79.module_f29+4093+7b5e633d.x86_64
+  - ghc-debugsource-0:8.6.5-79.module_f29+4093+7b5e633d.x86_64
+  - ghc-deepseq-0:1.4.4.0-79.module_f29+4093+7b5e633d.x86_64
+  - ghc-deepseq-devel-0:1.4.4.0-79.module_f29+4093+7b5e633d.x86_64
+  - ghc-directory-0:1.3.3.0-79.module_f29+4093+7b5e633d.x86_64
+  - ghc-directory-devel-0:1.3.3.0-79.module_f29+4093+7b5e633d.x86_64
+  - ghc-doc-cron-0:8.6.5-79.module_f29+4093+7b5e633d.noarch
+  - ghc-filepath-0:1.4.2.1-79.module_f29+4093+7b5e633d.x86_64
+  - ghc-filepath-devel-0:1.4.2.1-79.module_f29+4093+7b5e633d.x86_64
+  - ghc-ghc-0:8.6.5-79.module_f29+4093+7b5e633d.x86_64
+  - ghc-ghc-boot-0:8.6.5-79.module_f29+4093+7b5e633d.x86_64
+  - ghc-ghc-boot-devel-0:8.6.5-79.module_f29+4093+7b5e633d.x86_64
+  - ghc-ghc-boot-th-0:8.6.5-79.module_f29+4093+7b5e633d.x86_64
+  - ghc-ghc-boot-th-devel-0:8.6.5-79.module_f29+4093+7b5e633d.x86_64
+  - ghc-ghc-compact-0:0.1.0.0-79.module_f29+4093+7b5e633d.x86_64
+  - ghc-ghc-compact-devel-0:0.1.0.0-79.module_f29+4093+7b5e633d.x86_64
+  - ghc-ghc-devel-0:8.6.5-79.module_f29+4093+7b5e633d.x86_64
+  - ghc-ghc-heap-0:8.6.5-79.module_f29+4093+7b5e633d.x86_64
+  - ghc-ghc-heap-devel-0:8.6.5-79.module_f29+4093+7b5e633d.x86_64
+  - ghc-ghci-0:8.6.5-79.module_f29+4093+7b5e633d.x86_64
+  - ghc-ghci-devel-0:8.6.5-79.module_f29+4093+7b5e633d.x86_64
+  - ghc-haskeline-0:0.7.4.3-79.module_f29+4093+7b5e633d.x86_64
+  - ghc-haskeline-devel-0:0.7.4.3-79.module_f29+4093+7b5e633d.x86_64
+  - ghc-hpc-0:0.6.0.3-79.module_f29+4093+7b5e633d.x86_64
+  - ghc-hpc-devel-0:0.6.0.3-79.module_f29+4093+7b5e633d.x86_64
+  - ghc-libiserv-0:8.6.3-79.module_f29+4093+7b5e633d.x86_64
+  - ghc-libiserv-devel-0:8.6.3-79.module_f29+4093+7b5e633d.x86_64
+  - ghc-libraries-0:8.6.5-79.module_f29+4093+7b5e633d.x86_64
+  - ghc-manual-0:8.6.5-79.module_f29+4093+7b5e633d.noarch
+  - ghc-mtl-0:2.2.2-79.module_f29+4093+7b5e633d.x86_64
+  - ghc-mtl-devel-0:2.2.2-79.module_f29+4093+7b5e633d.x86_64
+  - ghc-parsec-0:3.1.13.0-79.module_f29+4093+7b5e633d.x86_64
+  - ghc-parsec-devel-0:3.1.13.0-79.module_f29+4093+7b5e633d.x86_64
+  - ghc-pretty-0:1.1.3.6-79.module_f29+4093+7b5e633d.x86_64
+  - ghc-pretty-devel-0:1.1.3.6-79.module_f29+4093+7b5e633d.x86_64
+  - ghc-process-0:1.6.5.0-79.module_f29+4093+7b5e633d.x86_64
+  - ghc-process-devel-0:1.6.5.0-79.module_f29+4093+7b5e633d.x86_64
+  - ghc-stm-0:2.5.0.0-79.module_f29+4093+7b5e633d.x86_64
+  - ghc-stm-devel-0:2.5.0.0-79.module_f29+4093+7b5e633d.x86_64
+  - ghc-template-haskell-0:2.14.0.0-79.module_f29+4093+7b5e633d.x86_64
+  - ghc-template-haskell-devel-0:2.14.0.0-79.module_f29+4093+7b5e633d.x86_64
+  - ghc-terminfo-0:0.4.1.2-79.module_f29+4093+7b5e633d.x86_64
+  - ghc-terminfo-devel-0:0.4.1.2-79.module_f29+4093+7b5e633d.x86_64
+  - ghc-text-0:1.2.3.1-79.module_f29+4093+7b5e633d.x86_64
+  - ghc-text-devel-0:1.2.3.1-79.module_f29+4093+7b5e633d.x86_64
+  - ghc-time-0:1.8.0.2-79.module_f29+4093+7b5e633d.x86_64
+  - ghc-time-devel-0:1.8.0.2-79.module_f29+4093+7b5e633d.x86_64
+  - ghc-transformers-0:0.5.6.2-79.module_f29+4093+7b5e633d.x86_64
+  - ghc-transformers-devel-0:0.5.6.2-79.module_f29+4093+7b5e633d.x86_64
+  - ghc-unix-0:2.7.2.2-79.module_f29+4093+7b5e633d.x86_64
+  - ghc-unix-devel-0:2.7.2.2-79.module_f29+4093+7b5e633d.x86_64
+  - ghc-xhtml-0:3000.2.2.1-79.module_f29+4093+7b5e633d.x86_64
+  - ghc-xhtml-devel-0:3000.2.2.1-79.module_f29+4093+7b5e633d.x86_64
+  context: 6c81f848
+  dependencies: []
+  name: ghc
+  profiles:
+    default:
+      description: standard installation
+      rpms:
+      - ghc
+    minimal:
+      description: just compiler and base
+      rpms:
+      - ghc-base-devel
+    small:
+      description: compiler with main core libs
+      rpms:
+      - ghc-libraries
+  repository_memberships:
+  - dest1
+  stream: '8.6'
+  unit_id: (hidden)
+  version: 2920190427173901
+- _class: ModulemdUnit
+  arch: x86_64
+  artifacts:
+  - ghc-0:8.8.0.20190721-83.module_f29+5217+55e07320.src
+  - ghc-0:8.8.0.20190721-83.module_f29+5217+55e07320.x86_64
+  - ghc-Cabal-0:3.0.0.0-83.module_f29+5217+55e07320.x86_64
+  - ghc-Cabal-debuginfo-0:3.0.0.0-83.module_f29+5217+55e07320.x86_64
+  - ghc-Cabal-devel-0:3.0.0.0-83.module_f29+5217+55e07320.x86_64
+  - ghc-array-0:0.5.4.0-83.module_f29+5217+55e07320.x86_64
+  - ghc-array-debuginfo-0:0.5.4.0-83.module_f29+5217+55e07320.x86_64
+  - ghc-array-devel-0:0.5.4.0-83.module_f29+5217+55e07320.x86_64
+  - ghc-base-0:4.13.0.0-83.module_f29+5217+55e07320.x86_64
+  - ghc-base-debuginfo-0:4.13.0.0-83.module_f29+5217+55e07320.x86_64
+  - ghc-base-devel-0:4.13.0.0-83.module_f29+5217+55e07320.x86_64
+  - ghc-binary-0:0.8.7.0-83.module_f29+5217+55e07320.x86_64
+  - ghc-binary-debuginfo-0:0.8.7.0-83.module_f29+5217+55e07320.x86_64
+  - ghc-binary-devel-0:0.8.7.0-83.module_f29+5217+55e07320.x86_64
+  - ghc-bytestring-0:0.10.10.0-83.module_f29+5217+55e07320.x86_64
+  - ghc-bytestring-debuginfo-0:0.10.10.0-83.module_f29+5217+55e07320.x86_64
+  - ghc-bytestring-devel-0:0.10.10.0-83.module_f29+5217+55e07320.x86_64
+  - ghc-compiler-0:8.8.0.20190721-83.module_f29+5217+55e07320.x86_64
+  - ghc-compiler-debuginfo-0:8.8.0.20190721-83.module_f29+5217+55e07320.x86_64
+  - ghc-containers-0:0.6.2.1-83.module_f29+5217+55e07320.x86_64
+  - ghc-containers-debuginfo-0:0.6.2.1-83.module_f29+5217+55e07320.x86_64
+  - ghc-containers-devel-0:0.6.2.1-83.module_f29+5217+55e07320.x86_64
+  - ghc-debuginfo-0:8.8.0.20190721-83.module_f29+5217+55e07320.x86_64
+  - ghc-debugsource-0:8.8.0.20190721-83.module_f29+5217+55e07320.x86_64
+  - ghc-deepseq-0:1.4.4.0-83.module_f29+5217+55e07320.x86_64
+  - ghc-deepseq-debuginfo-0:1.4.4.0-83.module_f29+5217+55e07320.x86_64
+  - ghc-deepseq-devel-0:1.4.4.0-83.module_f29+5217+55e07320.x86_64
+  - ghc-directory-0:1.3.3.2-83.module_f29+5217+55e07320.x86_64
+  - ghc-directory-debuginfo-0:1.3.3.2-83.module_f29+5217+55e07320.x86_64
+  - ghc-directory-devel-0:1.3.3.2-83.module_f29+5217+55e07320.x86_64
+  - ghc-doc-cron-0:8.8.0.20190721-83.module_f29+5217+55e07320.noarch
+  - ghc-filepath-0:1.4.2.1-83.module_f29+5217+55e07320.x86_64
+  - ghc-filepath-debuginfo-0:1.4.2.1-83.module_f29+5217+55e07320.x86_64
+  - ghc-filepath-devel-0:1.4.2.1-83.module_f29+5217+55e07320.x86_64
+  - ghc-ghc-0:8.8.0.20190721-83.module_f29+5217+55e07320.x86_64
+  - ghc-ghc-boot-0:8.8.0.20190721-83.module_f29+5217+55e07320.x86_64
+  - ghc-ghc-boot-debuginfo-0:8.8.0.20190721-83.module_f29+5217+55e07320.x86_64
+  - ghc-ghc-boot-devel-0:8.8.0.20190721-83.module_f29+5217+55e07320.x86_64
+  - ghc-ghc-boot-th-0:8.8.0.20190721-83.module_f29+5217+55e07320.x86_64
+  - ghc-ghc-boot-th-debuginfo-0:8.8.0.20190721-83.module_f29+5217+55e07320.x86_64
+  - ghc-ghc-boot-th-devel-0:8.8.0.20190721-83.module_f29+5217+55e07320.x86_64
+  - ghc-ghc-compact-0:0.1.0.0-83.module_f29+5217+55e07320.x86_64
+  - ghc-ghc-compact-debuginfo-0:0.1.0.0-83.module_f29+5217+55e07320.x86_64
+  - ghc-ghc-compact-devel-0:0.1.0.0-83.module_f29+5217+55e07320.x86_64
+  - ghc-ghc-debuginfo-0:8.8.0.20190721-83.module_f29+5217+55e07320.x86_64
+  - ghc-ghc-devel-0:8.8.0.20190721-83.module_f29+5217+55e07320.x86_64
+  - ghc-ghc-heap-0:8.8.0.20190721-83.module_f29+5217+55e07320.x86_64
+  - ghc-ghc-heap-debuginfo-0:8.8.0.20190721-83.module_f29+5217+55e07320.x86_64
+  - ghc-ghc-heap-devel-0:8.8.0.20190721-83.module_f29+5217+55e07320.x86_64
+  - ghc-ghci-0:8.8.0.20190721-83.module_f29+5217+55e07320.x86_64
+  - ghc-ghci-debuginfo-0:8.8.0.20190721-83.module_f29+5217+55e07320.x86_64
+  - ghc-ghci-devel-0:8.8.0.20190721-83.module_f29+5217+55e07320.x86_64
+  - ghc-haskeline-0:0.7.5.0-83.module_f29+5217+55e07320.x86_64
+  - ghc-haskeline-debuginfo-0:0.7.5.0-83.module_f29+5217+55e07320.x86_64
+  - ghc-haskeline-devel-0:0.7.5.0-83.module_f29+5217+55e07320.x86_64
+  - ghc-hpc-0:0.6.0.3-83.module_f29+5217+55e07320.x86_64
+  - ghc-hpc-debuginfo-0:0.6.0.3-83.module_f29+5217+55e07320.x86_64
+  - ghc-hpc-devel-0:0.6.0.3-83.module_f29+5217+55e07320.x86_64
+  - ghc-libiserv-0:8.8.0.20190721-83.module_f29+5217+55e07320.x86_64
+  - ghc-libiserv-debuginfo-0:8.8.0.20190721-83.module_f29+5217+55e07320.x86_64
+  - ghc-libiserv-devel-0:8.8.0.20190721-83.module_f29+5217+55e07320.x86_64
+  - ghc-libraries-0:8.8.0.20190721-83.module_f29+5217+55e07320.x86_64
+  - ghc-manual-0:8.8.0.20190721-83.module_f29+5217+55e07320.noarch
+  - ghc-mtl-0:2.2.2-83.module_f29+5217+55e07320.x86_64
+  - ghc-mtl-debuginfo-0:2.2.2-83.module_f29+5217+55e07320.x86_64
+  - ghc-mtl-devel-0:2.2.2-83.module_f29+5217+55e07320.x86_64
+  - ghc-parsec-0:3.1.14.0-83.module_f29+5217+55e07320.x86_64
+  - ghc-parsec-debuginfo-0:3.1.14.0-83.module_f29+5217+55e07320.x86_64
+  - ghc-parsec-devel-0:3.1.14.0-83.module_f29+5217+55e07320.x86_64
+  - ghc-pretty-0:1.1.3.6-83.module_f29+5217+55e07320.x86_64
+  - ghc-pretty-debuginfo-0:1.1.3.6-83.module_f29+5217+55e07320.x86_64
+  - ghc-pretty-devel-0:1.1.3.6-83.module_f29+5217+55e07320.x86_64
+  - ghc-process-0:1.6.5.1-83.module_f29+5217+55e07320.x86_64
+  - ghc-process-debuginfo-0:1.6.5.1-83.module_f29+5217+55e07320.x86_64
+  - ghc-process-devel-0:1.6.5.1-83.module_f29+5217+55e07320.x86_64
+  - ghc-stm-0:2.5.0.0-83.module_f29+5217+55e07320.x86_64
+  - ghc-stm-debuginfo-0:2.5.0.0-83.module_f29+5217+55e07320.x86_64
+  - ghc-stm-devel-0:2.5.0.0-83.module_f29+5217+55e07320.x86_64
+  - ghc-template-haskell-0:2.15.0.0-83.module_f29+5217+55e07320.x86_64
+  - ghc-template-haskell-debuginfo-0:2.15.0.0-83.module_f29+5217+55e07320.x86_64
+  - ghc-template-haskell-devel-0:2.15.0.0-83.module_f29+5217+55e07320.x86_64
+  - ghc-terminfo-0:0.4.1.4-83.module_f29+5217+55e07320.x86_64
+  - ghc-terminfo-debuginfo-0:0.4.1.4-83.module_f29+5217+55e07320.x86_64
+  - ghc-terminfo-devel-0:0.4.1.4-83.module_f29+5217+55e07320.x86_64
+  - ghc-text-0:1.2.3.1-83.module_f29+5217+55e07320.x86_64
+  - ghc-text-debuginfo-0:1.2.3.1-83.module_f29+5217+55e07320.x86_64
+  - ghc-text-devel-0:1.2.3.1-83.module_f29+5217+55e07320.x86_64
+  - ghc-time-0:1.9.3-83.module_f29+5217+55e07320.x86_64
+  - ghc-time-debuginfo-0:1.9.3-83.module_f29+5217+55e07320.x86_64
+  - ghc-time-devel-0:1.9.3-83.module_f29+5217+55e07320.x86_64
+  - ghc-transformers-0:0.5.6.2-83.module_f29+5217+55e07320.x86_64
+  - ghc-transformers-debuginfo-0:0.5.6.2-83.module_f29+5217+55e07320.x86_64
+  - ghc-transformers-devel-0:0.5.6.2-83.module_f29+5217+55e07320.x86_64
+  - ghc-unix-0:2.7.2.2-83.module_f29+5217+55e07320.x86_64
+  - ghc-unix-debuginfo-0:2.7.2.2-83.module_f29+5217+55e07320.x86_64
+  - ghc-unix-devel-0:2.7.2.2-83.module_f29+5217+55e07320.x86_64
+  - ghc-xhtml-0:3000.2.2.1-83.module_f29+5217+55e07320.x86_64
+  - ghc-xhtml-debuginfo-0:3000.2.2.1-83.module_f29+5217+55e07320.x86_64
+  - ghc-xhtml-devel-0:3000.2.2.1-83.module_f29+5217+55e07320.x86_64
+  context: 4a994e80
+  dependencies: []
+  name: ghc
+  profiles:
+    default:
+      description: standard installation
+      rpms:
+      - ghc
+    minimal:
+      description: just compiler and base
+      rpms:
+      - ghc-base-devel
+    small:
+      description: compiler with main core libs
+      rpms:
+      - ghc-libraries
+  repository_memberships:
+  - dest1
+  stream: '8.8'
+  unit_id: (hidden)
+  version: 2920190727145047
+- _class: ModulemdUnit
+  arch: x86_64
+  artifacts:
+  - gimp-2:2.10.12-3.module_f29+6176+86aefa84.src
+  - gimp-2:2.10.12-3.module_f29+6176+86aefa84.x86_64
+  - gimp-debuginfo-2:2.10.12-3.module_f29+6176+86aefa84.x86_64
+  - gimp-debugsource-2:2.10.12-3.module_f29+6176+86aefa84.x86_64
+  - gimp-devel-2:2.10.12-3.module_f29+6176+86aefa84.x86_64
+  - gimp-devel-tools-2:2.10.12-3.module_f29+6176+86aefa84.x86_64
+  - gimp-devel-tools-debuginfo-2:2.10.12-3.module_f29+6176+86aefa84.x86_64
+  - gimp-libs-2:2.10.12-3.module_f29+6176+86aefa84.x86_64
+  - gimp-libs-debuginfo-2:2.10.12-3.module_f29+6176+86aefa84.x86_64
+  context: 6c81f848
+  dependencies: []
+  name: gimp
+  profiles:
+    default:
+      rpms:
+      - gimp
+    devel:
+      rpms:
+      - gimp-devel
+      - gimp-devel-tools
+  repository_memberships:
+  - dest1
+  stream: '2.10'
+  unit_id: (hidden)
+  version: 2920190904121229
+- _class: ModulemdUnit
+  arch: x86_64
+  artifacts:
+  - heatseeker-0:1.6.1-2.module_f29+5144+99cb4f00.x86_64
+  - heatseeker-debuginfo-0:1.6.1-2.module_f29+5144+99cb4f00.x86_64
+  - rust-heatseeker-0:1.6.1-2.module_f29+5144+99cb4f00.src
+  - rust-heatseeker-debugsource-0:1.6.1-2.module_f29+5144+99cb4f00.x86_64
+  context: c5ebb199
+  dependencies: []
+  name: heatseeker
+  profiles:
+    default:
+      rpms:
+      - heatseeker
+  repository_memberships:
+  - dest1
+  stream: latest
+  unit_id: (hidden)
+  version: 2920190721075449
+- _class: ModulemdUnit
+  arch: x86_64
+  artifacts:
+  - http-parser-0:2.9.2-2.module_f29+5443+cbf9b748.src
+  - http-parser-0:2.9.2-2.module_f29+5443+cbf9b748.x86_64
+  - http-parser-debuginfo-0:2.9.2-2.module_f29+5443+cbf9b748.x86_64
+  - http-parser-debugsource-0:2.9.2-2.module_f29+5443+cbf9b748.x86_64
+  - http-parser-devel-0:2.9.2-2.module_f29+5443+cbf9b748.x86_64
+  - libnghttp2-0:1.39.2-1.module_f29+5959+e526a653.x86_64
+  - libnghttp2-debuginfo-0:1.39.2-1.module_f29+5959+e526a653.x86_64
+  - libnghttp2-devel-0:1.39.2-1.module_f29+5959+e526a653.x86_64
+  - libuv-1:1.30.1-1.module_f29+5443+cbf9b748.src
+  - libuv-1:1.30.1-1.module_f29+5443+cbf9b748.x86_64
+  - libuv-debuginfo-1:1.30.1-1.module_f29+5443+cbf9b748.x86_64
+  - libuv-debugsource-1:1.30.1-1.module_f29+5443+cbf9b748.x86_64
+  - libuv-devel-1:1.30.1-1.module_f29+5443+cbf9b748.x86_64
+  - libuv-static-1:1.30.1-1.module_f29+5443+cbf9b748.x86_64
+  - nghttp2-0:1.39.2-1.module_f29+5959+e526a653.src
+  - nghttp2-0:1.39.2-1.module_f29+5959+e526a653.x86_64
+  - nghttp2-debuginfo-0:1.39.2-1.module_f29+5959+e526a653.x86_64
+  - nghttp2-debugsource-0:1.39.2-1.module_f29+5959+e526a653.x86_64
+  - nodejs-1:10.16.3-1.module_f29+5959+e526a653.src
+  - nodejs-1:10.16.3-1.module_f29+5959+e526a653.x86_64
+  - nodejs-debuginfo-1:10.16.3-1.module_f29+5959+e526a653.x86_64
+  - nodejs-debugsource-1:10.16.3-1.module_f29+5959+e526a653.x86_64
+  - nodejs-devel-1:10.16.3-1.module_f29+5959+e526a653.x86_64
+  - nodejs-docs-1:10.16.3-1.module_f29+5959+e526a653.noarch
+  - nodejs-libs-1:10.16.3-1.module_f29+5959+e526a653.x86_64
+  - nodejs-libs-debuginfo-1:10.16.3-1.module_f29+5959+e526a653.x86_64
+  - npm-1:6.9.0-1.10.16.3.1.module_f29+5959+e526a653.x86_64
+  - v8-devel-1:6.8.275.32-1.10.16.3.1.module_f29+5959+e526a653.x86_64
+  context: 6c81f848
+  dependencies: []
+  name: nodejs
+  profiles:
+    default:
+      rpms:
+      - nodejs
+      - npm
+    development:
+      rpms:
+      - nodejs
+      - nodejs-devel
+      - npm
+    minimal:
+      rpms:
+      - nodejs
+  repository_memberships:
+  - dest1
+  stream: '10'
+  unit_id: (hidden)
+  version: 2920190816104510
+- _class: ModulemdUnit
+  arch: x86_64
+  artifacts:
+  - hyperfine-0:1.6.0-2.module_f29+5141+d706e1cb.x86_64
+  - hyperfine-debuginfo-0:1.6.0-2.module_f29+5141+d706e1cb.x86_64
+  - rust-hyperfine-0:1.6.0-2.module_f29+5141+d706e1cb.src
+  - rust-hyperfine-debugsource-0:1.6.0-2.module_f29+5141+d706e1cb.x86_64
+  context: c5ebb199
+  dependencies: []
+  name: hyperfine
+  profiles:
+    default:
+      rpms:
+      - hyperfine
+  repository_memberships:
+  - dest1
+  stream: latest
+  unit_id: (hidden)
+  version: 2920190721071357
+- _class: ModulemdUnit
+  arch: x86_64
+  artifacts:
+  - libgit2-0:0.26.8-1.module_2403+7aeb62bd.aarch64
+  - libgit2-0:0.26.8-1.module_2403+7aeb62bd.armv7hl
+  - libgit2-0:0.26.8-1.module_2403+7aeb62bd.ppc64le
+  - libgit2-0:0.26.8-1.module_2403+7aeb62bd.s390x
+  - libgit2-0:0.26.8-1.module_2403+7aeb62bd.src
+  - libgit2-0:0.26.8-1.module_2403+7aeb62bd.x86_64
+  - libgit2-debuginfo-0:0.26.8-1.module_2403+7aeb62bd.aarch64
+  - libgit2-debuginfo-0:0.26.8-1.module_2403+7aeb62bd.armv7hl
+  - libgit2-debuginfo-0:0.26.8-1.module_2403+7aeb62bd.ppc64le
+  - libgit2-debuginfo-0:0.26.8-1.module_2403+7aeb62bd.s390x
+  - libgit2-debuginfo-0:0.26.8-1.module_2403+7aeb62bd.x86_64
+  - libgit2-debugsource-0:0.26.8-1.module_2403+7aeb62bd.aarch64
+  - libgit2-debugsource-0:0.26.8-1.module_2403+7aeb62bd.armv7hl
+  - libgit2-debugsource-0:0.26.8-1.module_2403+7aeb62bd.ppc64le
+  - libgit2-debugsource-0:0.26.8-1.module_2403+7aeb62bd.s390x
+  - libgit2-debugsource-0:0.26.8-1.module_2403+7aeb62bd.x86_64
+  - libgit2-devel-0:0.26.8-1.module_2403+7aeb62bd.aarch64
+  - libgit2-devel-0:0.26.8-1.module_2403+7aeb62bd.armv7hl
+  - libgit2-devel-0:0.26.8-1.module_2403+7aeb62bd.ppc64le
+  - libgit2-devel-0:0.26.8-1.module_2403+7aeb62bd.s390x
+  - libgit2-devel-0:0.26.8-1.module_2403+7aeb62bd.x86_64
+  - python-pygit2-0:0.26.4-1.module_2241+da9f6017.src
+  - python-pygit2-debuginfo-0:0.26.4-1.module_2241+da9f6017.aarch64
+  - python-pygit2-debuginfo-0:0.26.4-1.module_2241+da9f6017.armv7hl
+  - python-pygit2-debuginfo-0:0.26.4-1.module_2241+da9f6017.ppc64le
+  - python-pygit2-debuginfo-0:0.26.4-1.module_2241+da9f6017.s390x
+  - python-pygit2-debuginfo-0:0.26.4-1.module_2241+da9f6017.x86_64
+  - python-pygit2-debugsource-0:0.26.4-1.module_2241+da9f6017.aarch64
+  - python-pygit2-debugsource-0:0.26.4-1.module_2241+da9f6017.armv7hl
+  - python-pygit2-debugsource-0:0.26.4-1.module_2241+da9f6017.ppc64le
+  - python-pygit2-debugsource-0:0.26.4-1.module_2241+da9f6017.s390x
+  - python-pygit2-debugsource-0:0.26.4-1.module_2241+da9f6017.x86_64
+  - python-pygit2-doc-0:0.26.4-1.module_2241+da9f6017.noarch
+  - python2-pygit2-0:0.26.4-1.module_2241+da9f6017.aarch64
+  - python2-pygit2-0:0.26.4-1.module_2241+da9f6017.armv7hl
+  - python2-pygit2-0:0.26.4-1.module_2241+da9f6017.ppc64le
+  - python2-pygit2-0:0.26.4-1.module_2241+da9f6017.s390x
+  - python2-pygit2-0:0.26.4-1.module_2241+da9f6017.x86_64
+  - python2-pygit2-debuginfo-0:0.26.4-1.module_2241+da9f6017.aarch64
+  - python2-pygit2-debuginfo-0:0.26.4-1.module_2241+da9f6017.armv7hl
+  - python2-pygit2-debuginfo-0:0.26.4-1.module_2241+da9f6017.ppc64le
+  - python2-pygit2-debuginfo-0:0.26.4-1.module_2241+da9f6017.s390x
+  - python2-pygit2-debuginfo-0:0.26.4-1.module_2241+da9f6017.x86_64
+  - python3-pygit2-0:0.26.4-1.module_2241+da9f6017.aarch64
+  - python3-pygit2-0:0.26.4-1.module_2241+da9f6017.armv7hl
+  - python3-pygit2-0:0.26.4-1.module_2241+da9f6017.ppc64le
+  - python3-pygit2-0:0.26.4-1.module_2241+da9f6017.s390x
+  - python3-pygit2-0:0.26.4-1.module_2241+da9f6017.x86_64
+  - python3-pygit2-debuginfo-0:0.26.4-1.module_2241+da9f6017.aarch64
+  - python3-pygit2-debuginfo-0:0.26.4-1.module_2241+da9f6017.armv7hl
+  - python3-pygit2-debuginfo-0:0.26.4-1.module_2241+da9f6017.ppc64le
+  - python3-pygit2-debuginfo-0:0.26.4-1.module_2241+da9f6017.s390x
+  - python3-pygit2-debuginfo-0:0.26.4-1.module_2241+da9f6017.x86_64
+  context: 6c81f848
+  dependencies: []
+  name: libgit2
+  repository_memberships:
+  - dest1
+  stream: '0.26'
+  unit_id: (hidden)
+  version: 20181103165214
+- _class: ModulemdUnit
+  arch: x86_64
+  artifacts:
+  - libgit2-0:0.27.8-1.module_f29+2764+dbb9cdda.src
+  - libgit2-0:0.27.8-1.module_f29+2764+dbb9cdda.x86_64
+  - libgit2-debuginfo-0:0.27.8-1.module_f29+2764+dbb9cdda.x86_64
+  - libgit2-debugsource-0:0.27.8-1.module_f29+2764+dbb9cdda.x86_64
+  - libgit2-devel-0:0.27.8-1.module_f29+2764+dbb9cdda.x86_64
+  - python-pygit2-0:0.27.4-1.module_f29+2764+dbb9cdda.src
+  - python-pygit2-doc-0:0.27.4-1.module_f29+2764+dbb9cdda.noarch
+  - python2-pygit2-0:0.27.4-1.module_f29+2764+dbb9cdda.x86_64
+  - python2-pygit2-debuginfo-0:0.27.4-1.module_f29+2764+dbb9cdda.x86_64
+  - python3-pygit2-0:0.27.4-1.module_f29+2764+dbb9cdda.x86_64
+  - python3-pygit2-debuginfo-0:0.27.4-1.module_f29+2764+dbb9cdda.x86_64
+  context: 6c81f848
+  dependencies: []
+  name: libgit2
+  repository_memberships:
+  - dest1
+  stream: '0.27'
+  unit_id: (hidden)
+  version: 2920190128145600
+- _class: ModulemdUnit
+  arch: x86_64
+  artifacts:
+  - libgit2-0:0.28.2-1.module_f29+4569+f92f935f.src
+  - libgit2-0:0.28.2-1.module_f29+4569+f92f935f.x86_64
+  - libgit2-debuginfo-0:0.28.2-1.module_f29+4569+f92f935f.x86_64
+  - libgit2-debugsource-0:0.28.2-1.module_f29+4569+f92f935f.x86_64
+  - libgit2-devel-0:0.28.2-1.module_f29+4569+f92f935f.x86_64
+  - python-pygit2-0:0.28.2-1.module_f29+4569+f92f935f.src
+  - python-pygit2-debuginfo-0:0.28.2-1.module_f29+4569+f92f935f.x86_64
+  - python-pygit2-debugsource-0:0.28.2-1.module_f29+4569+f92f935f.x86_64
+  - python-pygit2-doc-0:0.28.2-1.module_f29+4569+f92f935f.noarch
+  - python2-pygit2-0:0.28.2-1.module_f29+4569+f92f935f.x86_64
+  - python2-pygit2-debuginfo-0:0.28.2-1.module_f29+4569+f92f935f.x86_64
+  - python3-pygit2-0:0.28.2-1.module_f29+4569+f92f935f.x86_64
+  - python3-pygit2-debuginfo-0:0.28.2-1.module_f29+4569+f92f935f.x86_64
+  context: 6c81f848
+  dependencies: []
+  name: libgit2
+  repository_memberships:
+  - dest1
+  stream: '0.28'
+  unit_id: (hidden)
+  version: 2920190606170438
+- _class: ModulemdUnit
+  arch: x86_64
+  artifacts:
+  - librealsense-0:2.23.0-2.module_f29+5412+fad57365.src
+  - librealsense-0:2.23.0-2.module_f29+5412+fad57365.x86_64
+  - librealsense-debuginfo-0:2.23.0-2.module_f29+5412+fad57365.x86_64
+  - librealsense-debugsource-0:2.23.0-2.module_f29+5412+fad57365.x86_64
+  - librealsense-devel-0:2.23.0-2.module_f29+5412+fad57365.x86_64
+  - librealsense-doc-0:2.23.0-2.module_f29+5412+fad57365.x86_64
+  context: 6c81f848
+  dependencies: []
+  name: librealsense
+  profiles:
+    default:
+      description: A standard installation.
+      rpms:
+      - librealsense
+    dev:
+      description: Development with librealsense.
+      rpms:
+      - librealsense
+      - librealsense-devel
+  repository_memberships:
+  - dest1
+  stream: rolling
+  unit_id: (hidden)
+  version: 2920190813195551
+- _class: ModulemdUnit
+  arch: x86_64
+  artifacts:
+  - lizardfs-0:3.13.0-0.rc1r1.module_f29+5417+07e87f5f.src
+  - lizardfs-adm-0:3.13.0-0.rc1r1.module_f29+5417+07e87f5f.x86_64
+  - lizardfs-adm-debuginfo-0:3.13.0-0.rc1r1.module_f29+5417+07e87f5f.x86_64
+  - lizardfs-cgi-0:3.13.0-0.rc1r1.module_f29+5417+07e87f5f.x86_64
+  - lizardfs-cgiserv-0:3.13.0-0.rc1r1.module_f29+5417+07e87f5f.x86_64
+  - lizardfs-chunkserver-0:3.13.0-0.rc1r1.module_f29+5417+07e87f5f.x86_64
+  - lizardfs-chunkserver-debuginfo-0:3.13.0-0.rc1r1.module_f29+5417+07e87f5f.x86_64
+  - lizardfs-client-0:3.13.0-0.rc1r1.module_f29+5417+07e87f5f.x86_64
+  - lizardfs-client-debuginfo-0:3.13.0-0.rc1r1.module_f29+5417+07e87f5f.x86_64
+  - lizardfs-debuginfo-0:3.13.0-0.rc1r1.module_f29+5417+07e87f5f.x86_64
+  - lizardfs-debugsource-0:3.13.0-0.rc1r1.module_f29+5417+07e87f5f.x86_64
+  - lizardfs-master-0:3.13.0-0.rc1r1.module_f29+5417+07e87f5f.x86_64
+  - lizardfs-master-debuginfo-0:3.13.0-0.rc1r1.module_f29+5417+07e87f5f.x86_64
+  - lizardfs-metalogger-0:3.13.0-0.rc1r1.module_f29+5417+07e87f5f.x86_64
+  - lizardfs-metalogger-debuginfo-0:3.13.0-0.rc1r1.module_f29+5417+07e87f5f.x86_64
+  - lizardfs-uraft-0:3.13.0-0.rc1r1.module_f29+5417+07e87f5f.x86_64
+  - lizardfs-uraft-debuginfo-0:3.13.0-0.rc1r1.module_f29+5417+07e87f5f.x86_64
+  context: 6c81f848
+  dependencies: []
+  name: lizardfs
+  profiles:
+    chunkserver:
+      description: LizardFS chunkserver
+      rpms:
+      - lizardfs-chunkserver
+    default:
+      description: The LizardFS client software
+      rpms:
+      - lizardfs-client
+    metadata-server:
+      description: LizardFS metadata server
+      rpms:
+      - lizardfs-adm
+      - lizardfs-cgi
+      - lizardfs-master
+    metalogger:
+      description: LizardFS metadata logging server
+      rpms:
+      - lizardfs-metalogger
+  repository_memberships:
+  - dest1
+  stream: devel
+  unit_id: (hidden)
+  version: 2920190824162217
+- _class: ModulemdUnit
+  arch: x86_64
+  artifacts:
+  - lsd-0:0.16.0-1.module_f29+5274+b191998f.x86_64
+  - lsd-debuginfo-0:0.16.0-1.module_f29+5274+b191998f.x86_64
+  - rust-lsd-0:0.16.0-1.module_f29+5274+b191998f.src
+  - rust-lsd-debugsource-0:0.16.0-1.module_f29+5274+b191998f.x86_64
+  context: c5ebb199
+  dependencies: []
+  name: lsd
+  profiles:
+    default:
+      rpms:
+      - lsd
+  repository_memberships:
+  - dest1
+  stream: rolling
+  unit_id: (hidden)
+  version: 2920190803124134
+- _class: ModulemdUnit
+  arch: x86_64
+  artifacts:
+  - mako-0:1.4-1.module_f29+6137+87eab977.src
+  - mako-0:1.4-1.module_f29+6137+87eab977.x86_64
+  - mako-debuginfo-0:1.4-1.module_f29+6137+87eab977.x86_64
+  - mako-debugsource-0:1.4-1.module_f29+6137+87eab977.x86_64
+  - rofi-0:1.5.4-1.module_f29+5895+db11ea68.src
+  - rofi-0:1.5.4-1.module_f29+5895+db11ea68.x86_64
+  - rofi-debuginfo-0:1.5.4-1.module_f29+5895+db11ea68.x86_64
+  - rofi-debugsource-0:1.5.4-1.module_f29+5895+db11ea68.x86_64
+  - rofi-devel-0:1.5.4-1.module_f29+5895+db11ea68.x86_64
+  - rofi-devel-doc-0:1.5.4-1.module_f29+5895+db11ea68.noarch
+  - rofi-themes-0:1.5.4-1.module_f29+5895+db11ea68.noarch
+  - sway-0:1.2-1.module_f29+6137+87eab977.src
+  - sway-0:1.2-1.module_f29+6137+87eab977.x86_64
+  - sway-debuginfo-0:1.2-1.module_f29+6137+87eab977.x86_64
+  - sway-debugsource-0:1.2-1.module_f29+6137+87eab977.x86_64
+  - swaybg-0:1.0-2.module_f29+5895+db11ea68.src
+  - swaybg-0:1.0-2.module_f29+5895+db11ea68.x86_64
+  - swaybg-debuginfo-0:1.0-2.module_f29+5895+db11ea68.x86_64
+  - swaybg-debugsource-0:1.0-2.module_f29+5895+db11ea68.x86_64
+  - swayidle-0:1.5-2.module_f29+5895+db11ea68.src
+  - swayidle-0:1.5-2.module_f29+5895+db11ea68.x86_64
+  - swayidle-debuginfo-0:1.5-2.module_f29+5895+db11ea68.x86_64
+  - swayidle-debugsource-0:1.5-2.module_f29+5895+db11ea68.x86_64
+  - swaylock-0:1.4-2.module_f29+5895+db11ea68.src
+  - swaylock-0:1.4-2.module_f29+5895+db11ea68.x86_64
+  - swaylock-debuginfo-0:1.4-2.module_f29+5895+db11ea68.x86_64
+  - swaylock-debugsource-0:1.4-2.module_f29+5895+db11ea68.x86_64
+  - wayland-protocols-0:1.18-1.module_f29+5895+db11ea68.src
+  - wayland-protocols-devel-0:1.18-1.module_f29+5895+db11ea68.noarch
+  - wlroots-0:0.7.0-1.module_f29+6137+87eab977.src
+  - wlroots-0:0.7.0-1.module_f29+6137+87eab977.x86_64
+  - wlroots-debuginfo-0:0.7.0-1.module_f29+6137+87eab977.x86_64
+  - wlroots-debugsource-0:0.7.0-1.module_f29+6137+87eab977.x86_64
+  - wlroots-devel-0:0.7.0-1.module_f29+6137+87eab977.x86_64
+  context: 6c81f848
+  dependencies: []
+  name: sway
+  profiles:
+    default:
+      description: A standard installation.
+      rpms:
+      - sway
+      - swaybg
+      - swayidle
+      - swaylock
+    full:
+      description: A full installation including all optional packages.
+      rpms:
+      - mako
+      - rofi
+      - sway
+      - swaybg
+      - swayidle
+      - swaylock
+  repository_memberships:
+  - dest1
+  stream: rolling
+  unit_id: (hidden)
+  version: 2920190901112359
+- _class: ModulemdUnit
+  arch: x86_64
+  artifacts:
+  - meson-0:0.50.1-1.module_f29+3965+7871328a.noarch
+  - meson-0:0.50.1-1.module_f29+3965+7871328a.src
+  context: 06d0a27d
+  dependencies:
+  - _class: ModulemdDependency
+    name: ninja
+  name: meson
+  profiles:
+    default:
+      rpms:
+      - meson
+  repository_memberships:
+  - dest1
+  stream: latest
+  unit_id: (hidden)
+  version: 2920190417114446
+- _class: ModulemdUnit
+  arch: x86_64
+  artifacts:
+  - minetest-0:5.0.0-1.module_f29+3568+6fedc27b.src
+  - minetest-0:5.0.0-1.module_f29+3568+6fedc27b.x86_64
+  - minetest-debuginfo-0:5.0.0-1.module_f29+3568+6fedc27b.x86_64
+  - minetest-debugsource-0:5.0.0-1.module_f29+3568+6fedc27b.x86_64
+  - minetest-server-0:5.0.0-1.module_f29+3568+6fedc27b.x86_64
+  - minetest-server-debuginfo-0:5.0.0-1.module_f29+3568+6fedc27b.x86_64
+  context: 6c81f848
+  dependencies: []
+  name: minetest
+  profiles:
+    client:
+      rpms:
+      - minetest
+    server:
+      rpms:
+      - minetest-server
+  repository_memberships:
+  - dest1
+  stream: '5'
+  unit_id: (hidden)
+  version: 2920190308194723
+- _class: ModulemdUnit
+  arch: x86_64
+  artifacts:
+  - nest-0:2.16.0-11.module_f29+5114+046f4a1f.src
+  - nest-0:2.16.0-11.module_f29+5114+046f4a1f.x86_64
+  - nest-common-0:2.16.0-11.module_f29+5114+046f4a1f.noarch
+  - nest-debuginfo-0:2.16.0-11.module_f29+5114+046f4a1f.x86_64
+  - nest-debugsource-0:2.16.0-11.module_f29+5114+046f4a1f.x86_64
+  - nest-doc-0:2.16.0-11.module_f29+5114+046f4a1f.noarch
+  - nest-headers-0:2.16.0-11.module_f29+5114+046f4a1f.noarch
+  - nest-mpich-0:2.16.0-11.module_f29+5114+046f4a1f.x86_64
+  - nest-mpich-common-0:2.16.0-11.module_f29+5114+046f4a1f.x86_64
+  - nest-mpich-debuginfo-0:2.16.0-11.module_f29+5114+046f4a1f.x86_64
+  - nest-mpich-headers-0:2.16.0-11.module_f29+5114+046f4a1f.x86_64
+  - nest-openmpi-0:2.16.0-11.module_f29+5114+046f4a1f.x86_64
+  - nest-openmpi-common-0:2.16.0-11.module_f29+5114+046f4a1f.x86_64
+  - nest-openmpi-debuginfo-0:2.16.0-11.module_f29+5114+046f4a1f.x86_64
+  - nest-openmpi-headers-0:2.16.0-11.module_f29+5114+046f4a1f.x86_64
+  - python2-nest-0:2.16.0-11.module_f29+5114+046f4a1f.x86_64
+  - python2-nest-debuginfo-0:2.16.0-11.module_f29+5114+046f4a1f.x86_64
+  - python2-nest-mpich-0:2.16.0-11.module_f29+5114+046f4a1f.x86_64
+  - python2-nest-mpich-debuginfo-0:2.16.0-11.module_f29+5114+046f4a1f.x86_64
+  - python2-nest-openmpi-0:2.16.0-11.module_f29+5114+046f4a1f.x86_64
+  - python2-nest-openmpi-debuginfo-0:2.16.0-11.module_f29+5114+046f4a1f.x86_64
+  - python3-nest-0:2.16.0-11.module_f29+5114+046f4a1f.x86_64
+  - python3-nest-debuginfo-0:2.16.0-11.module_f29+5114+046f4a1f.x86_64
+  - python3-nest-mpich-0:2.16.0-11.module_f29+5114+046f4a1f.x86_64
+  - python3-nest-mpich-debuginfo-0:2.16.0-11.module_f29+5114+046f4a1f.x86_64
+  - python3-nest-openmpi-0:2.16.0-11.module_f29+5114+046f4a1f.x86_64
+  - python3-nest-openmpi-debuginfo-0:2.16.0-11.module_f29+5114+046f4a1f.x86_64
+  context: 6c81f848
+  dependencies: []
+  name: nest
+  profiles:
+    default:
+      description: A standard NEST installation
+      rpms:
+      - nest
+      - nest-common
+      - nest-doc
+      - nest-headers
+      - python3-nest
+    mpich:
+      description: NEST built with MPICH
+      rpms:
+      - nest-mpich
+      - nest-mpich-common
+      - nest-mpich-headers
+      - python3-nest-mpich
+    openmpi:
+      description: NEST built with OpenMPI
+      rpms:
+      - nest-openmpi
+      - nest-openmpi-common
+      - nest-openmpi-headers
+      - python3-nest-openmpi
+  repository_memberships:
+  - dest1
+  stream: 2.16.0
+  unit_id: (hidden)
+  version: 2920190731163251
+- _class: ModulemdUnit
+  arch: x86_64
+  artifacts:
+  - newsboat-0:2.16.1-2.module_f29+5174+0044ee9c.src
+  - newsboat-0:2.16.1-2.module_f29+5174+0044ee9c.x86_64
+  - newsboat-debuginfo-0:2.16.1-2.module_f29+5174+0044ee9c.x86_64
+  - newsboat-debugsource-0:2.16.1-2.module_f29+5174+0044ee9c.x86_64
+  context: c5ebb199
+  dependencies: []
+  name: newsboat
+  profiles:
+    default:
+      rpms:
+      - newsboat
+  repository_memberships:
+  - dest1
+  stream: latest
+  unit_id: (hidden)
+  version: 2920190722112326
+- _class: ModulemdUnit
+  arch: x86_64
+  artifacts:
+  - nginx-1:1.16.0-3.module_f29+5006+c4920bcb.src
+  - nginx-1:1.16.0-3.module_f29+5006+c4920bcb.x86_64
+  - nginx-all-modules-1:1.16.0-3.module_f29+5006+c4920bcb.noarch
+  - nginx-debuginfo-1:1.16.0-3.module_f29+5006+c4920bcb.x86_64
+  - nginx-debugsource-1:1.16.0-3.module_f29+5006+c4920bcb.x86_64
+  - nginx-filesystem-1:1.16.0-3.module_f29+5006+c4920bcb.noarch
+  - nginx-mod-http-image-filter-1:1.16.0-3.module_f29+5006+c4920bcb.x86_64
+  - nginx-mod-http-image-filter-debuginfo-1:1.16.0-3.module_f29+5006+c4920bcb.x86_64
+  - nginx-mod-http-perl-1:1.16.0-3.module_f29+5006+c4920bcb.x86_64
+  - nginx-mod-http-perl-debuginfo-1:1.16.0-3.module_f29+5006+c4920bcb.x86_64
+  - nginx-mod-http-xslt-filter-1:1.16.0-3.module_f29+5006+c4920bcb.x86_64
+  - nginx-mod-http-xslt-filter-debuginfo-1:1.16.0-3.module_f29+5006+c4920bcb.x86_64
+  - nginx-mod-mail-1:1.16.0-3.module_f29+5006+c4920bcb.x86_64
+  - nginx-mod-mail-debuginfo-1:1.16.0-3.module_f29+5006+c4920bcb.x86_64
+  - nginx-mod-stream-1:1.16.0-3.module_f29+5006+c4920bcb.x86_64
+  - nginx-mod-stream-debuginfo-1:1.16.0-3.module_f29+5006+c4920bcb.x86_64
+  context: 6c81f848
+  dependencies: []
+  name: nginx
+  profiles:
+    common:
+      rpms:
+      - nginx
+      - nginx-all-modules
+      - nginx-filesystem
+      - nginx-mod-http-image-filter
+      - nginx-mod-http-perl
+      - nginx-mod-http-xslt-filter
+      - nginx-mod-mail
+      - nginx-mod-stream
+  repository_memberships:
+  - dest1
+  stream: '1.16'
+  unit_id: (hidden)
+  version: 2920190711155942
+- _class: ModulemdUnit
+  arch: x86_64
+  artifacts:
+  - nginx-1:1.17.3-1.module_f29+5964+40dc5dba.src
+  - nginx-1:1.17.3-1.module_f29+5964+40dc5dba.x86_64
+  - nginx-all-modules-1:1.17.3-1.module_f29+5964+40dc5dba.noarch
+  - nginx-debuginfo-1:1.17.3-1.module_f29+5964+40dc5dba.x86_64
+  - nginx-debugsource-1:1.17.3-1.module_f29+5964+40dc5dba.x86_64
+  - nginx-filesystem-1:1.17.3-1.module_f29+5964+40dc5dba.noarch
+  - nginx-mod-http-image-filter-1:1.17.3-1.module_f29+5964+40dc5dba.x86_64
+  - nginx-mod-http-image-filter-debuginfo-1:1.17.3-1.module_f29+5964+40dc5dba.x86_64
+  - nginx-mod-http-perl-1:1.17.3-1.module_f29+5964+40dc5dba.x86_64
+  - nginx-mod-http-perl-debuginfo-1:1.17.3-1.module_f29+5964+40dc5dba.x86_64
+  - nginx-mod-http-xslt-filter-1:1.17.3-1.module_f29+5964+40dc5dba.x86_64
+  - nginx-mod-http-xslt-filter-debuginfo-1:1.17.3-1.module_f29+5964+40dc5dba.x86_64
+  - nginx-mod-mail-1:1.17.3-1.module_f29+5964+40dc5dba.x86_64
+  - nginx-mod-mail-debuginfo-1:1.17.3-1.module_f29+5964+40dc5dba.x86_64
+  - nginx-mod-stream-1:1.17.3-1.module_f29+5964+40dc5dba.x86_64
+  - nginx-mod-stream-debuginfo-1:1.17.3-1.module_f29+5964+40dc5dba.x86_64
+  context: 6c81f848
+  dependencies: []
+  name: nginx
+  profiles:
+    common:
+      rpms:
+      - nginx
+      - nginx-all-modules
+      - nginx-filesystem
+      - nginx-mod-http-image-filter
+      - nginx-mod-http-perl
+      - nginx-mod-http-xslt-filter
+      - nginx-mod-mail
+      - nginx-mod-stream
+  repository_memberships:
+  - dest1
+  stream: mainline
+  unit_id: (hidden)
+  version: 2920190816153353
+- _class: ModulemdUnit
+  arch: x86_64
+  artifacts:
+  - ninja-build-0:1.9.0-1.module_f29+2771+09509018.src
+  - ninja-build-0:1.9.0-1.module_f29+2771+09509018.x86_64
+  - ninja-build-debuginfo-0:1.9.0-1.module_f29+2771+09509018.x86_64
+  - ninja-build-debugsource-0:1.9.0-1.module_f29+2771+09509018.x86_64
+  context: 6c81f848
+  dependencies: []
+  name: ninja
+  profiles:
+    default:
+      rpms:
+      - ninja-build
+  repository_memberships:
+  - dest1
+  stream: latest
+  unit_id: (hidden)
+  version: 2920190131012415
+- _class: ModulemdUnit
+  arch: x86_64
+  artifacts:
+  - octave-6:4.4.1-1.module_2492+b120f89b.aarch64
+  - octave-6:4.4.1-1.module_2492+b120f89b.armv7hl
+  - octave-6:4.4.1-1.module_2492+b120f89b.ppc64le
+  - octave-6:4.4.1-1.module_2492+b120f89b.s390x
+  - octave-6:4.4.1-1.module_2492+b120f89b.src
+  - octave-6:4.4.1-1.module_2492+b120f89b.x86_64
+  - octave-control-0:3.1.0-3.module_2492+b120f89b.aarch64
+  - octave-control-0:3.1.0-3.module_2492+b120f89b.armv7hl
+  - octave-control-0:3.1.0-3.module_2492+b120f89b.ppc64le
+  - octave-control-0:3.1.0-3.module_2492+b120f89b.s390x
+  - octave-control-0:3.1.0-3.module_2492+b120f89b.src
+  - octave-control-0:3.1.0-3.module_2492+b120f89b.x86_64
+  - octave-control-debuginfo-0:3.1.0-3.module_2492+b120f89b.aarch64
+  - octave-control-debuginfo-0:3.1.0-3.module_2492+b120f89b.armv7hl
+  - octave-control-debuginfo-0:3.1.0-3.module_2492+b120f89b.ppc64le
+  - octave-control-debuginfo-0:3.1.0-3.module_2492+b120f89b.s390x
+  - octave-control-debuginfo-0:3.1.0-3.module_2492+b120f89b.x86_64
+  - octave-control-debugsource-0:3.1.0-3.module_2492+b120f89b.aarch64
+  - octave-control-debugsource-0:3.1.0-3.module_2492+b120f89b.armv7hl
+  - octave-control-debugsource-0:3.1.0-3.module_2492+b120f89b.ppc64le
+  - octave-control-debugsource-0:3.1.0-3.module_2492+b120f89b.s390x
+  - octave-control-debugsource-0:3.1.0-3.module_2492+b120f89b.x86_64
+  - octave-debuginfo-6:4.4.1-1.module_2492+b120f89b.aarch64
+  - octave-debuginfo-6:4.4.1-1.module_2492+b120f89b.armv7hl
+  - octave-debuginfo-6:4.4.1-1.module_2492+b120f89b.ppc64le
+  - octave-debuginfo-6:4.4.1-1.module_2492+b120f89b.s390x
+  - octave-debuginfo-6:4.4.1-1.module_2492+b120f89b.x86_64
+  - octave-debugsource-6:4.4.1-1.module_2492+b120f89b.aarch64
+  - octave-debugsource-6:4.4.1-1.module_2492+b120f89b.armv7hl
+  - octave-debugsource-6:4.4.1-1.module_2492+b120f89b.ppc64le
+  - octave-debugsource-6:4.4.1-1.module_2492+b120f89b.s390x
+  - octave-debugsource-6:4.4.1-1.module_2492+b120f89b.x86_64
+  - octave-devel-6:4.4.1-1.module_2492+b120f89b.aarch64
+  - octave-devel-6:4.4.1-1.module_2492+b120f89b.armv7hl
+  - octave-devel-6:4.4.1-1.module_2492+b120f89b.ppc64le
+  - octave-devel-6:4.4.1-1.module_2492+b120f89b.s390x
+  - octave-devel-6:4.4.1-1.module_2492+b120f89b.x86_64
+  - octave-dicom-0:0.2.1-2.module_2492+b120f89b.aarch64
+  - octave-dicom-0:0.2.1-2.module_2492+b120f89b.armv7hl
+  - octave-dicom-0:0.2.1-2.module_2492+b120f89b.ppc64le
+  - octave-dicom-0:0.2.1-2.module_2492+b120f89b.s390x
+  - octave-dicom-0:0.2.1-2.module_2492+b120f89b.src
+  - octave-dicom-0:0.2.1-2.module_2492+b120f89b.x86_64
+  - octave-dicom-debuginfo-0:0.2.1-2.module_2492+b120f89b.aarch64
+  - octave-dicom-debuginfo-0:0.2.1-2.module_2492+b120f89b.armv7hl
+  - octave-dicom-debuginfo-0:0.2.1-2.module_2492+b120f89b.ppc64le
+  - octave-dicom-debuginfo-0:0.2.1-2.module_2492+b120f89b.s390x
+  - octave-dicom-debuginfo-0:0.2.1-2.module_2492+b120f89b.x86_64
+  - octave-dicom-debugsource-0:0.2.1-2.module_2492+b120f89b.aarch64
+  - octave-dicom-debugsource-0:0.2.1-2.module_2492+b120f89b.armv7hl
+  - octave-dicom-debugsource-0:0.2.1-2.module_2492+b120f89b.ppc64le
+  - octave-dicom-debugsource-0:0.2.1-2.module_2492+b120f89b.s390x
+  - octave-dicom-debugsource-0:0.2.1-2.module_2492+b120f89b.x86_64
+  - octave-doc-6:4.4.1-1.module_2492+b120f89b.noarch
+  - octave-doctest-0:0.6.1-4.module_2492+b120f89b.noarch
+  - octave-doctest-0:0.6.1-4.module_2492+b120f89b.src
+  - octave-general-0:2.1.0-1.module_2492+b120f89b.aarch64
+  - octave-general-0:2.1.0-1.module_2492+b120f89b.armv7hl
+  - octave-general-0:2.1.0-1.module_2492+b120f89b.ppc64le
+  - octave-general-0:2.1.0-1.module_2492+b120f89b.s390x
+  - octave-general-0:2.1.0-1.module_2492+b120f89b.src
+  - octave-general-0:2.1.0-1.module_2492+b120f89b.x86_64
+  - octave-general-debuginfo-0:2.1.0-1.module_2492+b120f89b.aarch64
+  - octave-general-debuginfo-0:2.1.0-1.module_2492+b120f89b.armv7hl
+  - octave-general-debuginfo-0:2.1.0-1.module_2492+b120f89b.ppc64le
+  - octave-general-debuginfo-0:2.1.0-1.module_2492+b120f89b.s390x
+  - octave-general-debuginfo-0:2.1.0-1.module_2492+b120f89b.x86_64
+  - octave-general-debugsource-0:2.1.0-1.module_2492+b120f89b.aarch64
+  - octave-general-debugsource-0:2.1.0-1.module_2492+b120f89b.armv7hl
+  - octave-general-debugsource-0:2.1.0-1.module_2492+b120f89b.ppc64le
+  - octave-general-debugsource-0:2.1.0-1.module_2492+b120f89b.s390x
+  - octave-general-debugsource-0:2.1.0-1.module_2492+b120f89b.x86_64
+  - octave-gsl-0:2.0.0-7.module_2492+b120f89b.aarch64
+  - octave-gsl-0:2.0.0-7.module_2492+b120f89b.armv7hl
+  - octave-gsl-0:2.0.0-7.module_2492+b120f89b.ppc64le
+  - octave-gsl-0:2.0.0-7.module_2492+b120f89b.s390x
+  - octave-gsl-0:2.0.0-7.module_2492+b120f89b.src
+  - octave-gsl-0:2.0.0-7.module_2492+b120f89b.x86_64
+  - octave-gsl-debuginfo-0:2.0.0-7.module_2492+b120f89b.aarch64
+  - octave-gsl-debuginfo-0:2.0.0-7.module_2492+b120f89b.armv7hl
+  - octave-gsl-debuginfo-0:2.0.0-7.module_2492+b120f89b.ppc64le
+  - octave-gsl-debuginfo-0:2.0.0-7.module_2492+b120f89b.s390x
+  - octave-gsl-debuginfo-0:2.0.0-7.module_2492+b120f89b.x86_64
+  - octave-gsl-debugsource-0:2.0.0-7.module_2492+b120f89b.aarch64
+  - octave-gsl-debugsource-0:2.0.0-7.module_2492+b120f89b.armv7hl
+  - octave-gsl-debugsource-0:2.0.0-7.module_2492+b120f89b.ppc64le
+  - octave-gsl-debugsource-0:2.0.0-7.module_2492+b120f89b.s390x
+  - octave-gsl-debugsource-0:2.0.0-7.module_2492+b120f89b.x86_64
+  - octave-image-0:2.8.1-1.module_2627+e073eacf.aarch64
+  - octave-image-0:2.8.1-1.module_2627+e073eacf.armv7hl
+  - octave-image-0:2.8.1-1.module_2627+e073eacf.ppc64le
+  - octave-image-0:2.8.1-1.module_2627+e073eacf.s390x
+  - octave-image-0:2.8.1-1.module_2627+e073eacf.src
+  - octave-image-0:2.8.1-1.module_2627+e073eacf.x86_64
+  - octave-image-debuginfo-0:2.8.1-1.module_2627+e073eacf.aarch64
+  - octave-image-debuginfo-0:2.8.1-1.module_2627+e073eacf.armv7hl
+  - octave-image-debuginfo-0:2.8.1-1.module_2627+e073eacf.ppc64le
+  - octave-image-debuginfo-0:2.8.1-1.module_2627+e073eacf.s390x
+  - octave-image-debuginfo-0:2.8.1-1.module_2627+e073eacf.x86_64
+  - octave-image-debugsource-0:2.8.1-1.module_2627+e073eacf.aarch64
+  - octave-image-debugsource-0:2.8.1-1.module_2627+e073eacf.armv7hl
+  - octave-image-debugsource-0:2.8.1-1.module_2627+e073eacf.ppc64le
+  - octave-image-debugsource-0:2.8.1-1.module_2627+e073eacf.s390x
+  - octave-image-debugsource-0:2.8.1-1.module_2627+e073eacf.x86_64
+  - octave-interval-0:3.2.0-3.module_2492+b120f89b.aarch64
+  - octave-interval-0:3.2.0-3.module_2492+b120f89b.armv7hl
+  - octave-interval-0:3.2.0-3.module_2492+b120f89b.ppc64le
+  - octave-interval-0:3.2.0-3.module_2492+b120f89b.s390x
+  - octave-interval-0:3.2.0-3.module_2492+b120f89b.src
+  - octave-interval-0:3.2.0-3.module_2492+b120f89b.x86_64
+  - octave-interval-debuginfo-0:3.2.0-3.module_2492+b120f89b.aarch64
+  - octave-interval-debuginfo-0:3.2.0-3.module_2492+b120f89b.armv7hl
+  - octave-interval-debuginfo-0:3.2.0-3.module_2492+b120f89b.ppc64le
+  - octave-interval-debuginfo-0:3.2.0-3.module_2492+b120f89b.s390x
+  - octave-interval-debuginfo-0:3.2.0-3.module_2492+b120f89b.x86_64
+  - octave-interval-debugsource-0:3.2.0-3.module_2492+b120f89b.aarch64
+  - octave-interval-debugsource-0:3.2.0-3.module_2492+b120f89b.armv7hl
+  - octave-interval-debugsource-0:3.2.0-3.module_2492+b120f89b.ppc64le
+  - octave-interval-debugsource-0:3.2.0-3.module_2492+b120f89b.s390x
+  - octave-interval-debugsource-0:3.2.0-3.module_2492+b120f89b.x86_64
+  - octave-io-0:2.4.12-1.module_2627+e073eacf.aarch64
+  - octave-io-0:2.4.12-1.module_2627+e073eacf.armv7hl
+  - octave-io-0:2.4.12-1.module_2627+e073eacf.ppc64le
+  - octave-io-0:2.4.12-1.module_2627+e073eacf.s390x
+  - octave-io-0:2.4.12-1.module_2627+e073eacf.src
+  - octave-io-0:2.4.12-1.module_2627+e073eacf.x86_64
+  - octave-io-debuginfo-0:2.4.12-1.module_2627+e073eacf.aarch64
+  - octave-io-debuginfo-0:2.4.12-1.module_2627+e073eacf.armv7hl
+  - octave-io-debuginfo-0:2.4.12-1.module_2627+e073eacf.ppc64le
+  - octave-io-debuginfo-0:2.4.12-1.module_2627+e073eacf.s390x
+  - octave-io-debuginfo-0:2.4.12-1.module_2627+e073eacf.x86_64
+  - octave-io-debugsource-0:2.4.12-1.module_2627+e073eacf.aarch64
+  - octave-io-debugsource-0:2.4.12-1.module_2627+e073eacf.armv7hl
+  - octave-io-debugsource-0:2.4.12-1.module_2627+e073eacf.ppc64le
+  - octave-io-debugsource-0:2.4.12-1.module_2627+e073eacf.s390x
+  - octave-io-debugsource-0:2.4.12-1.module_2627+e073eacf.x86_64
+  - octave-jsonlab-0:1.8-2.module_2492+b120f89b.noarch
+  - octave-jsonlab-0:1.8-2.module_2492+b120f89b.src
+  - octave-metch-0:0.5.0-7.module_2492+b120f89b.noarch
+  - octave-metch-0:0.5.0-7.module_2492+b120f89b.src
+  - octave-miscellaneous-0:1.2.1-13.module_2492+b120f89b.aarch64
+  - octave-miscellaneous-0:1.2.1-13.module_2492+b120f89b.armv7hl
+  - octave-miscellaneous-0:1.2.1-13.module_2492+b120f89b.ppc64le
+  - octave-miscellaneous-0:1.2.1-13.module_2492+b120f89b.s390x
+  - octave-miscellaneous-0:1.2.1-13.module_2492+b120f89b.src
+  - octave-miscellaneous-0:1.2.1-13.module_2492+b120f89b.x86_64
+  - octave-miscellaneous-debuginfo-0:1.2.1-13.module_2492+b120f89b.aarch64
+  - octave-miscellaneous-debuginfo-0:1.2.1-13.module_2492+b120f89b.armv7hl
+  - octave-miscellaneous-debuginfo-0:1.2.1-13.module_2492+b120f89b.ppc64le
+  - octave-miscellaneous-debuginfo-0:1.2.1-13.module_2492+b120f89b.s390x
+  - octave-miscellaneous-debuginfo-0:1.2.1-13.module_2492+b120f89b.x86_64
+  - octave-miscellaneous-debugsource-0:1.2.1-13.module_2492+b120f89b.aarch64
+  - octave-miscellaneous-debugsource-0:1.2.1-13.module_2492+b120f89b.armv7hl
+  - octave-miscellaneous-debugsource-0:1.2.1-13.module_2492+b120f89b.ppc64le
+  - octave-miscellaneous-debugsource-0:1.2.1-13.module_2492+b120f89b.s390x
+  - octave-miscellaneous-debugsource-0:1.2.1-13.module_2492+b120f89b.x86_64
+  - octave-ncarray-0:1.0.4-6.module_2492+b120f89b.noarch
+  - octave-ncarray-0:1.0.4-6.module_2492+b120f89b.src
+  - octave-netcdf-0:1.0.12-3.module_2492+b120f89b.aarch64
+  - octave-netcdf-0:1.0.12-3.module_2492+b120f89b.armv7hl
+  - octave-netcdf-0:1.0.12-3.module_2492+b120f89b.ppc64le
+  - octave-netcdf-0:1.0.12-3.module_2492+b120f89b.s390x
+  - octave-netcdf-0:1.0.12-3.module_2492+b120f89b.src
+  - octave-netcdf-0:1.0.12-3.module_2492+b120f89b.x86_64
+  - octave-netcdf-debuginfo-0:1.0.12-3.module_2492+b120f89b.aarch64
+  - octave-netcdf-debuginfo-0:1.0.12-3.module_2492+b120f89b.armv7hl
+  - octave-netcdf-debuginfo-0:1.0.12-3.module_2492+b120f89b.ppc64le
+  - octave-netcdf-debuginfo-0:1.0.12-3.module_2492+b120f89b.s390x
+  - octave-netcdf-debuginfo-0:1.0.12-3.module_2492+b120f89b.x86_64
+  - octave-netcdf-debugsource-0:1.0.12-3.module_2492+b120f89b.aarch64
+  - octave-netcdf-debugsource-0:1.0.12-3.module_2492+b120f89b.armv7hl
+  - octave-netcdf-debugsource-0:1.0.12-3.module_2492+b120f89b.ppc64le
+  - octave-netcdf-debugsource-0:1.0.12-3.module_2492+b120f89b.s390x
+  - octave-netcdf-debugsource-0:1.0.12-3.module_2492+b120f89b.x86_64
+  - octave-nnet-0:0.1.13-15.module_2492+b120f89b.noarch
+  - octave-nnet-0:0.1.13-15.module_2492+b120f89b.src
+  - octave-odepkg-0:0.9.1-0.6.20170102hg609.module_2492+b120f89b.aarch64
+  - octave-odepkg-0:0.9.1-0.6.20170102hg609.module_2492+b120f89b.armv7hl
+  - octave-odepkg-0:0.9.1-0.6.20170102hg609.module_2492+b120f89b.ppc64le
+  - octave-odepkg-0:0.9.1-0.6.20170102hg609.module_2492+b120f89b.s390x
+  - octave-odepkg-0:0.9.1-0.6.20170102hg609.module_2492+b120f89b.src
+  - octave-odepkg-0:0.9.1-0.6.20170102hg609.module_2492+b120f89b.x86_64
+  - octave-odepkg-debuginfo-0:0.9.1-0.6.20170102hg609.module_2492+b120f89b.aarch64
+  - octave-odepkg-debuginfo-0:0.9.1-0.6.20170102hg609.module_2492+b120f89b.armv7hl
+  - octave-odepkg-debuginfo-0:0.9.1-0.6.20170102hg609.module_2492+b120f89b.ppc64le
+  - octave-odepkg-debuginfo-0:0.9.1-0.6.20170102hg609.module_2492+b120f89b.s390x
+  - octave-odepkg-debuginfo-0:0.9.1-0.6.20170102hg609.module_2492+b120f89b.x86_64
+  - octave-odepkg-debugsource-0:0.9.1-0.6.20170102hg609.module_2492+b120f89b.aarch64
+  - octave-odepkg-debugsource-0:0.9.1-0.6.20170102hg609.module_2492+b120f89b.armv7hl
+  - octave-odepkg-debugsource-0:0.9.1-0.6.20170102hg609.module_2492+b120f89b.ppc64le
+  - octave-odepkg-debugsource-0:0.9.1-0.6.20170102hg609.module_2492+b120f89b.s390x
+  - octave-odepkg-debugsource-0:0.9.1-0.6.20170102hg609.module_2492+b120f89b.x86_64
+  - octave-optim-0:1.5.3-2.module_2492+b120f89b.aarch64
+  - octave-optim-0:1.5.3-2.module_2492+b120f89b.armv7hl
+  - octave-optim-0:1.5.3-2.module_2492+b120f89b.ppc64le
+  - octave-optim-0:1.5.3-2.module_2492+b120f89b.s390x
+  - octave-optim-0:1.5.3-2.module_2492+b120f89b.src
+  - octave-optim-0:1.5.3-2.module_2492+b120f89b.x86_64
+  - octave-optim-debuginfo-0:1.5.3-2.module_2492+b120f89b.aarch64
+  - octave-optim-debuginfo-0:1.5.3-2.module_2492+b120f89b.armv7hl
+  - octave-optim-debuginfo-0:1.5.3-2.module_2492+b120f89b.ppc64le
+  - octave-optim-debuginfo-0:1.5.3-2.module_2492+b120f89b.s390x
+  - octave-optim-debuginfo-0:1.5.3-2.module_2492+b120f89b.x86_64
+  - octave-optim-debugsource-0:1.5.3-2.module_2492+b120f89b.aarch64
+  - octave-optim-debugsource-0:1.5.3-2.module_2492+b120f89b.armv7hl
+  - octave-optim-debugsource-0:1.5.3-2.module_2492+b120f89b.ppc64le
+  - octave-optim-debugsource-0:1.5.3-2.module_2492+b120f89b.s390x
+  - octave-optim-debugsource-0:1.5.3-2.module_2492+b120f89b.x86_64
+  - octave-parallel-0:3.1.3-2.module_2492+b120f89b.aarch64
+  - octave-parallel-0:3.1.3-2.module_2492+b120f89b.armv7hl
+  - octave-parallel-0:3.1.3-2.module_2492+b120f89b.ppc64le
+  - octave-parallel-0:3.1.3-2.module_2492+b120f89b.s390x
+  - octave-parallel-0:3.1.3-2.module_2492+b120f89b.src
+  - octave-parallel-0:3.1.3-2.module_2492+b120f89b.x86_64
+  - octave-parallel-debuginfo-0:3.1.3-2.module_2492+b120f89b.aarch64
+  - octave-parallel-debuginfo-0:3.1.3-2.module_2492+b120f89b.armv7hl
+  - octave-parallel-debuginfo-0:3.1.3-2.module_2492+b120f89b.ppc64le
+  - octave-parallel-debuginfo-0:3.1.3-2.module_2492+b120f89b.s390x
+  - octave-parallel-debuginfo-0:3.1.3-2.module_2492+b120f89b.x86_64
+  - octave-parallel-debugsource-0:3.1.3-2.module_2492+b120f89b.aarch64
+  - octave-parallel-debugsource-0:3.1.3-2.module_2492+b120f89b.armv7hl
+  - octave-parallel-debugsource-0:3.1.3-2.module_2492+b120f89b.ppc64le
+  - octave-parallel-debugsource-0:3.1.3-2.module_2492+b120f89b.s390x
+  - octave-parallel-debugsource-0:3.1.3-2.module_2492+b120f89b.x86_64
+  - octave-quaternion-0:2.4.0-9.module_2492+b120f89b.aarch64
+  - octave-quaternion-0:2.4.0-9.module_2492+b120f89b.armv7hl
+  - octave-quaternion-0:2.4.0-9.module_2492+b120f89b.ppc64le
+  - octave-quaternion-0:2.4.0-9.module_2492+b120f89b.s390x
+  - octave-quaternion-0:2.4.0-9.module_2492+b120f89b.src
+  - octave-quaternion-0:2.4.0-9.module_2492+b120f89b.x86_64
+  - octave-quaternion-debuginfo-0:2.4.0-9.module_2492+b120f89b.aarch64
+  - octave-quaternion-debuginfo-0:2.4.0-9.module_2492+b120f89b.armv7hl
+  - octave-quaternion-debuginfo-0:2.4.0-9.module_2492+b120f89b.ppc64le
+  - octave-quaternion-debuginfo-0:2.4.0-9.module_2492+b120f89b.s390x
+  - octave-quaternion-debuginfo-0:2.4.0-9.module_2492+b120f89b.x86_64
+  - octave-quaternion-debugsource-0:2.4.0-9.module_2492+b120f89b.aarch64
+  - octave-quaternion-debugsource-0:2.4.0-9.module_2492+b120f89b.armv7hl
+  - octave-quaternion-debugsource-0:2.4.0-9.module_2492+b120f89b.ppc64le
+  - octave-quaternion-debugsource-0:2.4.0-9.module_2492+b120f89b.s390x
+  - octave-quaternion-debugsource-0:2.4.0-9.module_2492+b120f89b.x86_64
+  - octave-signal-0:1.4.0-5.module_2492+b120f89b.aarch64
+  - octave-signal-0:1.4.0-5.module_2492+b120f89b.armv7hl
+  - octave-signal-0:1.4.0-5.module_2492+b120f89b.ppc64le
+  - octave-signal-0:1.4.0-5.module_2492+b120f89b.src
+  - octave-signal-0:1.4.0-5.module_2492+b120f89b.x86_64
+  - octave-signal-debuginfo-0:1.4.0-5.module_2492+b120f89b.aarch64
+  - octave-signal-debuginfo-0:1.4.0-5.module_2492+b120f89b.armv7hl
+  - octave-signal-debuginfo-0:1.4.0-5.module_2492+b120f89b.ppc64le
+  - octave-signal-debuginfo-0:1.4.0-5.module_2492+b120f89b.x86_64
+  - octave-signal-debugsource-0:1.4.0-5.module_2492+b120f89b.aarch64
+  - octave-signal-debugsource-0:1.4.0-5.module_2492+b120f89b.armv7hl
+  - octave-signal-debugsource-0:1.4.0-5.module_2492+b120f89b.ppc64le
+  - octave-signal-debugsource-0:1.4.0-5.module_2492+b120f89b.x86_64
+  - octave-specfun-0:1.1.0-20.module_2492+b120f89b.aarch64
+  - octave-specfun-0:1.1.0-20.module_2492+b120f89b.armv7hl
+  - octave-specfun-0:1.1.0-20.module_2492+b120f89b.ppc64le
+  - octave-specfun-0:1.1.0-20.module_2492+b120f89b.s390x
+  - octave-specfun-0:1.1.0-20.module_2492+b120f89b.src
+  - octave-specfun-0:1.1.0-20.module_2492+b120f89b.x86_64
+  - octave-specfun-debuginfo-0:1.1.0-20.module_2492+b120f89b.aarch64
+  - octave-specfun-debuginfo-0:1.1.0-20.module_2492+b120f89b.armv7hl
+  - octave-specfun-debuginfo-0:1.1.0-20.module_2492+b120f89b.ppc64le
+  - octave-specfun-debuginfo-0:1.1.0-20.module_2492+b120f89b.s390x
+  - octave-specfun-debuginfo-0:1.1.0-20.module_2492+b120f89b.x86_64
+  - octave-specfun-debugsource-0:1.1.0-20.module_2492+b120f89b.aarch64
+  - octave-specfun-debugsource-0:1.1.0-20.module_2492+b120f89b.armv7hl
+  - octave-specfun-debugsource-0:1.1.0-20.module_2492+b120f89b.ppc64le
+  - octave-specfun-debugsource-0:1.1.0-20.module_2492+b120f89b.s390x
+  - octave-specfun-debugsource-0:1.1.0-20.module_2492+b120f89b.x86_64
+  - octave-statistics-0:1.4.0-2.module_2492+b120f89b.aarch64
+  - octave-statistics-0:1.4.0-2.module_2492+b120f89b.armv7hl
+  - octave-statistics-0:1.4.0-2.module_2492+b120f89b.ppc64le
+  - octave-statistics-0:1.4.0-2.module_2492+b120f89b.s390x
+  - octave-statistics-0:1.4.0-2.module_2492+b120f89b.src
+  - octave-statistics-0:1.4.0-2.module_2492+b120f89b.x86_64
+  - octave-struct-0:1.0.15-3.module_2492+b120f89b.aarch64
+  - octave-struct-0:1.0.15-3.module_2492+b120f89b.armv7hl
+  - octave-struct-0:1.0.15-3.module_2492+b120f89b.ppc64le
+  - octave-struct-0:1.0.15-3.module_2492+b120f89b.s390x
+  - octave-struct-0:1.0.15-3.module_2492+b120f89b.src
+  - octave-struct-0:1.0.15-3.module_2492+b120f89b.x86_64
+  - octave-struct-debuginfo-0:1.0.15-3.module_2492+b120f89b.aarch64
+  - octave-struct-debuginfo-0:1.0.15-3.module_2492+b120f89b.armv7hl
+  - octave-struct-debuginfo-0:1.0.15-3.module_2492+b120f89b.ppc64le
+  - octave-struct-debuginfo-0:1.0.15-3.module_2492+b120f89b.s390x
+  - octave-struct-debuginfo-0:1.0.15-3.module_2492+b120f89b.x86_64
+  - octave-struct-debugsource-0:1.0.15-3.module_2492+b120f89b.aarch64
+  - octave-struct-debugsource-0:1.0.15-3.module_2492+b120f89b.armv7hl
+  - octave-struct-debugsource-0:1.0.15-3.module_2492+b120f89b.ppc64le
+  - octave-struct-debugsource-0:1.0.15-3.module_2492+b120f89b.s390x
+  - octave-struct-debugsource-0:1.0.15-3.module_2492+b120f89b.x86_64
+  - octave-symbolic-0:2.7.1-3.module_2492+b120f89b.noarch
+  - octave-symbolic-0:2.7.1-3.module_2492+b120f89b.src
+  context: 6c81f848
+  dependencies: []
+  name: octave
+  profiles:
+    buildroot:
+      rpms:
+      - octave-devel
+    default:
+      rpms:
+      - octave
+  repository_memberships:
+  - dest1
+  stream: '4.4'
+  unit_id: (hidden)
+  version: 20181215220609
+- _class: ModulemdUnit
+  arch: x86_64
+  artifacts:
+  - octave-6:5.1.0-1.module_f29+4759+cd54e576.src
+  - octave-6:5.1.0-1.module_f29+4759+cd54e576.x86_64
+  - octave-communications-0:1.2.1-14.module_f29+4759+cd54e576.src
+  - octave-communications-0:1.2.1-14.module_f29+4759+cd54e576.x86_64
+  - octave-communications-debuginfo-0:1.2.1-14.module_f29+4759+cd54e576.x86_64
+  - octave-communications-debugsource-0:1.2.1-14.module_f29+4759+cd54e576.x86_64
+  - octave-control-0:3.2.0-2.module_f29+4759+cd54e576.src
+  - octave-control-0:3.2.0-2.module_f29+4759+cd54e576.x86_64
+  - octave-control-debuginfo-0:3.2.0-2.module_f29+4759+cd54e576.x86_64
+  - octave-control-debugsource-0:3.2.0-2.module_f29+4759+cd54e576.x86_64
+  - octave-debuginfo-6:5.1.0-1.module_f29+4759+cd54e576.x86_64
+  - octave-debugsource-6:5.1.0-1.module_f29+4759+cd54e576.x86_64
+  - octave-devel-6:5.1.0-1.module_f29+4759+cd54e576.x86_64
+  - octave-doc-6:5.1.0-1.module_f29+4759+cd54e576.noarch
+  - octave-doctest-0:0.7.0-3.module_f29+4759+cd54e576.noarch
+  - octave-doctest-0:0.7.0-3.module_f29+4759+cd54e576.src
+  - octave-general-0:2.1.0-3.module_f29+4759+cd54e576.src
+  - octave-general-0:2.1.0-3.module_f29+4759+cd54e576.x86_64
+  - octave-general-debuginfo-0:2.1.0-3.module_f29+4759+cd54e576.x86_64
+  - octave-general-debugsource-0:2.1.0-3.module_f29+4759+cd54e576.x86_64
+  - octave-gsl-0:2.0.0-9.module_f29+4759+cd54e576.src
+  - octave-gsl-0:2.0.0-9.module_f29+4759+cd54e576.x86_64
+  - octave-gsl-debuginfo-0:2.0.0-9.module_f29+4759+cd54e576.x86_64
+  - octave-gsl-debugsource-0:2.0.0-9.module_f29+4759+cd54e576.x86_64
+  - octave-image-0:2.8.1-3.module_f29+4759+cd54e576.src
+  - octave-image-0:2.8.1-3.module_f29+4759+cd54e576.x86_64
+  - octave-image-debuginfo-0:2.8.1-3.module_f29+4759+cd54e576.x86_64
+  - octave-image-debugsource-0:2.8.1-3.module_f29+4759+cd54e576.x86_64
+  - octave-interval-0:3.2.0-5.module_f29+4759+cd54e576.src
+  - octave-interval-0:3.2.0-5.module_f29+4759+cd54e576.x86_64
+  - octave-interval-debuginfo-0:3.2.0-5.module_f29+4759+cd54e576.x86_64
+  - octave-interval-debugsource-0:3.2.0-5.module_f29+4759+cd54e576.x86_64
+  - octave-io-0:2.4.12-3.module_f29+4759+cd54e576.src
+  - octave-io-0:2.4.12-3.module_f29+4759+cd54e576.x86_64
+  - octave-io-debuginfo-0:2.4.12-3.module_f29+4759+cd54e576.x86_64
+  - octave-io-debugsource-0:2.4.12-3.module_f29+4759+cd54e576.x86_64
+  - octave-jsonlab-0:1.8-4.module_f29+4759+cd54e576.noarch
+  - octave-jsonlab-0:1.8-4.module_f29+4759+cd54e576.src
+  - octave-metch-0:0.5.0-9.module_f29+4759+cd54e576.noarch
+  - octave-metch-0:0.5.0-9.module_f29+4759+cd54e576.src
+  - octave-miscellaneous-0:1.2.1-15.module_f29+4759+cd54e576.src
+  - octave-miscellaneous-0:1.2.1-15.module_f29+4759+cd54e576.x86_64
+  - octave-miscellaneous-debuginfo-0:1.2.1-15.module_f29+4759+cd54e576.x86_64
+  - octave-miscellaneous-debugsource-0:1.2.1-15.module_f29+4759+cd54e576.x86_64
+  - octave-ncarray-0:1.0.4-8.module_f29+4759+cd54e576.noarch
+  - octave-ncarray-0:1.0.4-8.module_f29+4759+cd54e576.src
+  - octave-netcdf-0:1.0.12-6.module_f29+4759+cd54e576.src
+  - octave-netcdf-0:1.0.12-6.module_f29+4759+cd54e576.x86_64
+  - octave-netcdf-debuginfo-0:1.0.12-6.module_f29+4759+cd54e576.x86_64
+  - octave-netcdf-debugsource-0:1.0.12-6.module_f29+4759+cd54e576.x86_64
+  - octave-nnet-0:0.1.13-17.module_f29+4759+cd54e576.noarch
+  - octave-nnet-0:0.1.13-17.module_f29+4759+cd54e576.src
+  - octave-odepkg-0:0.9.1-0.8.20170102hg609.module_f29+4759+cd54e576.src
+  - octave-odepkg-0:0.9.1-0.8.20170102hg609.module_f29+4759+cd54e576.x86_64
+  - octave-odepkg-debuginfo-0:0.9.1-0.8.20170102hg609.module_f29+4759+cd54e576.x86_64
+  - octave-odepkg-debugsource-0:0.9.1-0.8.20170102hg609.module_f29+4759+cd54e576.x86_64
+  - octave-optim-0:1.6.0-2.module_f29+4759+cd54e576.src
+  - octave-optim-0:1.6.0-2.module_f29+4759+cd54e576.x86_64
+  - octave-optim-debuginfo-0:1.6.0-2.module_f29+4759+cd54e576.x86_64
+  - octave-optim-debugsource-0:1.6.0-2.module_f29+4759+cd54e576.x86_64
+  - octave-quaternion-0:2.4.0-11.module_f29+4759+cd54e576.src
+  - octave-quaternion-0:2.4.0-11.module_f29+4759+cd54e576.x86_64
+  - octave-quaternion-debuginfo-0:2.4.0-11.module_f29+4759+cd54e576.x86_64
+  - octave-quaternion-debugsource-0:2.4.0-11.module_f29+4759+cd54e576.x86_64
+  - octave-signal-0:1.4.1-3.module_f29+4759+cd54e576.src
+  - octave-signal-0:1.4.1-3.module_f29+4759+cd54e576.x86_64
+  - octave-signal-debuginfo-0:1.4.1-3.module_f29+4759+cd54e576.x86_64
+  - octave-signal-debugsource-0:1.4.1-3.module_f29+4759+cd54e576.x86_64
+  - octave-specfun-0:1.1.0-22.module_f29+4759+cd54e576.src
+  - octave-specfun-0:1.1.0-22.module_f29+4759+cd54e576.x86_64
+  - octave-specfun-debuginfo-0:1.1.0-22.module_f29+4759+cd54e576.x86_64
+  - octave-specfun-debugsource-0:1.1.0-22.module_f29+4759+cd54e576.x86_64
+  - octave-statistics-0:1.4.1-2.module_f29+4759+cd54e576.src
+  - octave-statistics-0:1.4.1-2.module_f29+4759+cd54e576.x86_64
+  - octave-struct-0:1.0.16-2.module_f29+4759+cd54e576.src
+  - octave-struct-0:1.0.16-2.module_f29+4759+cd54e576.x86_64
+  - octave-struct-debuginfo-0:1.0.16-2.module_f29+4759+cd54e576.x86_64
+  - octave-struct-debugsource-0:1.0.16-2.module_f29+4759+cd54e576.x86_64
+  - octave-symbolic-0:2.8.0-2.module_f29+4759+cd54e576.noarch
+  - octave-symbolic-0:2.8.0-2.module_f29+4759+cd54e576.src
+  context: 6c81f848
+  dependencies: []
+  name: octave
+  profiles:
+    buildroot:
+      rpms:
+      - octave-devel
+    default:
+      rpms:
+      - octave
+  repository_memberships:
+  - dest1
+  stream: '5.1'
+  unit_id: (hidden)
+  version: 2920190619125442
+- _class: ModulemdUnit
+  arch: x86_64
+  artifacts:
+  - openmpi-0:2.1.6-0.1.rc1.module_2624+118a8493.aarch64
+  - openmpi-0:2.1.6-0.1.rc1.module_2624+118a8493.armv7hl
+  - openmpi-0:2.1.6-0.1.rc1.module_2624+118a8493.ppc64le
+  - openmpi-0:2.1.6-0.1.rc1.module_2624+118a8493.s390x
+  - openmpi-0:2.1.6-0.1.rc1.module_2624+118a8493.src
+  - openmpi-0:2.1.6-0.1.rc1.module_2624+118a8493.x86_64
+  - openmpi-debuginfo-0:2.1.6-0.1.rc1.module_2624+118a8493.aarch64
+  - openmpi-debuginfo-0:2.1.6-0.1.rc1.module_2624+118a8493.armv7hl
+  - openmpi-debuginfo-0:2.1.6-0.1.rc1.module_2624+118a8493.ppc64le
+  - openmpi-debuginfo-0:2.1.6-0.1.rc1.module_2624+118a8493.s390x
+  - openmpi-debuginfo-0:2.1.6-0.1.rc1.module_2624+118a8493.x86_64
+  - openmpi-debugsource-0:2.1.6-0.1.rc1.module_2624+118a8493.aarch64
+  - openmpi-debugsource-0:2.1.6-0.1.rc1.module_2624+118a8493.armv7hl
+  - openmpi-debugsource-0:2.1.6-0.1.rc1.module_2624+118a8493.ppc64le
+  - openmpi-debugsource-0:2.1.6-0.1.rc1.module_2624+118a8493.s390x
+  - openmpi-debugsource-0:2.1.6-0.1.rc1.module_2624+118a8493.x86_64
+  - openmpi-devel-0:2.1.6-0.1.rc1.module_2624+118a8493.aarch64
+  - openmpi-devel-0:2.1.6-0.1.rc1.module_2624+118a8493.armv7hl
+  - openmpi-devel-0:2.1.6-0.1.rc1.module_2624+118a8493.ppc64le
+  - openmpi-devel-0:2.1.6-0.1.rc1.module_2624+118a8493.s390x
+  - openmpi-devel-0:2.1.6-0.1.rc1.module_2624+118a8493.x86_64
+  - openmpi-devel-debuginfo-0:2.1.6-0.1.rc1.module_2624+118a8493.aarch64
+  - openmpi-devel-debuginfo-0:2.1.6-0.1.rc1.module_2624+118a8493.armv7hl
+  - openmpi-devel-debuginfo-0:2.1.6-0.1.rc1.module_2624+118a8493.ppc64le
+  - openmpi-devel-debuginfo-0:2.1.6-0.1.rc1.module_2624+118a8493.s390x
+  - openmpi-devel-debuginfo-0:2.1.6-0.1.rc1.module_2624+118a8493.x86_64
+  - openmpi-java-0:2.1.6-0.1.rc1.module_2624+118a8493.aarch64
+  - openmpi-java-0:2.1.6-0.1.rc1.module_2624+118a8493.armv7hl
+  - openmpi-java-0:2.1.6-0.1.rc1.module_2624+118a8493.ppc64le
+  - openmpi-java-0:2.1.6-0.1.rc1.module_2624+118a8493.s390x
+  - openmpi-java-0:2.1.6-0.1.rc1.module_2624+118a8493.x86_64
+  - openmpi-java-devel-0:2.1.6-0.1.rc1.module_2624+118a8493.aarch64
+  - openmpi-java-devel-0:2.1.6-0.1.rc1.module_2624+118a8493.armv7hl
+  - openmpi-java-devel-0:2.1.6-0.1.rc1.module_2624+118a8493.ppc64le
+  - openmpi-java-devel-0:2.1.6-0.1.rc1.module_2624+118a8493.s390x
+  - openmpi-java-devel-0:2.1.6-0.1.rc1.module_2624+118a8493.x86_64
+  - python2-openmpi-0:2.1.6-0.1.rc1.module_2624+118a8493.aarch64
+  - python2-openmpi-0:2.1.6-0.1.rc1.module_2624+118a8493.armv7hl
+  - python2-openmpi-0:2.1.6-0.1.rc1.module_2624+118a8493.ppc64le
+  - python2-openmpi-0:2.1.6-0.1.rc1.module_2624+118a8493.s390x
+  - python2-openmpi-0:2.1.6-0.1.rc1.module_2624+118a8493.x86_64
+  - python3-openmpi-0:2.1.6-0.1.rc1.module_2624+118a8493.aarch64
+  - python3-openmpi-0:2.1.6-0.1.rc1.module_2624+118a8493.armv7hl
+  - python3-openmpi-0:2.1.6-0.1.rc1.module_2624+118a8493.ppc64le
+  - python3-openmpi-0:2.1.6-0.1.rc1.module_2624+118a8493.s390x
+  - python3-openmpi-0:2.1.6-0.1.rc1.module_2624+118a8493.x86_64
+  context: 6c81f848
+  dependencies: []
+  name: openmpi
+  repository_memberships:
+  - dest1
+  stream: '2.1'
+  unit_id: (hidden)
+  version: 20181215212125
+- _class: ModulemdUnit
+  arch: x86_64
+  artifacts:
+  - openmpi-0:3.1.3-1.module_f29+3054+0cb8829a.src
+  - openmpi-0:3.1.3-1.module_f29+3054+0cb8829a.x86_64
+  - openmpi-debuginfo-0:3.1.3-1.module_f29+3054+0cb8829a.x86_64
+  - openmpi-debugsource-0:3.1.3-1.module_f29+3054+0cb8829a.x86_64
+  - openmpi-devel-0:3.1.3-1.module_f29+3054+0cb8829a.x86_64
+  - openmpi-devel-debuginfo-0:3.1.3-1.module_f29+3054+0cb8829a.x86_64
+  - openmpi-java-0:3.1.3-1.module_f29+3054+0cb8829a.x86_64
+  - openmpi-java-devel-0:3.1.3-1.module_f29+3054+0cb8829a.x86_64
+  - python2-openmpi-0:3.1.3-1.module_f29+3054+0cb8829a.x86_64
+  - python3-openmpi-0:3.1.3-1.module_f29+3054+0cb8829a.x86_64
+  context: 6c81f848
+  dependencies: []
+  name: openmpi
+  profiles:
+    buildroot:
+      rpms:
+      - openmpi-devel
+    default:
+      rpms:
+      - openmpi
+  repository_memberships:
+  - dest1
+  stream: '3.1'
+  unit_id: (hidden)
+  version: 2920190331033351
+- _class: ModulemdUnit
+  arch: x86_64
+  artifacts:
+  - openmpi-0:4.0.1-1.module_f29+3805+1962808d.src
+  - openmpi-0:4.0.1-1.module_f29+3805+1962808d.x86_64
+  - openmpi-debuginfo-0:4.0.1-1.module_f29+3805+1962808d.x86_64
+  - openmpi-debugsource-0:4.0.1-1.module_f29+3805+1962808d.x86_64
+  - openmpi-devel-0:4.0.1-1.module_f29+3805+1962808d.x86_64
+  - openmpi-devel-debuginfo-0:4.0.1-1.module_f29+3805+1962808d.x86_64
+  - openmpi-java-0:4.0.1-1.module_f29+3805+1962808d.x86_64
+  - openmpi-java-devel-0:4.0.1-1.module_f29+3805+1962808d.x86_64
+  - python2-openmpi-0:4.0.1-1.module_f29+3805+1962808d.x86_64
+  - python3-openmpi-0:4.0.1-1.module_f29+3805+1962808d.x86_64
+  context: 6c81f848
+  dependencies: []
+  name: openmpi
+  profiles:
+    buildroot:
+      rpms:
+      - openmpi-devel
+    default:
+      rpms:
+      - openmpi
+  repository_memberships:
+  - dest1
+  stream: '4.0'
+  unit_id: (hidden)
+  version: 2920190331170644
+- _class: ModulemdUnit
+  arch: x86_64
+  artifacts:
+  - perl-4:5.26.3-415.module_2543+eed510a0.aarch64
+  - perl-4:5.26.3-415.module_2543+eed510a0.armv7hl
+  - perl-4:5.26.3-415.module_2543+eed510a0.ppc64le
+  - perl-4:5.26.3-415.module_2543+eed510a0.s390x
+  - perl-4:5.26.3-415.module_2543+eed510a0.src
+  - perl-4:5.26.3-415.module_2543+eed510a0.x86_64
+  - perl-Algorithm-Diff-0:1.1903-9.module_1681+b405d8e2.noarch
+  - perl-Algorithm-Diff-0:1.1903-9.module_1681+b405d8e2.src
+  - perl-Archive-Tar-0:2.28-1.module_2543+eed510a0.noarch
+  - perl-Archive-Tar-0:2.28-1.module_2543+eed510a0.src
+  - perl-Archive-Zip-0:1.64-1.module_2543+eed510a0.noarch
+  - perl-Archive-Zip-0:1.64-1.module_2543+eed510a0.src
+  - perl-Attribute-Handlers-0:0.99-415.module_2543+eed510a0.noarch
+  - perl-B-Debug-0:1.26-2.module_1681+b405d8e2.noarch
+  - perl-B-Debug-0:1.26-2.module_1681+b405d8e2.src
+  - perl-CPAN-0:2.18-397.module_1681+b405d8e2.noarch
+  - perl-CPAN-0:2.18-397.module_1681+b405d8e2.src
+  - perl-CPAN-Meta-0:2.150010-396.module_1681+b405d8e2.noarch
+  - perl-CPAN-Meta-0:2.150010-396.module_1681+b405d8e2.src
+  - perl-CPAN-Meta-Requirements-0:2.140-396.module_1681+b405d8e2.noarch
+  - perl-CPAN-Meta-Requirements-0:2.140-396.module_1681+b405d8e2.src
+  - perl-CPAN-Meta-YAML-0:0.018-397.module_1681+b405d8e2.noarch
+  - perl-CPAN-Meta-YAML-0:0.018-397.module_1681+b405d8e2.src
+  - perl-Carp-0:1.42-396.module_2543+eed510a0.noarch
+  - perl-Carp-0:1.42-396.module_2543+eed510a0.src
+  - perl-Compress-Bzip2-0:2.26-6.module_1681+b405d8e2.aarch64
+  - perl-Compress-Bzip2-0:2.26-6.module_1681+b405d8e2.armv7hl
+  - perl-Compress-Bzip2-0:2.26-6.module_1681+b405d8e2.ppc64
+  - perl-Compress-Bzip2-0:2.26-6.module_1681+b405d8e2.ppc64le
+  - perl-Compress-Bzip2-0:2.26-6.module_1681+b405d8e2.s390x
+  - perl-Compress-Bzip2-0:2.26-6.module_1681+b405d8e2.src
+  - perl-Compress-Bzip2-0:2.26-6.module_1681+b405d8e2.x86_64
+  - perl-Compress-Bzip2-debuginfo-0:2.26-6.module_1681+b405d8e2.aarch64
+  - perl-Compress-Bzip2-debuginfo-0:2.26-6.module_1681+b405d8e2.armv7hl
+  - perl-Compress-Bzip2-debuginfo-0:2.26-6.module_1681+b405d8e2.ppc64
+  - perl-Compress-Bzip2-debuginfo-0:2.26-6.module_1681+b405d8e2.ppc64le
+  - perl-Compress-Bzip2-debuginfo-0:2.26-6.module_1681+b405d8e2.s390x
+  - perl-Compress-Bzip2-debuginfo-0:2.26-6.module_1681+b405d8e2.x86_64
+  - perl-Compress-Bzip2-debugsource-0:2.26-6.module_1681+b405d8e2.aarch64
+  - perl-Compress-Bzip2-debugsource-0:2.26-6.module_1681+b405d8e2.armv7hl
+  - perl-Compress-Bzip2-debugsource-0:2.26-6.module_1681+b405d8e2.ppc64
+  - perl-Compress-Bzip2-debugsource-0:2.26-6.module_1681+b405d8e2.ppc64le
+  - perl-Compress-Bzip2-debugsource-0:2.26-6.module_1681+b405d8e2.s390x
+  - perl-Compress-Bzip2-debugsource-0:2.26-6.module_1681+b405d8e2.x86_64
+  - perl-Compress-Raw-Bzip2-0:2.081-1.module_1681+b405d8e2.aarch64
+  - perl-Compress-Raw-Bzip2-0:2.081-1.module_1681+b405d8e2.armv7hl
+  - perl-Compress-Raw-Bzip2-0:2.081-1.module_1681+b405d8e2.ppc64
+  - perl-Compress-Raw-Bzip2-0:2.081-1.module_1681+b405d8e2.ppc64le
+  - perl-Compress-Raw-Bzip2-0:2.081-1.module_1681+b405d8e2.s390x
+  - perl-Compress-Raw-Bzip2-0:2.081-1.module_1681+b405d8e2.src
+  - perl-Compress-Raw-Bzip2-0:2.081-1.module_1681+b405d8e2.x86_64
+  - perl-Compress-Raw-Bzip2-debuginfo-0:2.081-1.module_1681+b405d8e2.aarch64
+  - perl-Compress-Raw-Bzip2-debuginfo-0:2.081-1.module_1681+b405d8e2.armv7hl
+  - perl-Compress-Raw-Bzip2-debuginfo-0:2.081-1.module_1681+b405d8e2.ppc64
+  - perl-Compress-Raw-Bzip2-debuginfo-0:2.081-1.module_1681+b405d8e2.ppc64le
+  - perl-Compress-Raw-Bzip2-debuginfo-0:2.081-1.module_1681+b405d8e2.s390x
+  - perl-Compress-Raw-Bzip2-debuginfo-0:2.081-1.module_1681+b405d8e2.x86_64
+  - perl-Compress-Raw-Bzip2-debugsource-0:2.081-1.module_1681+b405d8e2.aarch64
+  - perl-Compress-Raw-Bzip2-debugsource-0:2.081-1.module_1681+b405d8e2.armv7hl
+  - perl-Compress-Raw-Bzip2-debugsource-0:2.081-1.module_1681+b405d8e2.ppc64
+  - perl-Compress-Raw-Bzip2-debugsource-0:2.081-1.module_1681+b405d8e2.ppc64le
+  - perl-Compress-Raw-Bzip2-debugsource-0:2.081-1.module_1681+b405d8e2.s390x
+  - perl-Compress-Raw-Bzip2-debugsource-0:2.081-1.module_1681+b405d8e2.x86_64
+  - perl-Compress-Raw-Zlib-0:2.081-1.module_1681+b405d8e2.aarch64
+  - perl-Compress-Raw-Zlib-0:2.081-1.module_1681+b405d8e2.armv7hl
+  - perl-Compress-Raw-Zlib-0:2.081-1.module_1681+b405d8e2.ppc64
+  - perl-Compress-Raw-Zlib-0:2.081-1.module_1681+b405d8e2.ppc64le
+  - perl-Compress-Raw-Zlib-0:2.081-1.module_1681+b405d8e2.s390x
+  - perl-Compress-Raw-Zlib-0:2.081-1.module_1681+b405d8e2.src
+  - perl-Compress-Raw-Zlib-0:2.081-1.module_1681+b405d8e2.x86_64
+  - perl-Compress-Raw-Zlib-debuginfo-0:2.081-1.module_1681+b405d8e2.aarch64
+  - perl-Compress-Raw-Zlib-debuginfo-0:2.081-1.module_1681+b405d8e2.armv7hl
+  - perl-Compress-Raw-Zlib-debuginfo-0:2.081-1.module_1681+b405d8e2.ppc64
+  - perl-Compress-Raw-Zlib-debuginfo-0:2.081-1.module_1681+b405d8e2.ppc64le
+  - perl-Compress-Raw-Zlib-debuginfo-0:2.081-1.module_1681+b405d8e2.s390x
+  - perl-Compress-Raw-Zlib-debuginfo-0:2.081-1.module_1681+b405d8e2.x86_64
+  - perl-Compress-Raw-Zlib-debugsource-0:2.081-1.module_1681+b405d8e2.aarch64
+  - perl-Compress-Raw-Zlib-debugsource-0:2.081-1.module_1681+b405d8e2.armv7hl
+  - perl-Compress-Raw-Zlib-debugsource-0:2.081-1.module_1681+b405d8e2.ppc64
+  - perl-Compress-Raw-Zlib-debugsource-0:2.081-1.module_1681+b405d8e2.ppc64le
+  - perl-Compress-Raw-Zlib-debugsource-0:2.081-1.module_1681+b405d8e2.s390x
+  - perl-Compress-Raw-Zlib-debugsource-0:2.081-1.module_1681+b405d8e2.x86_64
+  - perl-Config-Perl-V-0:0.30-1.module_2543+eed510a0.noarch
+  - perl-Config-Perl-V-0:0.30-1.module_2543+eed510a0.src
+  - perl-DB_File-0:1.843-1.module_2543+eed510a0.aarch64
+  - perl-DB_File-0:1.843-1.module_2543+eed510a0.armv7hl
+  - perl-DB_File-0:1.843-1.module_2543+eed510a0.ppc64le
+  - perl-DB_File-0:1.843-1.module_2543+eed510a0.s390x
+  - perl-DB_File-0:1.843-1.module_2543+eed510a0.src
+  - perl-DB_File-0:1.843-1.module_2543+eed510a0.x86_64
+  - perl-DB_File-debuginfo-0:1.843-1.module_2543+eed510a0.aarch64
+  - perl-DB_File-debuginfo-0:1.843-1.module_2543+eed510a0.armv7hl
+  - perl-DB_File-debuginfo-0:1.843-1.module_2543+eed510a0.ppc64le
+  - perl-DB_File-debuginfo-0:1.843-1.module_2543+eed510a0.s390x
+  - perl-DB_File-debuginfo-0:1.843-1.module_2543+eed510a0.x86_64
+  - perl-DB_File-debugsource-0:1.843-1.module_2543+eed510a0.aarch64
+  - perl-DB_File-debugsource-0:1.843-1.module_2543+eed510a0.armv7hl
+  - perl-DB_File-debugsource-0:1.843-1.module_2543+eed510a0.ppc64le
+  - perl-DB_File-debugsource-0:1.843-1.module_2543+eed510a0.s390x
+  - perl-DB_File-debugsource-0:1.843-1.module_2543+eed510a0.x86_64
+  - perl-Data-Dumper-0:2.167-399.module_1681+b405d8e2.aarch64
+  - perl-Data-Dumper-0:2.167-399.module_1681+b405d8e2.armv7hl
+  - perl-Data-Dumper-0:2.167-399.module_1681+b405d8e2.ppc64
+  - perl-Data-Dumper-0:2.167-399.module_1681+b405d8e2.ppc64le
+  - perl-Data-Dumper-0:2.167-399.module_1681+b405d8e2.s390x
+  - perl-Data-Dumper-0:2.167-399.module_1681+b405d8e2.src
+  - perl-Data-Dumper-0:2.167-399.module_1681+b405d8e2.x86_64
+  - perl-Data-Dumper-debuginfo-0:2.167-399.module_1681+b405d8e2.aarch64
+  - perl-Data-Dumper-debuginfo-0:2.167-399.module_1681+b405d8e2.armv7hl
+  - perl-Data-Dumper-debuginfo-0:2.167-399.module_1681+b405d8e2.ppc64
+  - perl-Data-Dumper-debuginfo-0:2.167-399.module_1681+b405d8e2.ppc64le
+  - perl-Data-Dumper-debuginfo-0:2.167-399.module_1681+b405d8e2.s390x
+  - perl-Data-Dumper-debuginfo-0:2.167-399.module_1681+b405d8e2.x86_64
+  - perl-Data-Dumper-debugsource-0:2.167-399.module_1681+b405d8e2.aarch64
+  - perl-Data-Dumper-debugsource-0:2.167-399.module_1681+b405d8e2.armv7hl
+  - perl-Data-Dumper-debugsource-0:2.167-399.module_1681+b405d8e2.ppc64
+  - perl-Data-Dumper-debugsource-0:2.167-399.module_1681+b405d8e2.ppc64le
+  - perl-Data-Dumper-debugsource-0:2.167-399.module_1681+b405d8e2.s390x
+  - perl-Data-Dumper-debugsource-0:2.167-399.module_1681+b405d8e2.x86_64
+  - perl-Data-OptList-0:0.110-6.module_1681+b405d8e2.noarch
+  - perl-Data-OptList-0:0.110-6.module_1681+b405d8e2.src
+  - perl-Data-Section-0:0.200007-3.module_1681+b405d8e2.noarch
+  - perl-Data-Section-0:0.200007-3.module_1681+b405d8e2.src
+  - perl-Devel-PPPort-0:3.36-5.module_1681+b405d8e2.aarch64
+  - perl-Devel-PPPort-0:3.36-5.module_1681+b405d8e2.armv7hl
+  - perl-Devel-PPPort-0:3.36-5.module_1681+b405d8e2.ppc64
+  - perl-Devel-PPPort-0:3.36-5.module_1681+b405d8e2.ppc64le
+  - perl-Devel-PPPort-0:3.36-5.module_1681+b405d8e2.s390x
+  - perl-Devel-PPPort-0:3.36-5.module_1681+b405d8e2.src
+  - perl-Devel-PPPort-0:3.36-5.module_1681+b405d8e2.x86_64
+  - perl-Devel-PPPort-debuginfo-0:3.36-5.module_1681+b405d8e2.aarch64
+  - perl-Devel-PPPort-debuginfo-0:3.36-5.module_1681+b405d8e2.armv7hl
+  - perl-Devel-PPPort-debuginfo-0:3.36-5.module_1681+b405d8e2.ppc64
+  - perl-Devel-PPPort-debuginfo-0:3.36-5.module_1681+b405d8e2.ppc64le
+  - perl-Devel-PPPort-debuginfo-0:3.36-5.module_1681+b405d8e2.s390x
+  - perl-Devel-PPPort-debuginfo-0:3.36-5.module_1681+b405d8e2.x86_64
+  - perl-Devel-PPPort-debugsource-0:3.36-5.module_1681+b405d8e2.aarch64
+  - perl-Devel-PPPort-debugsource-0:3.36-5.module_1681+b405d8e2.armv7hl
+  - perl-Devel-PPPort-debugsource-0:3.36-5.module_1681+b405d8e2.ppc64
+  - perl-Devel-PPPort-debugsource-0:3.36-5.module_1681+b405d8e2.ppc64le
+  - perl-Devel-PPPort-debugsource-0:3.36-5.module_1681+b405d8e2.s390x
+  - perl-Devel-PPPort-debugsource-0:3.36-5.module_1681+b405d8e2.x86_64
+  - perl-Devel-Peek-0:1.26-415.module_2543+eed510a0.aarch64
+  - perl-Devel-Peek-0:1.26-415.module_2543+eed510a0.armv7hl
+  - perl-Devel-Peek-0:1.26-415.module_2543+eed510a0.ppc64le
+  - perl-Devel-Peek-0:1.26-415.module_2543+eed510a0.s390x
+  - perl-Devel-Peek-0:1.26-415.module_2543+eed510a0.x86_64
+  - perl-Devel-Peek-debuginfo-0:1.26-415.module_2543+eed510a0.aarch64
+  - perl-Devel-Peek-debuginfo-0:1.26-415.module_2543+eed510a0.armv7hl
+  - perl-Devel-Peek-debuginfo-0:1.26-415.module_2543+eed510a0.ppc64le
+  - perl-Devel-Peek-debuginfo-0:1.26-415.module_2543+eed510a0.s390x
+  - perl-Devel-Peek-debuginfo-0:1.26-415.module_2543+eed510a0.x86_64
+  - perl-Devel-SelfStubber-0:1.06-415.module_2543+eed510a0.noarch
+  - perl-Devel-Size-0:0.82-1.module_2543+eed510a0.aarch64
+  - perl-Devel-Size-0:0.82-1.module_2543+eed510a0.armv7hl
+  - perl-Devel-Size-0:0.82-1.module_2543+eed510a0.ppc64le
+  - perl-Devel-Size-0:0.82-1.module_2543+eed510a0.s390x
+  - perl-Devel-Size-0:0.82-1.module_2543+eed510a0.src
+  - perl-Devel-Size-0:0.82-1.module_2543+eed510a0.x86_64
+  - perl-Devel-Size-debuginfo-0:0.82-1.module_2543+eed510a0.aarch64
+  - perl-Devel-Size-debuginfo-0:0.82-1.module_2543+eed510a0.armv7hl
+  - perl-Devel-Size-debuginfo-0:0.82-1.module_2543+eed510a0.ppc64le
+  - perl-Devel-Size-debuginfo-0:0.82-1.module_2543+eed510a0.s390x
+  - perl-Devel-Size-debuginfo-0:0.82-1.module_2543+eed510a0.x86_64
+  - perl-Devel-Size-debugsource-0:0.82-1.module_2543+eed510a0.aarch64
+  - perl-Devel-Size-debugsource-0:0.82-1.module_2543+eed510a0.armv7hl
+  - perl-Devel-Size-debugsource-0:0.82-1.module_2543+eed510a0.ppc64le
+  - perl-Devel-Size-debugsource-0:0.82-1.module_2543+eed510a0.s390x
+  - perl-Devel-Size-debugsource-0:0.82-1.module_2543+eed510a0.x86_64
+  - perl-Digest-0:1.17-395.module_1681+b405d8e2.noarch
+  - perl-Digest-0:1.17-395.module_1681+b405d8e2.src
+  - perl-Digest-MD5-0:2.55-396.module_1681+b405d8e2.aarch64
+  - perl-Digest-MD5-0:2.55-396.module_1681+b405d8e2.armv7hl
+  - perl-Digest-MD5-0:2.55-396.module_1681+b405d8e2.ppc64
+  - perl-Digest-MD5-0:2.55-396.module_1681+b405d8e2.ppc64le
+  - perl-Digest-MD5-0:2.55-396.module_1681+b405d8e2.s390x
+  - perl-Digest-MD5-0:2.55-396.module_1681+b405d8e2.src
+  - perl-Digest-MD5-0:2.55-396.module_1681+b405d8e2.x86_64
+  - perl-Digest-MD5-debuginfo-0:2.55-396.module_1681+b405d8e2.aarch64
+  - perl-Digest-MD5-debuginfo-0:2.55-396.module_1681+b405d8e2.armv7hl
+  - perl-Digest-MD5-debuginfo-0:2.55-396.module_1681+b405d8e2.ppc64
+  - perl-Digest-MD5-debuginfo-0:2.55-396.module_1681+b405d8e2.ppc64le
+  - perl-Digest-MD5-debuginfo-0:2.55-396.module_1681+b405d8e2.s390x
+  - perl-Digest-MD5-debuginfo-0:2.55-396.module_1681+b405d8e2.x86_64
+  - perl-Digest-MD5-debugsource-0:2.55-396.module_1681+b405d8e2.aarch64
+  - perl-Digest-MD5-debugsource-0:2.55-396.module_1681+b405d8e2.armv7hl
+  - perl-Digest-MD5-debugsource-0:2.55-396.module_1681+b405d8e2.ppc64
+  - perl-Digest-MD5-debugsource-0:2.55-396.module_1681+b405d8e2.ppc64le
+  - perl-Digest-MD5-debugsource-0:2.55-396.module_1681+b405d8e2.s390x
+  - perl-Digest-MD5-debugsource-0:2.55-396.module_1681+b405d8e2.x86_64
+  - perl-Digest-SHA-1:6.02-1.module_2543+eed510a0.aarch64
+  - perl-Digest-SHA-1:6.02-1.module_2543+eed510a0.armv7hl
+  - perl-Digest-SHA-1:6.02-1.module_2543+eed510a0.ppc64le
+  - perl-Digest-SHA-1:6.02-1.module_2543+eed510a0.s390x
+  - perl-Digest-SHA-1:6.02-1.module_2543+eed510a0.src
+  - perl-Digest-SHA-1:6.02-1.module_2543+eed510a0.x86_64
+  - perl-Digest-SHA-debuginfo-1:6.02-1.module_2543+eed510a0.aarch64
+  - perl-Digest-SHA-debuginfo-1:6.02-1.module_2543+eed510a0.armv7hl
+  - perl-Digest-SHA-debuginfo-1:6.02-1.module_2543+eed510a0.ppc64le
+  - perl-Digest-SHA-debuginfo-1:6.02-1.module_2543+eed510a0.s390x
+  - perl-Digest-SHA-debuginfo-1:6.02-1.module_2543+eed510a0.x86_64
+  - perl-Digest-SHA-debugsource-1:6.02-1.module_2543+eed510a0.aarch64
+  - perl-Digest-SHA-debugsource-1:6.02-1.module_2543+eed510a0.armv7hl
+  - perl-Digest-SHA-debugsource-1:6.02-1.module_2543+eed510a0.ppc64le
+  - perl-Digest-SHA-debugsource-1:6.02-1.module_2543+eed510a0.s390x
+  - perl-Digest-SHA-debugsource-1:6.02-1.module_2543+eed510a0.x86_64
+  - perl-Encode-4:2.97-3.module_1681+b405d8e2.aarch64
+  - perl-Encode-4:2.97-3.module_1681+b405d8e2.armv7hl
+  - perl-Encode-4:2.97-3.module_1681+b405d8e2.ppc64
+  - perl-Encode-4:2.97-3.module_1681+b405d8e2.ppc64le
+  - perl-Encode-4:2.97-3.module_1681+b405d8e2.s390x
+  - perl-Encode-4:2.97-3.module_1681+b405d8e2.src
+  - perl-Encode-4:2.97-3.module_1681+b405d8e2.x86_64
+  - perl-Encode-debuginfo-4:2.97-3.module_1681+b405d8e2.aarch64
+  - perl-Encode-debuginfo-4:2.97-3.module_1681+b405d8e2.armv7hl
+  - perl-Encode-debuginfo-4:2.97-3.module_1681+b405d8e2.ppc64
+  - perl-Encode-debuginfo-4:2.97-3.module_1681+b405d8e2.ppc64le
+  - perl-Encode-debuginfo-4:2.97-3.module_1681+b405d8e2.s390x
+  - perl-Encode-debuginfo-4:2.97-3.module_1681+b405d8e2.x86_64
+  - perl-Encode-debugsource-4:2.97-3.module_1681+b405d8e2.aarch64
+  - perl-Encode-debugsource-4:2.97-3.module_1681+b405d8e2.armv7hl
+  - perl-Encode-debugsource-4:2.97-3.module_1681+b405d8e2.ppc64
+  - perl-Encode-debugsource-4:2.97-3.module_1681+b405d8e2.ppc64le
+  - perl-Encode-debugsource-4:2.97-3.module_1681+b405d8e2.s390x
+  - perl-Encode-debugsource-4:2.97-3.module_1681+b405d8e2.x86_64
+  - perl-Encode-devel-4:2.97-3.module_1681+b405d8e2.aarch64
+  - perl-Encode-devel-4:2.97-3.module_1681+b405d8e2.armv7hl
+  - perl-Encode-devel-4:2.97-3.module_1681+b405d8e2.ppc64
+  - perl-Encode-devel-4:2.97-3.module_1681+b405d8e2.ppc64le
+  - perl-Encode-devel-4:2.97-3.module_1681+b405d8e2.s390x
+  - perl-Encode-devel-4:2.97-3.module_1681+b405d8e2.x86_64
+  - perl-Env-0:1.04-395.module_1681+b405d8e2.noarch
+  - perl-Env-0:1.04-395.module_1681+b405d8e2.src
+  - perl-Errno-0:1.28-415.module_2543+eed510a0.aarch64
+  - perl-Errno-0:1.28-415.module_2543+eed510a0.armv7hl
+  - perl-Errno-0:1.28-415.module_2543+eed510a0.ppc64le
+  - perl-Errno-0:1.28-415.module_2543+eed510a0.s390x
+  - perl-Errno-0:1.28-415.module_2543+eed510a0.x86_64
+  - perl-Exporter-0:5.72-396.module_1681+b405d8e2.noarch
+  - perl-Exporter-0:5.72-396.module_1681+b405d8e2.src
+  - perl-ExtUtils-CBuilder-1:0.280230-2.module_1681+b405d8e2.noarch
+  - perl-ExtUtils-CBuilder-1:0.280230-2.module_1681+b405d8e2.src
+  - perl-ExtUtils-Command-1:7.34-1.module_1681+b405d8e2.noarch
+  - perl-ExtUtils-Embed-0:1.34-415.module_2543+eed510a0.noarch
+  - perl-ExtUtils-Install-0:2.14-4.module_1681+b405d8e2.noarch
+  - perl-ExtUtils-Install-0:2.14-4.module_1681+b405d8e2.src
+  - perl-ExtUtils-MM-Utils-1:7.34-1.module_1681+b405d8e2.noarch
+  - perl-ExtUtils-MakeMaker-1:7.34-1.module_1681+b405d8e2.noarch
+  - perl-ExtUtils-MakeMaker-1:7.34-1.module_1681+b405d8e2.src
+  - perl-ExtUtils-Manifest-0:1.70-395.module_1681+b405d8e2.noarch
+  - perl-ExtUtils-Manifest-0:1.70-395.module_1681+b405d8e2.src
+  - perl-ExtUtils-Miniperl-0:1.06-415.module_2543+eed510a0.noarch
+  - perl-ExtUtils-ParseXS-1:3.35-3.module_2543+eed510a0.noarch
+  - perl-ExtUtils-ParseXS-1:3.35-3.module_2543+eed510a0.src
+  - perl-Fedora-VSP-0:0.001-9.module_1681+b405d8e2.noarch
+  - perl-Fedora-VSP-0:0.001-9.module_1681+b405d8e2.src
+  - perl-File-Fetch-0:0.56-2.module_1681+b405d8e2.noarch
+  - perl-File-Fetch-0:0.56-2.module_1681+b405d8e2.src
+  - perl-File-HomeDir-0:1.002-4.module_1681+b405d8e2.noarch
+  - perl-File-HomeDir-0:1.002-4.module_1681+b405d8e2.src
+  - perl-File-Path-0:2.16-1.module_2543+eed510a0.noarch
+  - perl-File-Path-0:2.16-1.module_2543+eed510a0.src
+  - perl-File-Temp-0:0.230.600-1.module_2543+eed510a0.noarch
+  - perl-File-Temp-0:0.230.600-1.module_2543+eed510a0.src
+  - perl-File-Which-0:1.22-2.module_1681+b405d8e2.noarch
+  - perl-File-Which-0:1.22-2.module_1681+b405d8e2.src
+  - perl-Filter-2:1.58-2.module_1681+b405d8e2.aarch64
+  - perl-Filter-2:1.58-2.module_1681+b405d8e2.armv7hl
+  - perl-Filter-2:1.58-2.module_1681+b405d8e2.ppc64
+  - perl-Filter-2:1.58-2.module_1681+b405d8e2.ppc64le
+  - perl-Filter-2:1.58-2.module_1681+b405d8e2.s390x
+  - perl-Filter-2:1.58-2.module_1681+b405d8e2.src
+  - perl-Filter-2:1.58-2.module_1681+b405d8e2.x86_64
+  - perl-Filter-Simple-0:0.94-2.module_1681+b405d8e2.noarch
+  - perl-Filter-Simple-0:0.94-2.module_1681+b405d8e2.src
+  - perl-Filter-debuginfo-2:1.58-2.module_1681+b405d8e2.aarch64
+  - perl-Filter-debuginfo-2:1.58-2.module_1681+b405d8e2.armv7hl
+  - perl-Filter-debuginfo-2:1.58-2.module_1681+b405d8e2.ppc64
+  - perl-Filter-debuginfo-2:1.58-2.module_1681+b405d8e2.ppc64le
+  - perl-Filter-debuginfo-2:1.58-2.module_1681+b405d8e2.s390x
+  - perl-Filter-debuginfo-2:1.58-2.module_1681+b405d8e2.x86_64
+  - perl-Filter-debugsource-2:1.58-2.module_1681+b405d8e2.aarch64
+  - perl-Filter-debugsource-2:1.58-2.module_1681+b405d8e2.armv7hl
+  - perl-Filter-debugsource-2:1.58-2.module_1681+b405d8e2.ppc64
+  - perl-Filter-debugsource-2:1.58-2.module_1681+b405d8e2.ppc64le
+  - perl-Filter-debugsource-2:1.58-2.module_1681+b405d8e2.s390x
+  - perl-Filter-debugsource-2:1.58-2.module_1681+b405d8e2.x86_64
+  - perl-Getopt-Long-1:2.50-4.module_1681+b405d8e2.noarch
+  - perl-Getopt-Long-1:2.50-4.module_1681+b405d8e2.src
+  - perl-HTTP-Tiny-0:0.076-1.module_2543+eed510a0.noarch
+  - perl-HTTP-Tiny-0:0.076-1.module_2543+eed510a0.src
+  - perl-IO-0:1.38-415.module_2543+eed510a0.aarch64
+  - perl-IO-0:1.38-415.module_2543+eed510a0.armv7hl
+  - perl-IO-0:1.38-415.module_2543+eed510a0.ppc64le
+  - perl-IO-0:1.38-415.module_2543+eed510a0.s390x
+  - perl-IO-0:1.38-415.module_2543+eed510a0.x86_64
+  - perl-IO-Compress-0:2.081-1.module_1681+b405d8e2.noarch
+  - perl-IO-Compress-0:2.081-1.module_1681+b405d8e2.src
+  - perl-IO-Socket-IP-0:0.39-5.module_1681+b405d8e2.noarch
+  - perl-IO-Socket-IP-0:0.39-5.module_1681+b405d8e2.src
+  - perl-IO-Zlib-1:1.10-415.module_2543+eed510a0.noarch
+  - perl-IO-debuginfo-0:1.38-415.module_2543+eed510a0.aarch64
+  - perl-IO-debuginfo-0:1.38-415.module_2543+eed510a0.armv7hl
+  - perl-IO-debuginfo-0:1.38-415.module_2543+eed510a0.ppc64le
+  - perl-IO-debuginfo-0:1.38-415.module_2543+eed510a0.s390x
+  - perl-IO-debuginfo-0:1.38-415.module_2543+eed510a0.x86_64
+  - perl-IPC-Cmd-2:1.02-1.module_2543+eed510a0.noarch
+  - perl-IPC-Cmd-2:1.02-1.module_2543+eed510a0.src
+  - perl-IPC-SysV-0:2.07-397.module_1681+b405d8e2.aarch64
+  - perl-IPC-SysV-0:2.07-397.module_1681+b405d8e2.armv7hl
+  - perl-IPC-SysV-0:2.07-397.module_1681+b405d8e2.ppc64
+  - perl-IPC-SysV-0:2.07-397.module_1681+b405d8e2.ppc64le
+  - perl-IPC-SysV-0:2.07-397.module_1681+b405d8e2.s390x
+  - perl-IPC-SysV-0:2.07-397.module_1681+b405d8e2.src
+  - perl-IPC-SysV-0:2.07-397.module_1681+b405d8e2.x86_64
+  - perl-IPC-SysV-debuginfo-0:2.07-397.module_1681+b405d8e2.aarch64
+  - perl-IPC-SysV-debuginfo-0:2.07-397.module_1681+b405d8e2.armv7hl
+  - perl-IPC-SysV-debuginfo-0:2.07-397.module_1681+b405d8e2.ppc64
+  - perl-IPC-SysV-debuginfo-0:2.07-397.module_1681+b405d8e2.ppc64le
+  - perl-IPC-SysV-debuginfo-0:2.07-397.module_1681+b405d8e2.s390x
+  - perl-IPC-SysV-debuginfo-0:2.07-397.module_1681+b405d8e2.x86_64
+  - perl-IPC-SysV-debugsource-0:2.07-397.module_1681+b405d8e2.aarch64
+  - perl-IPC-SysV-debugsource-0:2.07-397.module_1681+b405d8e2.armv7hl
+  - perl-IPC-SysV-debugsource-0:2.07-397.module_1681+b405d8e2.ppc64
+  - perl-IPC-SysV-debugsource-0:2.07-397.module_1681+b405d8e2.ppc64le
+  - perl-IPC-SysV-debugsource-0:2.07-397.module_1681+b405d8e2.s390x
+  - perl-IPC-SysV-debugsource-0:2.07-397.module_1681+b405d8e2.x86_64
+  - perl-IPC-System-Simple-0:1.25-17.module_1681+b405d8e2.noarch
+  - perl-IPC-System-Simple-0:1.25-17.module_1681+b405d8e2.src
+  - perl-JSON-PP-1:2.97.001-2.module_1681+b405d8e2.noarch
+  - perl-JSON-PP-1:2.97.001-2.module_1681+b405d8e2.src
+  - perl-Locale-Codes-0:3.59-1.module_2543+eed510a0.noarch
+  - perl-Locale-Codes-0:3.59-1.module_2543+eed510a0.src
+  - perl-Locale-Maketext-0:1.28-396.module_1681+b405d8e2.noarch
+  - perl-Locale-Maketext-0:1.28-396.module_1681+b405d8e2.src
+  - perl-Locale-Maketext-Simple-1:0.21-415.module_2543+eed510a0.noarch
+  - perl-MIME-Base64-0:3.15-396.module_1681+b405d8e2.aarch64
+  - perl-MIME-Base64-0:3.15-396.module_1681+b405d8e2.armv7hl
+  - perl-MIME-Base64-0:3.15-396.module_1681+b405d8e2.ppc64
+  - perl-MIME-Base64-0:3.15-396.module_1681+b405d8e2.ppc64le
+  - perl-MIME-Base64-0:3.15-396.module_1681+b405d8e2.s390x
+  - perl-MIME-Base64-0:3.15-396.module_1681+b405d8e2.src
+  - perl-MIME-Base64-0:3.15-396.module_1681+b405d8e2.x86_64
+  - perl-MIME-Base64-debuginfo-0:3.15-396.module_1681+b405d8e2.aarch64
+  - perl-MIME-Base64-debuginfo-0:3.15-396.module_1681+b405d8e2.armv7hl
+  - perl-MIME-Base64-debuginfo-0:3.15-396.module_1681+b405d8e2.ppc64
+  - perl-MIME-Base64-debuginfo-0:3.15-396.module_1681+b405d8e2.ppc64le
+  - perl-MIME-Base64-debuginfo-0:3.15-396.module_1681+b405d8e2.s390x
+  - perl-MIME-Base64-debuginfo-0:3.15-396.module_1681+b405d8e2.x86_64
+  - perl-MIME-Base64-debugsource-0:3.15-396.module_1681+b405d8e2.aarch64
+  - perl-MIME-Base64-debugsource-0:3.15-396.module_1681+b405d8e2.armv7hl
+  - perl-MIME-Base64-debugsource-0:3.15-396.module_1681+b405d8e2.ppc64
+  - perl-MIME-Base64-debugsource-0:3.15-396.module_1681+b405d8e2.ppc64le
+  - perl-MIME-Base64-debugsource-0:3.15-396.module_1681+b405d8e2.s390x
+  - perl-MIME-Base64-debugsource-0:3.15-396.module_1681+b405d8e2.x86_64
+  - perl-MRO-Compat-0:0.13-4.module_1681+b405d8e2.noarch
+  - perl-MRO-Compat-0:0.13-4.module_1681+b405d8e2.src
+  - perl-Math-BigInt-1:1.9998.11-5.module_1681+b405d8e2.noarch
+  - perl-Math-BigInt-1:1.9998.11-5.module_1681+b405d8e2.src
+  - perl-Math-BigInt-FastCalc-0:0.500.600-6.module_1681+b405d8e2.aarch64
+  - perl-Math-BigInt-FastCalc-0:0.500.600-6.module_1681+b405d8e2.armv7hl
+  - perl-Math-BigInt-FastCalc-0:0.500.600-6.module_1681+b405d8e2.ppc64
+  - perl-Math-BigInt-FastCalc-0:0.500.600-6.module_1681+b405d8e2.ppc64le
+  - perl-Math-BigInt-FastCalc-0:0.500.600-6.module_1681+b405d8e2.s390x
+  - perl-Math-BigInt-FastCalc-0:0.500.600-6.module_1681+b405d8e2.src
+  - perl-Math-BigInt-FastCalc-0:0.500.600-6.module_1681+b405d8e2.x86_64
+  - perl-Math-BigInt-FastCalc-debuginfo-0:0.500.600-6.module_1681+b405d8e2.aarch64
+  - perl-Math-BigInt-FastCalc-debuginfo-0:0.500.600-6.module_1681+b405d8e2.armv7hl
+  - perl-Math-BigInt-FastCalc-debuginfo-0:0.500.600-6.module_1681+b405d8e2.ppc64
+  - perl-Math-BigInt-FastCalc-debuginfo-0:0.500.600-6.module_1681+b405d8e2.ppc64le
+  - perl-Math-BigInt-FastCalc-debuginfo-0:0.500.600-6.module_1681+b405d8e2.s390x
+  - perl-Math-BigInt-FastCalc-debuginfo-0:0.500.600-6.module_1681+b405d8e2.x86_64
+  - perl-Math-BigInt-FastCalc-debugsource-0:0.500.600-6.module_1681+b405d8e2.aarch64
+  - perl-Math-BigInt-FastCalc-debugsource-0:0.500.600-6.module_1681+b405d8e2.armv7hl
+  - perl-Math-BigInt-FastCalc-debugsource-0:0.500.600-6.module_1681+b405d8e2.ppc64
+  - perl-Math-BigInt-FastCalc-debugsource-0:0.500.600-6.module_1681+b405d8e2.ppc64le
+  - perl-Math-BigInt-FastCalc-debugsource-0:0.500.600-6.module_1681+b405d8e2.s390x
+  - perl-Math-BigInt-FastCalc-debugsource-0:0.500.600-6.module_1681+b405d8e2.x86_64
+  - perl-Math-BigRat-0:0.2614-1.module_2543+eed510a0.noarch
+  - perl-Math-BigRat-0:0.2614-1.module_2543+eed510a0.src
+  - perl-Math-Complex-0:1.59-415.module_2543+eed510a0.noarch
+  - perl-Memoize-0:1.03-415.module_2543+eed510a0.noarch
+  - perl-Module-Build-2:0.42.24-5.module_1681+b405d8e2.noarch
+  - perl-Module-Build-2:0.42.24-5.module_1681+b405d8e2.src
+  - perl-Module-CoreList-1:5.20181130-1.module_2543+eed510a0.noarch
+  - perl-Module-CoreList-1:5.20181130-1.module_2543+eed510a0.src
+  - perl-Module-CoreList-tools-1:5.20181130-1.module_2543+eed510a0.noarch
+  - perl-Module-Load-1:0.32-395.module_1681+b405d8e2.noarch
+  - perl-Module-Load-1:0.32-395.module_1681+b405d8e2.src
+  - perl-Module-Load-Conditional-0:0.68-395.module_1681+b405d8e2.noarch
+  - perl-Module-Load-Conditional-0:0.68-395.module_1681+b405d8e2.src
+  - perl-Module-Loaded-1:0.08-415.module_2543+eed510a0.noarch
+  - perl-Module-Metadata-0:1.000033-395.module_1681+b405d8e2.noarch
+  - perl-Module-Metadata-0:1.000033-395.module_1681+b405d8e2.src
+  - perl-Net-Ping-0:2.55-415.module_2543+eed510a0.noarch
+  - perl-Package-Generator-0:1.106-11.module_1681+b405d8e2.noarch
+  - perl-Package-Generator-0:1.106-11.module_1681+b405d8e2.src
+  - perl-Params-Check-1:0.38-395.module_1681+b405d8e2.noarch
+  - perl-Params-Check-1:0.38-395.module_1681+b405d8e2.src
+  - perl-Params-Util-0:1.07-22.module_1681+b405d8e2.aarch64
+  - perl-Params-Util-0:1.07-22.module_1681+b405d8e2.armv7hl
+  - perl-Params-Util-0:1.07-22.module_1681+b405d8e2.ppc64
+  - perl-Params-Util-0:1.07-22.module_1681+b405d8e2.ppc64le
+  - perl-Params-Util-0:1.07-22.module_1681+b405d8e2.s390x
+  - perl-Params-Util-0:1.07-22.module_1681+b405d8e2.src
+  - perl-Params-Util-0:1.07-22.module_1681+b405d8e2.x86_64
+  - perl-Params-Util-debuginfo-0:1.07-22.module_1681+b405d8e2.aarch64
+  - perl-Params-Util-debuginfo-0:1.07-22.module_1681+b405d8e2.armv7hl
+  - perl-Params-Util-debuginfo-0:1.07-22.module_1681+b405d8e2.ppc64
+  - perl-Params-Util-debuginfo-0:1.07-22.module_1681+b405d8e2.ppc64le
+  - perl-Params-Util-debuginfo-0:1.07-22.module_1681+b405d8e2.s390x
+  - perl-Params-Util-debuginfo-0:1.07-22.module_1681+b405d8e2.x86_64
+  - perl-Params-Util-debugsource-0:1.07-22.module_1681+b405d8e2.aarch64
+  - perl-Params-Util-debugsource-0:1.07-22.module_1681+b405d8e2.armv7hl
+  - perl-Params-Util-debugsource-0:1.07-22.module_1681+b405d8e2.ppc64
+  - perl-Params-Util-debugsource-0:1.07-22.module_1681+b405d8e2.ppc64le
+  - perl-Params-Util-debugsource-0:1.07-22.module_1681+b405d8e2.s390x
+  - perl-Params-Util-debugsource-0:1.07-22.module_1681+b405d8e2.x86_64
+  - perl-PathTools-0:3.75-1.module_2543+eed510a0.aarch64
+  - perl-PathTools-0:3.75-1.module_2543+eed510a0.armv7hl
+  - perl-PathTools-0:3.75-1.module_2543+eed510a0.ppc64le
+  - perl-PathTools-0:3.75-1.module_2543+eed510a0.s390x
+  - perl-PathTools-0:3.75-1.module_2543+eed510a0.src
+  - perl-PathTools-0:3.75-1.module_2543+eed510a0.x86_64
+  - perl-PathTools-debuginfo-0:3.75-1.module_2543+eed510a0.aarch64
+  - perl-PathTools-debuginfo-0:3.75-1.module_2543+eed510a0.armv7hl
+  - perl-PathTools-debuginfo-0:3.75-1.module_2543+eed510a0.ppc64le
+  - perl-PathTools-debuginfo-0:3.75-1.module_2543+eed510a0.s390x
+  - perl-PathTools-debuginfo-0:3.75-1.module_2543+eed510a0.x86_64
+  - perl-PathTools-debugsource-0:3.75-1.module_2543+eed510a0.aarch64
+  - perl-PathTools-debugsource-0:3.75-1.module_2543+eed510a0.armv7hl
+  - perl-PathTools-debugsource-0:3.75-1.module_2543+eed510a0.ppc64le
+  - perl-PathTools-debugsource-0:3.75-1.module_2543+eed510a0.s390x
+  - perl-PathTools-debugsource-0:3.75-1.module_2543+eed510a0.x86_64
+  - perl-Perl-OSType-0:1.010-396.module_1681+b405d8e2.noarch
+  - perl-Perl-OSType-0:1.010-396.module_1681+b405d8e2.src
+  - perl-PerlIO-via-QuotedPrint-0:0.08-395.module_1681+b405d8e2.noarch
+  - perl-PerlIO-via-QuotedPrint-0:0.08-395.module_1681+b405d8e2.src
+  - perl-Pod-Checker-4:1.73-395.module_1681+b405d8e2.noarch
+  - perl-Pod-Checker-4:1.73-395.module_1681+b405d8e2.src
+  - perl-Pod-Escapes-1:1.07-395.module_1681+b405d8e2.noarch
+  - perl-Pod-Escapes-1:1.07-395.module_1681+b405d8e2.src
+  - perl-Pod-Html-0:1.22.02-415.module_2543+eed510a0.noarch
+  - perl-Pod-Parser-0:1.63-396.module_1681+b405d8e2.noarch
+  - perl-Pod-Parser-0:1.63-396.module_1681+b405d8e2.src
+  - perl-Pod-Perldoc-0:3.28.01-1.module_2543+eed510a0.noarch
+  - perl-Pod-Perldoc-0:3.28.01-1.module_2543+eed510a0.src
+  - perl-Pod-Simple-1:3.35-395.module_1681+b405d8e2.noarch
+  - perl-Pod-Simple-1:3.35-395.module_1681+b405d8e2.src
+  - perl-Pod-Usage-4:1.69-395.module_1681+b405d8e2.noarch
+  - perl-Pod-Usage-4:1.69-395.module_1681+b405d8e2.src
+  - perl-Scalar-List-Utils-3:1.49-2.module_1681+b405d8e2.aarch64
+  - perl-Scalar-List-Utils-3:1.49-2.module_1681+b405d8e2.armv7hl
+  - perl-Scalar-List-Utils-3:1.49-2.module_1681+b405d8e2.ppc64
+  - perl-Scalar-List-Utils-3:1.49-2.module_1681+b405d8e2.ppc64le
+  - perl-Scalar-List-Utils-3:1.49-2.module_1681+b405d8e2.s390x
+  - perl-Scalar-List-Utils-3:1.49-2.module_1681+b405d8e2.src
+  - perl-Scalar-List-Utils-3:1.49-2.module_1681+b405d8e2.x86_64
+  - perl-Scalar-List-Utils-debuginfo-3:1.49-2.module_1681+b405d8e2.aarch64
+  - perl-Scalar-List-Utils-debuginfo-3:1.49-2.module_1681+b405d8e2.armv7hl
+  - perl-Scalar-List-Utils-debuginfo-3:1.49-2.module_1681+b405d8e2.ppc64
+  - perl-Scalar-List-Utils-debuginfo-3:1.49-2.module_1681+b405d8e2.ppc64le
+  - perl-Scalar-List-Utils-debuginfo-3:1.49-2.module_1681+b405d8e2.s390x
+  - perl-Scalar-List-Utils-debuginfo-3:1.49-2.module_1681+b405d8e2.x86_64
+  - perl-Scalar-List-Utils-debugsource-3:1.49-2.module_1681+b405d8e2.aarch64
+  - perl-Scalar-List-Utils-debugsource-3:1.49-2.module_1681+b405d8e2.armv7hl
+  - perl-Scalar-List-Utils-debugsource-3:1.49-2.module_1681+b405d8e2.ppc64
+  - perl-Scalar-List-Utils-debugsource-3:1.49-2.module_1681+b405d8e2.ppc64le
+  - perl-Scalar-List-Utils-debugsource-3:1.49-2.module_1681+b405d8e2.s390x
+  - perl-Scalar-List-Utils-debugsource-3:1.49-2.module_1681+b405d8e2.x86_64
+  - perl-SelfLoader-0:1.23-415.module_2543+eed510a0.noarch
+  - perl-Socket-4:2.027-2.module_1681+b405d8e2.aarch64
+  - perl-Socket-4:2.027-2.module_1681+b405d8e2.armv7hl
+  - perl-Socket-4:2.027-2.module_1681+b405d8e2.ppc64
+  - perl-Socket-4:2.027-2.module_1681+b405d8e2.ppc64le
+  - perl-Socket-4:2.027-2.module_1681+b405d8e2.s390x
+  - perl-Socket-4:2.027-2.module_1681+b405d8e2.src
+  - perl-Socket-4:2.027-2.module_1681+b405d8e2.x86_64
+  - perl-Socket-debuginfo-4:2.027-2.module_1681+b405d8e2.aarch64
+  - perl-Socket-debuginfo-4:2.027-2.module_1681+b405d8e2.armv7hl
+  - perl-Socket-debuginfo-4:2.027-2.module_1681+b405d8e2.ppc64
+  - perl-Socket-debuginfo-4:2.027-2.module_1681+b405d8e2.ppc64le
+  - perl-Socket-debuginfo-4:2.027-2.module_1681+b405d8e2.s390x
+  - perl-Socket-debuginfo-4:2.027-2.module_1681+b405d8e2.x86_64
+  - perl-Socket-debugsource-4:2.027-2.module_1681+b405d8e2.aarch64
+  - perl-Socket-debugsource-4:2.027-2.module_1681+b405d8e2.armv7hl
+  - perl-Socket-debugsource-4:2.027-2.module_1681+b405d8e2.ppc64
+  - perl-Socket-debugsource-4:2.027-2.module_1681+b405d8e2.ppc64le
+  - perl-Socket-debugsource-4:2.027-2.module_1681+b405d8e2.s390x
+  - perl-Socket-debugsource-4:2.027-2.module_1681+b405d8e2.x86_64
+  - perl-Software-License-0:0.103013-2.module_1681+b405d8e2.noarch
+  - perl-Software-License-0:0.103013-2.module_1681+b405d8e2.src
+  - perl-Storable-1:3.11-3.module_2543+eed510a0.aarch64
+  - perl-Storable-1:3.11-3.module_2543+eed510a0.armv7hl
+  - perl-Storable-1:3.11-3.module_2543+eed510a0.ppc64le
+  - perl-Storable-1:3.11-3.module_2543+eed510a0.s390x
+  - perl-Storable-1:3.11-3.module_2543+eed510a0.src
+  - perl-Storable-1:3.11-3.module_2543+eed510a0.x86_64
+  - perl-Storable-debuginfo-1:3.11-3.module_2543+eed510a0.aarch64
+  - perl-Storable-debuginfo-1:3.11-3.module_2543+eed510a0.armv7hl
+  - perl-Storable-debuginfo-1:3.11-3.module_2543+eed510a0.ppc64le
+  - perl-Storable-debuginfo-1:3.11-3.module_2543+eed510a0.s390x
+  - perl-Storable-debuginfo-1:3.11-3.module_2543+eed510a0.x86_64
+  - perl-Storable-debugsource-1:3.11-3.module_2543+eed510a0.aarch64
+  - perl-Storable-debugsource-1:3.11-3.module_2543+eed510a0.armv7hl
+  - perl-Storable-debugsource-1:3.11-3.module_2543+eed510a0.ppc64le
+  - perl-Storable-debugsource-1:3.11-3.module_2543+eed510a0.s390x
+  - perl-Storable-debugsource-1:3.11-3.module_2543+eed510a0.x86_64
+  - perl-Sub-Exporter-0:0.987-15.module_1681+b405d8e2.noarch
+  - perl-Sub-Exporter-0:0.987-15.module_1681+b405d8e2.src
+  - perl-Sub-Install-0:0.928-14.module_1681+b405d8e2.noarch
+  - perl-Sub-Install-0:0.928-14.module_1681+b405d8e2.src
+  - perl-Sys-Syslog-0:0.35-397.module_1681+b405d8e2.aarch64
+  - perl-Sys-Syslog-0:0.35-397.module_1681+b405d8e2.armv7hl
+  - perl-Sys-Syslog-0:0.35-397.module_1681+b405d8e2.ppc64
+  - perl-Sys-Syslog-0:0.35-397.module_1681+b405d8e2.ppc64le
+  - perl-Sys-Syslog-0:0.35-397.module_1681+b405d8e2.s390x
+  - perl-Sys-Syslog-0:0.35-397.module_1681+b405d8e2.src
+  - perl-Sys-Syslog-0:0.35-397.module_1681+b405d8e2.x86_64
+  - perl-Sys-Syslog-debuginfo-0:0.35-397.module_1681+b405d8e2.aarch64
+  - perl-Sys-Syslog-debuginfo-0:0.35-397.module_1681+b405d8e2.armv7hl
+  - perl-Sys-Syslog-debuginfo-0:0.35-397.module_1681+b405d8e2.ppc64
+  - perl-Sys-Syslog-debuginfo-0:0.35-397.module_1681+b405d8e2.ppc64le
+  - perl-Sys-Syslog-debuginfo-0:0.35-397.module_1681+b405d8e2.s390x
+  - perl-Sys-Syslog-debuginfo-0:0.35-397.module_1681+b405d8e2.x86_64
+  - perl-Sys-Syslog-debugsource-0:0.35-397.module_1681+b405d8e2.aarch64
+  - perl-Sys-Syslog-debugsource-0:0.35-397.module_1681+b405d8e2.armv7hl
+  - perl-Sys-Syslog-debugsource-0:0.35-397.module_1681+b405d8e2.ppc64
+  - perl-Sys-Syslog-debugsource-0:0.35-397.module_1681+b405d8e2.ppc64le
+  - perl-Sys-Syslog-debugsource-0:0.35-397.module_1681+b405d8e2.s390x
+  - perl-Sys-Syslog-debugsource-0:0.35-397.module_1681+b405d8e2.x86_64
+  - perl-Term-ANSIColor-0:4.06-396.module_1681+b405d8e2.noarch
+  - perl-Term-ANSIColor-0:4.06-396.module_1681+b405d8e2.src
+  - perl-Term-Cap-0:1.17-395.module_1681+b405d8e2.noarch
+  - perl-Term-Cap-0:1.17-395.module_1681+b405d8e2.src
+  - perl-Test-0:1.30-415.module_2543+eed510a0.noarch
+  - perl-Test-Harness-1:3.42-1.module_1681+b405d8e2.noarch
+  - perl-Test-Harness-1:3.42-1.module_1681+b405d8e2.src
+  - perl-Test-Simple-1:1.302135-1.module_1681+b405d8e2.noarch
+  - perl-Test-Simple-1:1.302135-1.module_1681+b405d8e2.src
+  - perl-Text-Balanced-0:2.03-395.module_1681+b405d8e2.noarch
+  - perl-Text-Balanced-0:2.03-395.module_1681+b405d8e2.src
+  - perl-Text-Diff-0:1.45-2.module_1681+b405d8e2.noarch
+  - perl-Text-Diff-0:1.45-2.module_1681+b405d8e2.src
+  - perl-Text-Glob-0:0.11-4.module_1681+b405d8e2.noarch
+  - perl-Text-Glob-0:0.11-4.module_1681+b405d8e2.src
+  - perl-Text-ParseWords-0:3.30-395.module_1681+b405d8e2.noarch
+  - perl-Text-ParseWords-0:3.30-395.module_1681+b405d8e2.src
+  - perl-Text-Tabs+Wrap-0:2013.0523-395.module_1681+b405d8e2.noarch
+  - perl-Text-Tabs+Wrap-0:2013.0523-395.module_1681+b405d8e2.src
+  - perl-Text-Template-0:1.51-1.module_1681+b405d8e2.noarch
+  - perl-Text-Template-0:1.51-1.module_1681+b405d8e2.src
+  - perl-Thread-Queue-0:3.13-1.module_2543+eed510a0.noarch
+  - perl-Thread-Queue-0:3.13-1.module_2543+eed510a0.src
+  - perl-Time-HiRes-0:1.9758-1.module_1681+b405d8e2.aarch64
+  - perl-Time-HiRes-0:1.9758-1.module_1681+b405d8e2.armv7hl
+  - perl-Time-HiRes-0:1.9758-1.module_1681+b405d8e2.ppc64
+  - perl-Time-HiRes-0:1.9758-1.module_1681+b405d8e2.ppc64le
+  - perl-Time-HiRes-0:1.9758-1.module_1681+b405d8e2.s390x
+  - perl-Time-HiRes-0:1.9758-1.module_1681+b405d8e2.src
+  - perl-Time-HiRes-0:1.9758-1.module_1681+b405d8e2.x86_64
+  - perl-Time-HiRes-debuginfo-0:1.9758-1.module_1681+b405d8e2.aarch64
+  - perl-Time-HiRes-debuginfo-0:1.9758-1.module_1681+b405d8e2.armv7hl
+  - perl-Time-HiRes-debuginfo-0:1.9758-1.module_1681+b405d8e2.ppc64
+  - perl-Time-HiRes-debuginfo-0:1.9758-1.module_1681+b405d8e2.ppc64le
+  - perl-Time-HiRes-debuginfo-0:1.9758-1.module_1681+b405d8e2.s390x
+  - perl-Time-HiRes-debuginfo-0:1.9758-1.module_1681+b405d8e2.x86_64
+  - perl-Time-HiRes-debugsource-0:1.9758-1.module_1681+b405d8e2.aarch64
+  - perl-Time-HiRes-debugsource-0:1.9758-1.module_1681+b405d8e2.armv7hl
+  - perl-Time-HiRes-debugsource-0:1.9758-1.module_1681+b405d8e2.ppc64
+  - perl-Time-HiRes-debugsource-0:1.9758-1.module_1681+b405d8e2.ppc64le
+  - perl-Time-HiRes-debugsource-0:1.9758-1.module_1681+b405d8e2.s390x
+  - perl-Time-HiRes-debugsource-0:1.9758-1.module_1681+b405d8e2.x86_64
+  - perl-Time-Local-1:1.280-1.module_2543+eed510a0.noarch
+  - perl-Time-Local-1:1.280-1.module_2543+eed510a0.src
+  - perl-Time-Piece-0:1.31-415.module_2543+eed510a0.aarch64
+  - perl-Time-Piece-0:1.31-415.module_2543+eed510a0.armv7hl
+  - perl-Time-Piece-0:1.31-415.module_2543+eed510a0.ppc64le
+  - perl-Time-Piece-0:1.31-415.module_2543+eed510a0.s390x
+  - perl-Time-Piece-0:1.31-415.module_2543+eed510a0.x86_64
+  - perl-Time-Piece-debuginfo-0:1.31-415.module_2543+eed510a0.aarch64
+  - perl-Time-Piece-debuginfo-0:1.31-415.module_2543+eed510a0.armv7hl
+  - perl-Time-Piece-debuginfo-0:1.31-415.module_2543+eed510a0.ppc64le
+  - perl-Time-Piece-debuginfo-0:1.31-415.module_2543+eed510a0.s390x
+  - perl-Time-Piece-debuginfo-0:1.31-415.module_2543+eed510a0.x86_64
+  - perl-URI-0:1.73-2.module_1681+b405d8e2.noarch
+  - perl-URI-0:1.73-2.module_1681+b405d8e2.src
+  - perl-Unicode-Collate-0:1.25-2.module_1681+b405d8e2.aarch64
+  - perl-Unicode-Collate-0:1.25-2.module_1681+b405d8e2.armv7hl
+  - perl-Unicode-Collate-0:1.25-2.module_1681+b405d8e2.ppc64
+  - perl-Unicode-Collate-0:1.25-2.module_1681+b405d8e2.ppc64le
+  - perl-Unicode-Collate-0:1.25-2.module_1681+b405d8e2.s390x
+  - perl-Unicode-Collate-0:1.25-2.module_1681+b405d8e2.src
+  - perl-Unicode-Collate-0:1.25-2.module_1681+b405d8e2.x86_64
+  - perl-Unicode-Collate-debuginfo-0:1.25-2.module_1681+b405d8e2.aarch64
+  - perl-Unicode-Collate-debuginfo-0:1.25-2.module_1681+b405d8e2.armv7hl
+  - perl-Unicode-Collate-debuginfo-0:1.25-2.module_1681+b405d8e2.ppc64
+  - perl-Unicode-Collate-debuginfo-0:1.25-2.module_1681+b405d8e2.ppc64le
+  - perl-Unicode-Collate-debuginfo-0:1.25-2.module_1681+b405d8e2.s390x
+  - perl-Unicode-Collate-debuginfo-0:1.25-2.module_1681+b405d8e2.x86_64
+  - perl-Unicode-Collate-debugsource-0:1.25-2.module_1681+b405d8e2.aarch64
+  - perl-Unicode-Collate-debugsource-0:1.25-2.module_1681+b405d8e2.armv7hl
+  - perl-Unicode-Collate-debugsource-0:1.25-2.module_1681+b405d8e2.ppc64
+  - perl-Unicode-Collate-debugsource-0:1.25-2.module_1681+b405d8e2.ppc64le
+  - perl-Unicode-Collate-debugsource-0:1.25-2.module_1681+b405d8e2.s390x
+  - perl-Unicode-Collate-debugsource-0:1.25-2.module_1681+b405d8e2.x86_64
+  - perl-Unicode-Normalize-0:1.25-396.module_1681+b405d8e2.aarch64
+  - perl-Unicode-Normalize-0:1.25-396.module_1681+b405d8e2.armv7hl
+  - perl-Unicode-Normalize-0:1.25-396.module_1681+b405d8e2.ppc64
+  - perl-Unicode-Normalize-0:1.25-396.module_1681+b405d8e2.ppc64le
+  - perl-Unicode-Normalize-0:1.25-396.module_1681+b405d8e2.s390x
+  - perl-Unicode-Normalize-0:1.25-396.module_1681+b405d8e2.src
+  - perl-Unicode-Normalize-0:1.25-396.module_1681+b405d8e2.x86_64
+  - perl-Unicode-Normalize-debuginfo-0:1.25-396.module_1681+b405d8e2.aarch64
+  - perl-Unicode-Normalize-debuginfo-0:1.25-396.module_1681+b405d8e2.armv7hl
+  - perl-Unicode-Normalize-debuginfo-0:1.25-396.module_1681+b405d8e2.ppc64
+  - perl-Unicode-Normalize-debuginfo-0:1.25-396.module_1681+b405d8e2.ppc64le
+  - perl-Unicode-Normalize-debuginfo-0:1.25-396.module_1681+b405d8e2.s390x
+  - perl-Unicode-Normalize-debuginfo-0:1.25-396.module_1681+b405d8e2.x86_64
+  - perl-Unicode-Normalize-debugsource-0:1.25-396.module_1681+b405d8e2.aarch64
+  - perl-Unicode-Normalize-debugsource-0:1.25-396.module_1681+b405d8e2.armv7hl
+  - perl-Unicode-Normalize-debugsource-0:1.25-396.module_1681+b405d8e2.ppc64
+  - perl-Unicode-Normalize-debugsource-0:1.25-396.module_1681+b405d8e2.ppc64le
+  - perl-Unicode-Normalize-debugsource-0:1.25-396.module_1681+b405d8e2.s390x
+  - perl-Unicode-Normalize-debugsource-0:1.25-396.module_1681+b405d8e2.x86_64
+  - perl-autodie-0:2.29-396.module_1681+b405d8e2.noarch
+  - perl-autodie-0:2.29-396.module_1681+b405d8e2.src
+  - perl-bignum-0:0.49-2.module_1681+b405d8e2.noarch
+  - perl-bignum-0:0.49-2.module_1681+b405d8e2.src
+  - perl-constant-0:1.33-396.module_1681+b405d8e2.noarch
+  - perl-constant-0:1.33-396.module_1681+b405d8e2.src
+  - perl-debuginfo-4:5.26.3-415.module_2543+eed510a0.aarch64
+  - perl-debuginfo-4:5.26.3-415.module_2543+eed510a0.armv7hl
+  - perl-debuginfo-4:5.26.3-415.module_2543+eed510a0.ppc64le
+  - perl-debuginfo-4:5.26.3-415.module_2543+eed510a0.s390x
+  - perl-debuginfo-4:5.26.3-415.module_2543+eed510a0.x86_64
+  - perl-debugsource-4:5.26.3-415.module_2543+eed510a0.aarch64
+  - perl-debugsource-4:5.26.3-415.module_2543+eed510a0.armv7hl
+  - perl-debugsource-4:5.26.3-415.module_2543+eed510a0.ppc64le
+  - perl-debugsource-4:5.26.3-415.module_2543+eed510a0.s390x
+  - perl-debugsource-4:5.26.3-415.module_2543+eed510a0.x86_64
+  - perl-devel-4:5.26.3-415.module_2543+eed510a0.aarch64
+  - perl-devel-4:5.26.3-415.module_2543+eed510a0.armv7hl
+  - perl-devel-4:5.26.3-415.module_2543+eed510a0.ppc64le
+  - perl-devel-4:5.26.3-415.module_2543+eed510a0.s390x
+  - perl-devel-4:5.26.3-415.module_2543+eed510a0.x86_64
+  - perl-encoding-4:2.22-3.module_1681+b405d8e2.aarch64
+  - perl-encoding-4:2.22-3.module_1681+b405d8e2.armv7hl
+  - perl-encoding-4:2.22-3.module_1681+b405d8e2.ppc64
+  - perl-encoding-4:2.22-3.module_1681+b405d8e2.ppc64le
+  - perl-encoding-4:2.22-3.module_1681+b405d8e2.s390x
+  - perl-encoding-4:2.22-3.module_1681+b405d8e2.x86_64
+  - perl-experimental-0:0.020-1.module_2543+eed510a0.noarch
+  - perl-experimental-0:0.020-1.module_2543+eed510a0.src
+  - perl-generators-0:1.10-7.module_1681+b405d8e2.noarch
+  - perl-generators-0:1.10-7.module_1681+b405d8e2.src
+  - perl-homedir-0:2.000024-2.module_1681+b405d8e2.noarch
+  - perl-inc-latest-2:0.500-9.module_1681+b405d8e2.noarch
+  - perl-inc-latest-2:0.500-9.module_1681+b405d8e2.src
+  - perl-interpreter-4:5.26.3-415.module_2543+eed510a0.aarch64
+  - perl-interpreter-4:5.26.3-415.module_2543+eed510a0.armv7hl
+  - perl-interpreter-4:5.26.3-415.module_2543+eed510a0.ppc64le
+  - perl-interpreter-4:5.26.3-415.module_2543+eed510a0.s390x
+  - perl-interpreter-4:5.26.3-415.module_2543+eed510a0.x86_64
+  - perl-interpreter-debuginfo-4:5.26.3-415.module_2543+eed510a0.aarch64
+  - perl-interpreter-debuginfo-4:5.26.3-415.module_2543+eed510a0.armv7hl
+  - perl-interpreter-debuginfo-4:5.26.3-415.module_2543+eed510a0.ppc64le
+  - perl-interpreter-debuginfo-4:5.26.3-415.module_2543+eed510a0.s390x
+  - perl-interpreter-debuginfo-4:5.26.3-415.module_2543+eed510a0.x86_64
+  - perl-libnet-0:3.11-3.module_1681+b405d8e2.noarch
+  - perl-libnet-0:3.11-3.module_1681+b405d8e2.src
+  - perl-libnetcfg-4:5.26.3-415.module_2543+eed510a0.noarch
+  - perl-libs-4:5.26.3-415.module_2543+eed510a0.aarch64
+  - perl-libs-4:5.26.3-415.module_2543+eed510a0.armv7hl
+  - perl-libs-4:5.26.3-415.module_2543+eed510a0.ppc64le
+  - perl-libs-4:5.26.3-415.module_2543+eed510a0.s390x
+  - perl-libs-4:5.26.3-415.module_2543+eed510a0.x86_64
+  - perl-libs-debuginfo-4:5.26.3-415.module_2543+eed510a0.aarch64
+  - perl-libs-debuginfo-4:5.26.3-415.module_2543+eed510a0.armv7hl
+  - perl-libs-debuginfo-4:5.26.3-415.module_2543+eed510a0.ppc64le
+  - perl-libs-debuginfo-4:5.26.3-415.module_2543+eed510a0.s390x
+  - perl-libs-debuginfo-4:5.26.3-415.module_2543+eed510a0.x86_64
+  - perl-local-lib-0:2.000024-2.module_1681+b405d8e2.noarch
+  - perl-local-lib-0:2.000024-2.module_1681+b405d8e2.src
+  - perl-macros-4:5.26.3-415.module_2543+eed510a0.aarch64
+  - perl-macros-4:5.26.3-415.module_2543+eed510a0.armv7hl
+  - perl-macros-4:5.26.3-415.module_2543+eed510a0.ppc64le
+  - perl-macros-4:5.26.3-415.module_2543+eed510a0.s390x
+  - perl-macros-4:5.26.3-415.module_2543+eed510a0.x86_64
+  - perl-open-0:1.11-415.module_2543+eed510a0.noarch
+  - perl-parent-1:0.236-395.module_1681+b405d8e2.noarch
+  - perl-parent-1:0.236-395.module_1681+b405d8e2.src
+  - perl-perlfaq-0:5.20180915-1.module_2543+eed510a0.noarch
+  - perl-perlfaq-0:5.20180915-1.module_2543+eed510a0.src
+  - perl-podlators-0:4.11-1.module_2543+eed510a0.noarch
+  - perl-podlators-0:4.11-1.module_2543+eed510a0.src
+  - perl-tests-4:5.26.3-415.module_2543+eed510a0.aarch64
+  - perl-tests-4:5.26.3-415.module_2543+eed510a0.armv7hl
+  - perl-tests-4:5.26.3-415.module_2543+eed510a0.ppc64le
+  - perl-tests-4:5.26.3-415.module_2543+eed510a0.s390x
+  - perl-tests-4:5.26.3-415.module_2543+eed510a0.x86_64
+  - perl-threads-1:2.21-2.module_1681+b405d8e2.aarch64
+  - perl-threads-1:2.21-2.module_1681+b405d8e2.armv7hl
+  - perl-threads-1:2.21-2.module_1681+b405d8e2.ppc64
+  - perl-threads-1:2.21-2.module_1681+b405d8e2.ppc64le
+  - perl-threads-1:2.21-2.module_1681+b405d8e2.s390x
+  - perl-threads-1:2.21-2.module_1681+b405d8e2.src
+  - perl-threads-1:2.21-2.module_1681+b405d8e2.x86_64
+  - perl-threads-debuginfo-1:2.21-2.module_1681+b405d8e2.aarch64
+  - perl-threads-debuginfo-1:2.21-2.module_1681+b405d8e2.armv7hl
+  - perl-threads-debuginfo-1:2.21-2.module_1681+b405d8e2.ppc64
+  - perl-threads-debuginfo-1:2.21-2.module_1681+b405d8e2.ppc64le
+  - perl-threads-debuginfo-1:2.21-2.module_1681+b405d8e2.s390x
+  - perl-threads-debuginfo-1:2.21-2.module_1681+b405d8e2.x86_64
+  - perl-threads-debugsource-1:2.21-2.module_1681+b405d8e2.aarch64
+  - perl-threads-debugsource-1:2.21-2.module_1681+b405d8e2.armv7hl
+  - perl-threads-debugsource-1:2.21-2.module_1681+b405d8e2.ppc64
+  - perl-threads-debugsource-1:2.21-2.module_1681+b405d8e2.ppc64le
+  - perl-threads-debugsource-1:2.21-2.module_1681+b405d8e2.s390x
+  - perl-threads-debugsource-1:2.21-2.module_1681+b405d8e2.x86_64
+  - perl-threads-shared-0:1.59-1.module_2543+eed510a0.aarch64
+  - perl-threads-shared-0:1.59-1.module_2543+eed510a0.armv7hl
+  - perl-threads-shared-0:1.59-1.module_2543+eed510a0.ppc64le
+  - perl-threads-shared-0:1.59-1.module_2543+eed510a0.s390x
+  - perl-threads-shared-0:1.59-1.module_2543+eed510a0.src
+  - perl-threads-shared-0:1.59-1.module_2543+eed510a0.x86_64
+  - perl-threads-shared-debuginfo-0:1.59-1.module_2543+eed510a0.aarch64
+  - perl-threads-shared-debuginfo-0:1.59-1.module_2543+eed510a0.armv7hl
+  - perl-threads-shared-debuginfo-0:1.59-1.module_2543+eed510a0.ppc64le
+  - perl-threads-shared-debuginfo-0:1.59-1.module_2543+eed510a0.s390x
+  - perl-threads-shared-debuginfo-0:1.59-1.module_2543+eed510a0.x86_64
+  - perl-threads-shared-debugsource-0:1.59-1.module_2543+eed510a0.aarch64
+  - perl-threads-shared-debugsource-0:1.59-1.module_2543+eed510a0.armv7hl
+  - perl-threads-shared-debugsource-0:1.59-1.module_2543+eed510a0.ppc64le
+  - perl-threads-shared-debugsource-0:1.59-1.module_2543+eed510a0.s390x
+  - perl-threads-shared-debugsource-0:1.59-1.module_2543+eed510a0.x86_64
+  - perl-utils-0:5.26.3-415.module_2543+eed510a0.noarch
+  - perl-version-6:0.99.24-1.module_2543+eed510a0.aarch64
+  - perl-version-6:0.99.24-1.module_2543+eed510a0.armv7hl
+  - perl-version-6:0.99.24-1.module_2543+eed510a0.ppc64le
+  - perl-version-6:0.99.24-1.module_2543+eed510a0.s390x
+  - perl-version-6:0.99.24-1.module_2543+eed510a0.src
+  - perl-version-6:0.99.24-1.module_2543+eed510a0.x86_64
+  - perl-version-debuginfo-6:0.99.24-1.module_2543+eed510a0.aarch64
+  - perl-version-debuginfo-6:0.99.24-1.module_2543+eed510a0.armv7hl
+  - perl-version-debuginfo-6:0.99.24-1.module_2543+eed510a0.ppc64le
+  - perl-version-debuginfo-6:0.99.24-1.module_2543+eed510a0.s390x
+  - perl-version-debuginfo-6:0.99.24-1.module_2543+eed510a0.x86_64
+  - perl-version-debugsource-6:0.99.24-1.module_2543+eed510a0.aarch64
+  - perl-version-debugsource-6:0.99.24-1.module_2543+eed510a0.armv7hl
+  - perl-version-debugsource-6:0.99.24-1.module_2543+eed510a0.ppc64le
+  - perl-version-debugsource-6:0.99.24-1.module_2543+eed510a0.s390x
+  - perl-version-debugsource-6:0.99.24-1.module_2543+eed510a0.x86_64
+  context: b88aa309
+  dependencies: []
+  name: perl
+  profiles:
+    default:
+      description: Interpreter and all Perl modules bundled within upstream Perl.
+      rpms:
+      - perl
+    minimal:
+      description: Only the interpreter as a standalone executable.
+      rpms:
+      - perl-interpreter
+  repository_memberships:
+  - dest1
+  stream: '5.26'
+  unit_id: (hidden)
+  version: 20181205105946
+- _class: ModulemdUnit
+  arch: x86_64
+  artifacts:
+  - perl-4:5.28.2-439.module_f29+6053+0d44d598.src
+  - perl-4:5.28.2-439.module_f29+6053+0d44d598.x86_64
+  - perl-Algorithm-Diff-0:1.1903-12.module_f29+6053+0d44d598.noarch
+  - perl-Algorithm-Diff-0:1.1903-12.module_f29+6053+0d44d598.src
+  - perl-Archive-Tar-0:2.32-2.module_f29+6053+0d44d598.noarch
+  - perl-Archive-Tar-0:2.32-2.module_f29+6053+0d44d598.src
+  - perl-Archive-Zip-0:1.64-2.module_f29+6053+0d44d598.noarch
+  - perl-Archive-Zip-0:1.64-2.module_f29+6053+0d44d598.src
+  - perl-Attribute-Handlers-0:1.01-439.module_f29+6053+0d44d598.noarch
+  - perl-B-Debug-0:1.26-419.module_f29+6053+0d44d598.noarch
+  - perl-B-Debug-0:1.26-419.module_f29+6053+0d44d598.src
+  - perl-CPAN-0:2.26-1.module_f29+6053+0d44d598.noarch
+  - perl-CPAN-0:2.26-1.module_f29+6053+0d44d598.src
+  - perl-CPAN-Meta-0:2.150010-418.module_f29+6053+0d44d598.noarch
+  - perl-CPAN-Meta-0:2.150010-418.module_f29+6053+0d44d598.src
+  - perl-CPAN-Meta-Requirements-0:2.140-419.module_f29+6053+0d44d598.noarch
+  - perl-CPAN-Meta-Requirements-0:2.140-419.module_f29+6053+0d44d598.src
+  - perl-CPAN-Meta-YAML-0:0.018-419.module_f29+6053+0d44d598.noarch
+  - perl-CPAN-Meta-YAML-0:0.018-419.module_f29+6053+0d44d598.src
+  - perl-Carp-0:1.50-418.module_f29+6053+0d44d598.noarch
+  - perl-Carp-0:1.50-418.module_f29+6053+0d44d598.src
+  - perl-Compress-Bzip2-0:2.26-10.module_f29+6053+0d44d598.src
+  - perl-Compress-Bzip2-0:2.26-10.module_f29+6053+0d44d598.x86_64
+  - perl-Compress-Bzip2-debuginfo-0:2.26-10.module_f29+6053+0d44d598.x86_64
+  - perl-Compress-Bzip2-debugsource-0:2.26-10.module_f29+6053+0d44d598.x86_64
+  - perl-Compress-Raw-Bzip2-0:2.084-2.module_f29+6053+0d44d598.src
+  - perl-Compress-Raw-Bzip2-0:2.084-2.module_f29+6053+0d44d598.x86_64
+  - perl-Compress-Raw-Bzip2-debuginfo-0:2.084-2.module_f29+6053+0d44d598.x86_64
+  - perl-Compress-Raw-Bzip2-debugsource-0:2.084-2.module_f29+6053+0d44d598.x86_64
+  - perl-Compress-Raw-Zlib-0:2.084-2.module_f29+6053+0d44d598.src
+  - perl-Compress-Raw-Zlib-0:2.084-2.module_f29+6053+0d44d598.x86_64
+  - perl-Compress-Raw-Zlib-debuginfo-0:2.084-2.module_f29+6053+0d44d598.x86_64
+  - perl-Compress-Raw-Zlib-debugsource-0:2.084-2.module_f29+6053+0d44d598.x86_64
+  - perl-Config-Perl-V-0:0.31-2.module_f29+6053+0d44d598.noarch
+  - perl-Config-Perl-V-0:0.31-2.module_f29+6053+0d44d598.src
+  - perl-DB_File-0:1.852-1.module_f29+6053+0d44d598.src
+  - perl-DB_File-0:1.852-1.module_f29+6053+0d44d598.x86_64
+  - perl-DB_File-debuginfo-0:1.852-1.module_f29+6053+0d44d598.x86_64
+  - perl-DB_File-debugsource-0:1.852-1.module_f29+6053+0d44d598.x86_64
+  - perl-Data-Dumper-0:2.173-3.module_f29+6053+0d44d598.src
+  - perl-Data-Dumper-0:2.173-3.module_f29+6053+0d44d598.x86_64
+  - perl-Data-Dumper-debuginfo-0:2.173-3.module_f29+6053+0d44d598.x86_64
+  - perl-Data-Dumper-debugsource-0:2.173-3.module_f29+6053+0d44d598.x86_64
+  - perl-Data-OptList-0:0.110-9.module_f29+6053+0d44d598.noarch
+  - perl-Data-OptList-0:0.110-9.module_f29+6053+0d44d598.src
+  - perl-Data-Section-0:0.200007-6.module_f29+6053+0d44d598.noarch
+  - perl-Data-Section-0:0.200007-6.module_f29+6053+0d44d598.src
+  - perl-Devel-PPPort-0:3.51-1.module_f29+6053+0d44d598.src
+  - perl-Devel-PPPort-0:3.51-1.module_f29+6053+0d44d598.x86_64
+  - perl-Devel-PPPort-debuginfo-0:3.51-1.module_f29+6053+0d44d598.x86_64
+  - perl-Devel-PPPort-debugsource-0:3.51-1.module_f29+6053+0d44d598.x86_64
+  - perl-Devel-Peek-0:1.27-439.module_f29+6053+0d44d598.x86_64
+  - perl-Devel-Peek-debuginfo-0:1.27-439.module_f29+6053+0d44d598.x86_64
+  - perl-Devel-SelfStubber-0:1.06-439.module_f29+6053+0d44d598.noarch
+  - perl-Devel-Size-0:0.82-4.module_f29+6053+0d44d598.src
+  - perl-Devel-Size-0:0.82-4.module_f29+6053+0d44d598.x86_64
+  - perl-Devel-Size-debuginfo-0:0.82-4.module_f29+6053+0d44d598.x86_64
+  - perl-Devel-Size-debugsource-0:0.82-4.module_f29+6053+0d44d598.x86_64
+  - perl-Digest-0:1.17-418.module_f29+6053+0d44d598.noarch
+  - perl-Digest-0:1.17-418.module_f29+6053+0d44d598.src
+  - perl-Digest-MD5-0:2.55-418.module_f29+6053+0d44d598.src
+  - perl-Digest-MD5-0:2.55-418.module_f29+6053+0d44d598.x86_64
+  - perl-Digest-MD5-debuginfo-0:2.55-418.module_f29+6053+0d44d598.x86_64
+  - perl-Digest-MD5-debugsource-0:2.55-418.module_f29+6053+0d44d598.x86_64
+  - perl-Digest-SHA-1:6.02-5.module_f29+6053+0d44d598.src
+  - perl-Digest-SHA-1:6.02-5.module_f29+6053+0d44d598.x86_64
+  - perl-Digest-SHA-debuginfo-1:6.02-5.module_f29+6053+0d44d598.x86_64
+  - perl-Digest-SHA-debugsource-1:6.02-5.module_f29+6053+0d44d598.x86_64
+  - perl-Encode-4:3.01-10.module_f29+6053+0d44d598.src
+  - perl-Encode-4:3.01-10.module_f29+6053+0d44d598.x86_64
+  - perl-Encode-debuginfo-4:3.01-10.module_f29+6053+0d44d598.x86_64
+  - perl-Encode-debugsource-4:3.01-10.module_f29+6053+0d44d598.x86_64
+  - perl-Encode-devel-4:3.01-10.module_f29+6053+0d44d598.x86_64
+  - perl-Env-0:1.04-418.module_f29+6053+0d44d598.noarch
+  - perl-Env-0:1.04-418.module_f29+6053+0d44d598.src
+  - perl-Errno-0:1.29-439.module_f29+6053+0d44d598.x86_64
+  - perl-Exporter-0:5.73-419.module_f29+6053+0d44d598.noarch
+  - perl-Exporter-0:5.73-419.module_f29+6053+0d44d598.src
+  - perl-ExtUtils-CBuilder-1:0.280231-1.module_f29+6053+0d44d598.noarch
+  - perl-ExtUtils-CBuilder-1:0.280231-1.module_f29+6053+0d44d598.src
+  - perl-ExtUtils-Command-1:7.34-419.module_f29+6053+0d44d598.noarch
+  - perl-ExtUtils-Embed-0:1.35-439.module_f29+6053+0d44d598.noarch
+  - perl-ExtUtils-Install-0:2.14-419.module_f29+6053+0d44d598.noarch
+  - perl-ExtUtils-Install-0:2.14-419.module_f29+6053+0d44d598.src
+  - perl-ExtUtils-MM-Utils-1:7.34-419.module_f29+6053+0d44d598.noarch
+  - perl-ExtUtils-MakeMaker-1:7.34-419.module_f29+6053+0d44d598.noarch
+  - perl-ExtUtils-MakeMaker-1:7.34-419.module_f29+6053+0d44d598.src
+  - perl-ExtUtils-Manifest-1:1.72-1.module_f29+6053+0d44d598.noarch
+  - perl-ExtUtils-Manifest-1:1.72-1.module_f29+6053+0d44d598.src
+  - perl-ExtUtils-Miniperl-0:1.08-439.module_f29+6053+0d44d598.noarch
+  - perl-ExtUtils-ParseXS-1:3.39-419.module_f29+6053+0d44d598.noarch
+  - perl-ExtUtils-ParseXS-1:3.39-419.module_f29+6053+0d44d598.src
+  - perl-Fedora-VSP-0:0.001-13.module_f29+6053+0d44d598.noarch
+  - perl-Fedora-VSP-0:0.001-13.module_f29+6053+0d44d598.src
+  - perl-File-Fetch-0:0.56-418.module_f29+6053+0d44d598.noarch
+  - perl-File-Fetch-0:0.56-418.module_f29+6053+0d44d598.src
+  - perl-File-HomeDir-0:1.004-4.module_f29+6053+0d44d598.noarch
+  - perl-File-HomeDir-0:1.004-4.module_f29+6053+0d44d598.src
+  - perl-File-Path-0:2.16-2.module_f29+6053+0d44d598.noarch
+  - perl-File-Path-0:2.16-2.module_f29+6053+0d44d598.src
+  - perl-File-Temp-1:0.230.900-2.module_f29+6053+0d44d598.noarch
+  - perl-File-Temp-1:0.230.900-2.module_f29+6053+0d44d598.src
+  - perl-File-Which-0:1.23-2.module_f29+6053+0d44d598.noarch
+  - perl-File-Which-0:1.23-2.module_f29+6053+0d44d598.src
+  - perl-Filter-2:1.59-2.module_f29+6053+0d44d598.src
+  - perl-Filter-2:1.59-2.module_f29+6053+0d44d598.x86_64
+  - perl-Filter-Simple-0:0.95-418.module_f29+6053+0d44d598.noarch
+  - perl-Filter-Simple-0:0.95-418.module_f29+6053+0d44d598.src
+  - perl-Filter-debuginfo-2:1.59-2.module_f29+6053+0d44d598.x86_64
+  - perl-Filter-debugsource-2:1.59-2.module_f29+6053+0d44d598.x86_64
+  - perl-Getopt-Long-1:2.51-1.module_f29+6053+0d44d598.noarch
+  - perl-Getopt-Long-1:2.51-1.module_f29+6053+0d44d598.src
+  - perl-HTTP-Tiny-0:0.076-2.module_f29+6053+0d44d598.noarch
+  - perl-HTTP-Tiny-0:0.076-2.module_f29+6053+0d44d598.src
+  - perl-IO-0:1.39-439.module_f29+6053+0d44d598.x86_64
+  - perl-IO-Compress-0:2.084-2.module_f29+6053+0d44d598.noarch
+  - perl-IO-Compress-0:2.084-2.module_f29+6053+0d44d598.src
+  - perl-IO-Socket-IP-0:0.39-419.module_f29+6053+0d44d598.noarch
+  - perl-IO-Socket-IP-0:0.39-419.module_f29+6053+0d44d598.src
+  - perl-IO-Zlib-1:1.10-439.module_f29+6053+0d44d598.noarch
+  - perl-IO-debuginfo-0:1.39-439.module_f29+6053+0d44d598.x86_64
+  - perl-IPC-Cmd-2:1.04-1.module_f29+6053+0d44d598.noarch
+  - perl-IPC-Cmd-2:1.04-1.module_f29+6053+0d44d598.src
+  - perl-IPC-SysV-0:2.07-419.module_f29+6053+0d44d598.src
+  - perl-IPC-SysV-0:2.07-419.module_f29+6053+0d44d598.x86_64
+  - perl-IPC-SysV-debuginfo-0:2.07-419.module_f29+6053+0d44d598.x86_64
+  - perl-IPC-SysV-debugsource-0:2.07-419.module_f29+6053+0d44d598.x86_64
+  - perl-IPC-System-Simple-0:1.25-21.module_f29+6053+0d44d598.noarch
+  - perl-IPC-System-Simple-0:1.25-21.module_f29+6053+0d44d598.src
+  - perl-Importer-0:0.025-4.module_f29+6053+0d44d598.noarch
+  - perl-Importer-0:0.025-4.module_f29+6053+0d44d598.src
+  - perl-JSON-PP-1:4.02-1.module_f29+6053+0d44d598.noarch
+  - perl-JSON-PP-1:4.02-1.module_f29+6053+0d44d598.src
+  - perl-Locale-Codes-0:3.61-1.module_f29+6053+0d44d598.noarch
+  - perl-Locale-Codes-0:3.61-1.module_f29+6053+0d44d598.src
+  - perl-Locale-Maketext-0:1.29-419.module_f29+6053+0d44d598.noarch
+  - perl-Locale-Maketext-0:1.29-419.module_f29+6053+0d44d598.src
+  - perl-Locale-Maketext-Simple-1:0.21-439.module_f29+6053+0d44d598.noarch
+  - perl-MIME-Base64-0:3.15-418.module_f29+6053+0d44d598.src
+  - perl-MIME-Base64-0:3.15-418.module_f29+6053+0d44d598.x86_64
+  - perl-MIME-Base64-debuginfo-0:3.15-418.module_f29+6053+0d44d598.x86_64
+  - perl-MIME-Base64-debugsource-0:3.15-418.module_f29+6053+0d44d598.x86_64
+  - perl-MRO-Compat-0:0.13-7.module_f29+6053+0d44d598.noarch
+  - perl-MRO-Compat-0:0.13-7.module_f29+6053+0d44d598.src
+  - perl-Math-BigInt-1:1.9998.16-2.module_f29+6053+0d44d598.noarch
+  - perl-Math-BigInt-1:1.9998.16-2.module_f29+6053+0d44d598.src
+  - perl-Math-BigInt-FastCalc-0:0.500.800-2.module_f29+6053+0d44d598.src
+  - perl-Math-BigInt-FastCalc-0:0.500.800-2.module_f29+6053+0d44d598.x86_64
+  - perl-Math-BigInt-FastCalc-debuginfo-0:0.500.800-2.module_f29+6053+0d44d598.x86_64
+  - perl-Math-BigInt-FastCalc-debugsource-0:0.500.800-2.module_f29+6053+0d44d598.x86_64
+  - perl-Math-BigRat-0:0.2614-4.module_f29+6053+0d44d598.noarch
+  - perl-Math-BigRat-0:0.2614-4.module_f29+6053+0d44d598.src
+  - perl-Math-Complex-0:1.59-439.module_f29+6053+0d44d598.noarch
+  - perl-Memoize-0:1.03-439.module_f29+6053+0d44d598.noarch
+  - perl-Module-Build-2:0.42.24-11.module_f29+6053+0d44d598.noarch
+  - perl-Module-Build-2:0.42.24-11.module_f29+6053+0d44d598.src
+  - perl-Module-CoreList-1:5.20190820-1.module_f29+6053+0d44d598.noarch
+  - perl-Module-CoreList-1:5.20190820-1.module_f29+6053+0d44d598.src
+  - perl-Module-CoreList-tools-1:5.20190820-1.module_f29+6053+0d44d598.noarch
+  - perl-Module-Load-1:0.34-1.module_f29+6053+0d44d598.noarch
+  - perl-Module-Load-1:0.34-1.module_f29+6053+0d44d598.src
+  - perl-Module-Load-Conditional-0:0.68-418.module_f29+6053+0d44d598.noarch
+  - perl-Module-Load-Conditional-0:0.68-418.module_f29+6053+0d44d598.src
+  - perl-Module-Loaded-1:0.08-439.module_f29+6053+0d44d598.noarch
+  - perl-Module-Metadata-0:1.000036-1.module_f29+6053+0d44d598.noarch
+  - perl-Module-Metadata-0:1.000036-1.module_f29+6053+0d44d598.src
+  - perl-Net-Ping-0:2.62-439.module_f29+6053+0d44d598.noarch
+  - perl-Package-Generator-0:1.106-14.module_f29+6053+0d44d598.noarch
+  - perl-Package-Generator-0:1.106-14.module_f29+6053+0d44d598.src
+  - perl-Params-Check-1:0.38-418.module_f29+6053+0d44d598.noarch
+  - perl-Params-Check-1:0.38-418.module_f29+6053+0d44d598.src
+  - perl-Params-Util-0:1.07-26.module_f29+6053+0d44d598.src
+  - perl-Params-Util-0:1.07-26.module_f29+6053+0d44d598.x86_64
+  - perl-Params-Util-debuginfo-0:1.07-26.module_f29+6053+0d44d598.x86_64
+  - perl-Params-Util-debugsource-0:1.07-26.module_f29+6053+0d44d598.x86_64
+  - perl-PathTools-0:3.75-2.module_f29+6053+0d44d598.src
+  - perl-PathTools-0:3.75-2.module_f29+6053+0d44d598.x86_64
+  - perl-PathTools-debuginfo-0:3.75-2.module_f29+6053+0d44d598.x86_64
+  - perl-PathTools-debugsource-0:3.75-2.module_f29+6053+0d44d598.x86_64
+  - perl-Perl-OSType-0:1.010-420.module_f29+6053+0d44d598.noarch
+  - perl-Perl-OSType-0:1.010-420.module_f29+6053+0d44d598.src
+  - perl-PerlIO-via-QuotedPrint-0:0.08-418.module_f29+6053+0d44d598.noarch
+  - perl-PerlIO-via-QuotedPrint-0:0.08-418.module_f29+6053+0d44d598.src
+  - perl-Pod-Checker-4:1.73-418.module_f29+6053+0d44d598.noarch
+  - perl-Pod-Checker-4:1.73-418.module_f29+6053+0d44d598.src
+  - perl-Pod-Escapes-1:1.07-418.module_f29+6053+0d44d598.noarch
+  - perl-Pod-Escapes-1:1.07-418.module_f29+6053+0d44d598.src
+  - perl-Pod-Html-0:1.24-439.module_f29+6053+0d44d598.noarch
+  - perl-Pod-Parser-0:1.63-419.module_f29+6053+0d44d598.noarch
+  - perl-Pod-Parser-0:1.63-419.module_f29+6053+0d44d598.src
+  - perl-Pod-Perldoc-0:3.28.01-420.module_f29+6053+0d44d598.noarch
+  - perl-Pod-Perldoc-0:3.28.01-420.module_f29+6053+0d44d598.src
+  - perl-Pod-Simple-1:3.35-418.module_f29+6053+0d44d598.noarch
+  - perl-Pod-Simple-1:3.35-418.module_f29+6053+0d44d598.src
+  - perl-Pod-Usage-4:1.69-418.module_f29+6053+0d44d598.noarch
+  - perl-Pod-Usage-4:1.69-418.module_f29+6053+0d44d598.src
+  - perl-Scalar-List-Utils-3:1.50-418.module_f29+6053+0d44d598.src
+  - perl-Scalar-List-Utils-3:1.50-418.module_f29+6053+0d44d598.x86_64
+  - perl-Scalar-List-Utils-debuginfo-3:1.50-418.module_f29+6053+0d44d598.x86_64
+  - perl-Scalar-List-Utils-debugsource-3:1.50-418.module_f29+6053+0d44d598.x86_64
+  - perl-SelfLoader-0:1.25-439.module_f29+6053+0d44d598.noarch
+  - perl-Socket-4:2.029-1.module_f29+6053+0d44d598.src
+  - perl-Socket-4:2.029-1.module_f29+6053+0d44d598.x86_64
+  - perl-Socket-debuginfo-4:2.029-1.module_f29+6053+0d44d598.x86_64
+  - perl-Socket-debugsource-4:2.029-1.module_f29+6053+0d44d598.x86_64
+  - perl-Software-License-0:0.103014-2.module_f29+6053+0d44d598.noarch
+  - perl-Software-License-0:0.103014-2.module_f29+6053+0d44d598.src
+  - perl-Storable-1:3.15-3.module_f29+6053+0d44d598.src
+  - perl-Storable-1:3.15-3.module_f29+6053+0d44d598.x86_64
+  - perl-Storable-debuginfo-1:3.15-3.module_f29+6053+0d44d598.x86_64
+  - perl-Storable-debugsource-1:3.15-3.module_f29+6053+0d44d598.x86_64
+  - perl-Sub-Exporter-0:0.987-18.module_f29+6053+0d44d598.noarch
+  - perl-Sub-Exporter-0:0.987-18.module_f29+6053+0d44d598.src
+  - perl-Sub-Install-0:0.928-18.module_f29+6053+0d44d598.noarch
+  - perl-Sub-Install-0:0.928-18.module_f29+6053+0d44d598.src
+  - perl-Sys-Syslog-0:0.35-419.module_f29+6053+0d44d598.src
+  - perl-Sys-Syslog-0:0.35-419.module_f29+6053+0d44d598.x86_64
+  - perl-Sys-Syslog-debuginfo-0:0.35-419.module_f29+6053+0d44d598.x86_64
+  - perl-Sys-Syslog-debugsource-0:0.35-419.module_f29+6053+0d44d598.x86_64
+  - perl-Term-ANSIColor-0:4.06-419.module_f29+6053+0d44d598.noarch
+  - perl-Term-ANSIColor-0:4.06-419.module_f29+6053+0d44d598.src
+  - perl-Term-Cap-0:1.17-418.module_f29+6053+0d44d598.noarch
+  - perl-Term-Cap-0:1.17-418.module_f29+6053+0d44d598.src
+  - perl-Term-Table-0:0.013-2.module_f29+6053+0d44d598.noarch
+  - perl-Term-Table-0:0.013-2.module_f29+6053+0d44d598.src
+  - perl-Test-0:1.31-439.module_f29+6053+0d44d598.noarch
+  - perl-Test-Harness-1:3.42-419.module_f29+6053+0d44d598.noarch
+  - perl-Test-Harness-1:3.42-419.module_f29+6053+0d44d598.src
+  - perl-Test-Simple-2:1.302162-1.module_f29+6053+0d44d598.noarch
+  - perl-Test-Simple-2:1.302162-1.module_f29+6053+0d44d598.src
+  - perl-Text-Balanced-0:2.03-418.module_f29+6053+0d44d598.noarch
+  - perl-Text-Balanced-0:2.03-418.module_f29+6053+0d44d598.src
+  - perl-Text-Diff-0:1.45-5.module_f29+6053+0d44d598.noarch
+  - perl-Text-Diff-0:1.45-5.module_f29+6053+0d44d598.src
+  - perl-Text-Glob-0:0.11-7.module_f29+6053+0d44d598.noarch
+  - perl-Text-Glob-0:0.11-7.module_f29+6053+0d44d598.src
+  - perl-Text-ParseWords-0:3.30-418.module_f29+6053+0d44d598.noarch
+  - perl-Text-ParseWords-0:3.30-418.module_f29+6053+0d44d598.src
+  - perl-Text-Tabs+Wrap-0:2013.0523-418.module_f29+6053+0d44d598.noarch
+  - perl-Text-Tabs+Wrap-0:2013.0523-418.module_f29+6053+0d44d598.src
+  - perl-Text-Template-0:1.55-2.module_f29+6053+0d44d598.noarch
+  - perl-Text-Template-0:1.55-2.module_f29+6053+0d44d598.src
+  - perl-Thread-Queue-0:3.13-2.module_f29+6053+0d44d598.noarch
+  - perl-Thread-Queue-0:3.13-2.module_f29+6053+0d44d598.src
+  - perl-Time-HiRes-0:1.9760-1.module_f29+6053+0d44d598.src
+  - perl-Time-HiRes-0:1.9760-1.module_f29+6053+0d44d598.x86_64
+  - perl-Time-HiRes-debuginfo-0:1.9760-1.module_f29+6053+0d44d598.x86_64
+  - perl-Time-HiRes-debugsource-0:1.9760-1.module_f29+6053+0d44d598.x86_64
+  - perl-Time-Local-2:1.280-4.module_f29+6053+0d44d598.noarch
+  - perl-Time-Local-2:1.280-4.module_f29+6053+0d44d598.src
+  - perl-Time-Piece-0:1.33-439.module_f29+6053+0d44d598.x86_64
+  - perl-Time-Piece-debuginfo-0:1.33-439.module_f29+6053+0d44d598.x86_64
+  - perl-URI-0:1.76-2.module_f29+6053+0d44d598.noarch
+  - perl-URI-0:1.76-2.module_f29+6053+0d44d598.src
+  - perl-Unicode-Collate-0:1.27-2.module_f29+6053+0d44d598.src
+  - perl-Unicode-Collate-0:1.27-2.module_f29+6053+0d44d598.x86_64
+  - perl-Unicode-Collate-debuginfo-0:1.27-2.module_f29+6053+0d44d598.x86_64
+  - perl-Unicode-Collate-debugsource-0:1.27-2.module_f29+6053+0d44d598.x86_64
+  - perl-Unicode-Normalize-0:1.26-418.module_f29+6053+0d44d598.src
+  - perl-Unicode-Normalize-0:1.26-418.module_f29+6053+0d44d598.x86_64
+  - perl-Unicode-Normalize-debuginfo-0:1.26-418.module_f29+6053+0d44d598.x86_64
+  - perl-Unicode-Normalize-debugsource-0:1.26-418.module_f29+6053+0d44d598.x86_64
+  - perl-autodie-0:2.29-419.module_f29+6053+0d44d598.noarch
+  - perl-autodie-0:2.29-419.module_f29+6053+0d44d598.src
+  - perl-bignum-0:0.51-2.module_f29+6053+0d44d598.noarch
+  - perl-bignum-0:0.51-2.module_f29+6053+0d44d598.src
+  - perl-constant-0:1.33-419.module_f29+6053+0d44d598.noarch
+  - perl-constant-0:1.33-419.module_f29+6053+0d44d598.src
+  - perl-debuginfo-4:5.28.2-439.module_f29+6053+0d44d598.x86_64
+  - perl-debugsource-4:5.28.2-439.module_f29+6053+0d44d598.x86_64
+  - perl-devel-4:5.28.2-439.module_f29+6053+0d44d598.x86_64
+  - perl-encoding-4:2.22-10.module_f29+6053+0d44d598.x86_64
+  - perl-experimental-0:0.020-4.module_f29+6053+0d44d598.noarch
+  - perl-experimental-0:0.020-4.module_f29+6053+0d44d598.src
+  - perl-generators-0:1.10-11.module_f29+6053+0d44d598.noarch
+  - perl-generators-0:1.10-11.module_f29+6053+0d44d598.src
+  - perl-homedir-0:2.000024-5.module_f29+6053+0d44d598.noarch
+  - perl-inc-latest-2:0.500-12.module_f29+6053+0d44d598.noarch
+  - perl-inc-latest-2:0.500-12.module_f29+6053+0d44d598.src
+  - perl-interpreter-4:5.28.2-439.module_f29+6053+0d44d598.x86_64
+  - perl-interpreter-debuginfo-4:5.28.2-439.module_f29+6053+0d44d598.x86_64
+  - perl-libnet-0:3.11-419.module_f29+6053+0d44d598.noarch
+  - perl-libnet-0:3.11-419.module_f29+6053+0d44d598.src
+  - perl-libnetcfg-4:5.28.2-439.module_f29+6053+0d44d598.noarch
+  - perl-libs-4:5.28.2-439.module_f29+6053+0d44d598.x86_64
+  - perl-libs-debuginfo-4:5.28.2-439.module_f29+6053+0d44d598.x86_64
+  - perl-local-lib-0:2.000024-5.module_f29+6053+0d44d598.noarch
+  - perl-local-lib-0:2.000024-5.module_f29+6053+0d44d598.src
+  - perl-macros-4:5.28.2-439.module_f29+6053+0d44d598.x86_64
+  - perl-open-0:1.11-439.module_f29+6053+0d44d598.noarch
+  - perl-parent-1:0.237-3.module_f29+6053+0d44d598.noarch
+  - perl-parent-1:0.237-3.module_f29+6053+0d44d598.src
+  - perl-perlfaq-0:5.20190126-2.module_f29+6053+0d44d598.noarch
+  - perl-perlfaq-0:5.20190126-2.module_f29+6053+0d44d598.src
+  - perl-podlators-1:4.12-1.module_f29+6053+0d44d598.noarch
+  - perl-podlators-1:4.12-1.module_f29+6053+0d44d598.src
+  - perl-tests-4:5.28.2-439.module_f29+6053+0d44d598.x86_64
+  - perl-threads-1:2.22-418.module_f29+6053+0d44d598.src
+  - perl-threads-1:2.22-418.module_f29+6053+0d44d598.x86_64
+  - perl-threads-debuginfo-1:2.22-418.module_f29+6053+0d44d598.x86_64
+  - perl-threads-debugsource-1:2.22-418.module_f29+6053+0d44d598.x86_64
+  - perl-threads-shared-0:1.59-3.module_f29+6053+0d44d598.src
+  - perl-threads-shared-0:1.59-3.module_f29+6053+0d44d598.x86_64
+  - perl-threads-shared-debuginfo-0:1.59-3.module_f29+6053+0d44d598.x86_64
+  - perl-threads-shared-debugsource-0:1.59-3.module_f29+6053+0d44d598.x86_64
+  - perl-utils-0:5.28.2-439.module_f29+6053+0d44d598.noarch
+  - perl-version-7:0.99.24-6.module_f29+6053+0d44d598.src
+  - perl-version-7:0.99.24-6.module_f29+6053+0d44d598.x86_64
+  - perl-version-debuginfo-7:0.99.24-6.module_f29+6053+0d44d598.x86_64
+  - perl-version-debugsource-7:0.99.24-6.module_f29+6053+0d44d598.x86_64
+  context: c8f01160
+  dependencies: []
+  name: perl
+  profiles:
+    default:
+      description: Interpreter and all Perl modules bundled within upstream Perl.
+      rpms:
+      - perl
+    minimal:
+      description: Only the interpreter as a standalone executable.
+      rpms:
+      - perl-interpreter
+  repository_memberships:
+  - dest1
+  stream: '5.28'
+  unit_id: (hidden)
+  version: 2920190826113129
+- _class: ModulemdUnit
+  arch: x86_64
+  artifacts:
+  - perl-4:5.30.0-445.module_f29+6166+8b5ad319.src
+  - perl-4:5.30.0-445.module_f29+6166+8b5ad319.x86_64
+  - perl-Algorithm-Diff-0:1.1903-14.module_f29+5301+06000d52.noarch
+  - perl-Algorithm-Diff-0:1.1903-14.module_f29+5301+06000d52.src
+  - perl-Archive-Tar-0:2.32-440.module_f29+5301+06000d52.noarch
+  - perl-Archive-Tar-0:2.32-440.module_f29+5301+06000d52.src
+  - perl-Archive-Zip-0:1.64-4.module_f29+5301+06000d52.noarch
+  - perl-Archive-Zip-0:1.64-4.module_f29+5301+06000d52.src
+  - perl-Attribute-Handlers-0:1.01-445.module_f29+6166+8b5ad319.noarch
+  - perl-CPAN-0:2.27-2.module_f29+5301+06000d52.noarch
+  - perl-CPAN-0:2.27-2.module_f29+5301+06000d52.src
+  - perl-CPAN-DistnameInfo-0:0.12-17.module_f29+5301+06000d52.noarch
+  - perl-CPAN-DistnameInfo-0:0.12-17.module_f29+5301+06000d52.src
+  - perl-CPAN-Meta-0:2.150010-439.module_f29+5301+06000d52.noarch
+  - perl-CPAN-Meta-0:2.150010-439.module_f29+5301+06000d52.src
+  - perl-CPAN-Meta-Requirements-0:2.140-440.module_f29+5301+06000d52.noarch
+  - perl-CPAN-Meta-Requirements-0:2.140-440.module_f29+5301+06000d52.src
+  - perl-CPAN-Meta-YAML-0:0.018-440.module_f29+5301+06000d52.noarch
+  - perl-CPAN-Meta-YAML-0:0.018-440.module_f29+5301+06000d52.src
+  - perl-Carp-0:1.50-439.module_f29+5301+06000d52.noarch
+  - perl-Carp-0:1.50-439.module_f29+5301+06000d52.src
+  - perl-Compress-Bzip2-0:2.26-13.module_f29+5301+06000d52.src
+  - perl-Compress-Bzip2-0:2.26-13.module_f29+5301+06000d52.x86_64
+  - perl-Compress-Bzip2-debuginfo-0:2.26-13.module_f29+5301+06000d52.x86_64
+  - perl-Compress-Bzip2-debugsource-0:2.26-13.module_f29+5301+06000d52.x86_64
+  - perl-Compress-Raw-Bzip2-0:2.087-1.module_f29+5987+0ffb0315.src
+  - perl-Compress-Raw-Bzip2-0:2.087-1.module_f29+5987+0ffb0315.x86_64
+  - perl-Compress-Raw-Bzip2-debuginfo-0:2.087-1.module_f29+5987+0ffb0315.x86_64
+  - perl-Compress-Raw-Bzip2-debugsource-0:2.087-1.module_f29+5987+0ffb0315.x86_64
+  - perl-Compress-Raw-Zlib-0:2.087-1.module_f29+5987+0ffb0315.src
+  - perl-Compress-Raw-Zlib-0:2.087-1.module_f29+5987+0ffb0315.x86_64
+  - perl-Compress-Raw-Zlib-debuginfo-0:2.087-1.module_f29+5987+0ffb0315.x86_64
+  - perl-Compress-Raw-Zlib-debugsource-0:2.087-1.module_f29+5987+0ffb0315.x86_64
+  - perl-Config-Perl-V-0:0.32-440.module_f29+5301+06000d52.noarch
+  - perl-Config-Perl-V-0:0.32-440.module_f29+5301+06000d52.src
+  - perl-DB_File-0:1.852-4.module_f29+5301+06000d52.src
+  - perl-DB_File-0:1.852-4.module_f29+5301+06000d52.x86_64
+  - perl-DB_File-debuginfo-0:1.852-4.module_f29+5301+06000d52.x86_64
+  - perl-DB_File-debugsource-0:1.852-4.module_f29+5301+06000d52.x86_64
+  - perl-Data-Dumper-0:2.174-440.module_f29+5301+06000d52.src
+  - perl-Data-Dumper-0:2.174-440.module_f29+5301+06000d52.x86_64
+  - perl-Data-Dumper-debuginfo-0:2.174-440.module_f29+5301+06000d52.x86_64
+  - perl-Data-Dumper-debugsource-0:2.174-440.module_f29+5301+06000d52.x86_64
+  - perl-Data-OptList-0:0.110-11.module_f29+5301+06000d52.noarch
+  - perl-Data-OptList-0:0.110-11.module_f29+5301+06000d52.src
+  - perl-Data-Section-0:0.200007-8.module_f29+5301+06000d52.noarch
+  - perl-Data-Section-0:0.200007-8.module_f29+5301+06000d52.src
+  - perl-Devel-PPPort-0:3.52-440.module_f29+5301+06000d52.src
+  - perl-Devel-PPPort-0:3.52-440.module_f29+5301+06000d52.x86_64
+  - perl-Devel-PPPort-debuginfo-0:3.52-440.module_f29+5301+06000d52.x86_64
+  - perl-Devel-PPPort-debugsource-0:3.52-440.module_f29+5301+06000d52.x86_64
+  - perl-Devel-Peek-0:1.28-445.module_f29+6166+8b5ad319.x86_64
+  - perl-Devel-Peek-debuginfo-0:1.28-445.module_f29+6166+8b5ad319.x86_64
+  - perl-Devel-SelfStubber-0:1.06-445.module_f29+6166+8b5ad319.noarch
+  - perl-Devel-Size-0:0.83-3.module_f29+5301+06000d52.src
+  - perl-Devel-Size-0:0.83-3.module_f29+5301+06000d52.x86_64
+  - perl-Devel-Size-debuginfo-0:0.83-3.module_f29+5301+06000d52.x86_64
+  - perl-Devel-Size-debugsource-0:0.83-3.module_f29+5301+06000d52.x86_64
+  - perl-Digest-0:1.17-439.module_f29+5301+06000d52.noarch
+  - perl-Digest-0:1.17-439.module_f29+5301+06000d52.src
+  - perl-Digest-MD5-0:2.55-439.module_f29+5301+06000d52.src
+  - perl-Digest-MD5-0:2.55-439.module_f29+5301+06000d52.x86_64
+  - perl-Digest-MD5-debuginfo-0:2.55-439.module_f29+5301+06000d52.x86_64
+  - perl-Digest-MD5-debugsource-0:2.55-439.module_f29+5301+06000d52.x86_64
+  - perl-Digest-SHA-1:6.02-440.module_f29+5301+06000d52.src
+  - perl-Digest-SHA-1:6.02-440.module_f29+5301+06000d52.x86_64
+  - perl-Digest-SHA-debuginfo-1:6.02-440.module_f29+5301+06000d52.x86_64
+  - perl-Digest-SHA-debugsource-1:6.02-440.module_f29+5301+06000d52.x86_64
+  - perl-Encode-4:3.01-439.module_f29+5301+06000d52.src
+  - perl-Encode-4:3.01-439.module_f29+5301+06000d52.x86_64
+  - perl-Encode-debuginfo-4:3.01-439.module_f29+5301+06000d52.x86_64
+  - perl-Encode-debugsource-4:3.01-439.module_f29+5301+06000d52.x86_64
+  - perl-Encode-devel-4:3.01-439.module_f29+5301+06000d52.x86_64
+  - perl-Env-0:1.04-439.module_f29+5301+06000d52.noarch
+  - perl-Env-0:1.04-439.module_f29+5301+06000d52.src
+  - perl-Errno-0:1.30-445.module_f29+6166+8b5ad319.x86_64
+  - perl-Exporter-0:5.73-440.module_f29+5301+06000d52.noarch
+  - perl-Exporter-0:5.73-440.module_f29+5301+06000d52.src
+  - perl-ExtUtils-CBuilder-1:0.280231-439.module_f29+5301+06000d52.noarch
+  - perl-ExtUtils-CBuilder-1:0.280231-439.module_f29+5301+06000d52.src
+  - perl-ExtUtils-Command-2:7.36-4.module_f29+5301+06000d52.noarch
+  - perl-ExtUtils-Embed-0:1.35-445.module_f29+6166+8b5ad319.noarch
+  - perl-ExtUtils-Install-0:2.14-440.module_f29+5301+06000d52.noarch
+  - perl-ExtUtils-Install-0:2.14-440.module_f29+5301+06000d52.src
+  - perl-ExtUtils-MM-Utils-2:7.36-4.module_f29+5301+06000d52.noarch
+  - perl-ExtUtils-MakeMaker-2:7.36-4.module_f29+5301+06000d52.noarch
+  - perl-ExtUtils-MakeMaker-2:7.36-4.module_f29+5301+06000d52.src
+  - perl-ExtUtils-Manifest-1:1.72-439.module_f29+5301+06000d52.noarch
+  - perl-ExtUtils-Manifest-1:1.72-439.module_f29+5301+06000d52.src
+  - perl-ExtUtils-Miniperl-0:1.09-445.module_f29+6166+8b5ad319.noarch
+  - perl-ExtUtils-ParseXS-1:3.40-439.module_f29+5301+06000d52.noarch
+  - perl-ExtUtils-ParseXS-1:3.40-439.module_f29+5301+06000d52.src
+  - perl-Fedora-VSP-0:0.001-16.module_f29+5301+06000d52.noarch
+  - perl-Fedora-VSP-0:0.001-16.module_f29+5301+06000d52.src
+  - perl-File-Fetch-0:0.56-439.module_f29+5301+06000d52.noarch
+  - perl-File-Fetch-0:0.56-439.module_f29+5301+06000d52.src
+  - perl-File-HomeDir-0:1.004-6.module_f29+5301+06000d52.noarch
+  - perl-File-HomeDir-0:1.004-6.module_f29+5301+06000d52.src
+  - perl-File-Path-0:2.16-439.module_f29+5301+06000d52.noarch
+  - perl-File-Path-0:2.16-439.module_f29+5301+06000d52.src
+  - perl-File-Temp-1:0.230.900-439.module_f29+5301+06000d52.noarch
+  - perl-File-Temp-1:0.230.900-439.module_f29+5301+06000d52.src
+  - perl-File-Which-0:1.23-4.module_f29+5301+06000d52.noarch
+  - perl-File-Which-0:1.23-4.module_f29+5301+06000d52.src
+  - perl-Filter-2:1.59-440.module_f29+5301+06000d52.src
+  - perl-Filter-2:1.59-440.module_f29+5301+06000d52.x86_64
+  - perl-Filter-Simple-0:0.95-439.module_f29+5301+06000d52.noarch
+  - perl-Filter-Simple-0:0.95-439.module_f29+5301+06000d52.src
+  - perl-Filter-debuginfo-2:1.59-440.module_f29+5301+06000d52.x86_64
+  - perl-Filter-debugsource-2:1.59-440.module_f29+5301+06000d52.x86_64
+  - perl-Getopt-Long-1:2.51-1.module_f29+5987+0ffb0315.noarch
+  - perl-Getopt-Long-1:2.51-1.module_f29+5987+0ffb0315.src
+  - perl-HTTP-Tiny-0:0.076-439.module_f29+5301+06000d52.noarch
+  - perl-HTTP-Tiny-0:0.076-439.module_f29+5301+06000d52.src
+  - perl-IO-0:1.40-445.module_f29+6166+8b5ad319.x86_64
+  - perl-IO-Compress-0:2.087-1.module_f29+5987+0ffb0315.noarch
+  - perl-IO-Compress-0:2.087-1.module_f29+5987+0ffb0315.src
+  - perl-IO-Socket-IP-0:0.39-440.module_f29+5301+06000d52.noarch
+  - perl-IO-Socket-IP-0:0.39-440.module_f29+5301+06000d52.src
+  - perl-IO-Zlib-1:1.10-445.module_f29+6166+8b5ad319.noarch
+  - perl-IO-debuginfo-0:1.40-445.module_f29+6166+8b5ad319.x86_64
+  - perl-IPC-Cmd-2:1.04-2.module_f29+5301+06000d52.noarch
+  - perl-IPC-Cmd-2:1.04-2.module_f29+5301+06000d52.src
+  - perl-IPC-SysV-0:2.07-440.module_f29+5301+06000d52.src
+  - perl-IPC-SysV-0:2.07-440.module_f29+5301+06000d52.x86_64
+  - perl-IPC-SysV-debuginfo-0:2.07-440.module_f29+5301+06000d52.x86_64
+  - perl-IPC-SysV-debugsource-0:2.07-440.module_f29+5301+06000d52.x86_64
+  - perl-IPC-System-Simple-0:1.25-24.module_f29+5301+06000d52.noarch
+  - perl-IPC-System-Simple-0:1.25-24.module_f29+5301+06000d52.src
+  - perl-Importer-0:0.025-6.module_f29+5301+06000d52.noarch
+  - perl-Importer-0:0.025-6.module_f29+5301+06000d52.src
+  - perl-JSON-PP-1:4.04-2.module_f29+5301+06000d52.noarch
+  - perl-JSON-PP-1:4.04-2.module_f29+5301+06000d52.src
+  - perl-Locale-Maketext-0:1.29-440.module_f29+5301+06000d52.noarch
+  - perl-Locale-Maketext-0:1.29-440.module_f29+5301+06000d52.src
+  - perl-Locale-Maketext-Simple-1:0.21-445.module_f29+6166+8b5ad319.noarch
+  - perl-MIME-Base64-0:3.15-439.module_f29+5301+06000d52.src
+  - perl-MIME-Base64-0:3.15-439.module_f29+5301+06000d52.x86_64
+  - perl-MIME-Base64-debuginfo-0:3.15-439.module_f29+5301+06000d52.x86_64
+  - perl-MIME-Base64-debugsource-0:3.15-439.module_f29+5301+06000d52.x86_64
+  - perl-MRO-Compat-0:0.13-9.module_f29+5301+06000d52.noarch
+  - perl-MRO-Compat-0:0.13-9.module_f29+5301+06000d52.src
+  - perl-Math-BigInt-1:1.9998.16-439.module_f29+5301+06000d52.noarch
+  - perl-Math-BigInt-1:1.9998.16-439.module_f29+5301+06000d52.src
+  - perl-Math-BigInt-FastCalc-0:0.500.800-439.module_f29+5301+06000d52.src
+  - perl-Math-BigInt-FastCalc-0:0.500.800-439.module_f29+5301+06000d52.x86_64
+  - perl-Math-BigInt-FastCalc-debuginfo-0:0.500.800-439.module_f29+5301+06000d52.x86_64
+  - perl-Math-BigInt-FastCalc-debugsource-0:0.500.800-439.module_f29+5301+06000d52.x86_64
+  - perl-Math-BigRat-0:0.2614-439.module_f29+5301+06000d52.noarch
+  - perl-Math-BigRat-0:0.2614-439.module_f29+5301+06000d52.src
+  - perl-Math-Complex-0:1.59-445.module_f29+6166+8b5ad319.noarch
+  - perl-Memoize-0:1.03-445.module_f29+6166+8b5ad319.noarch
+  - perl-Module-Build-2:0.42.29-4.module_f29+5301+06000d52.noarch
+  - perl-Module-Build-2:0.42.29-4.module_f29+5301+06000d52.src
+  - perl-Module-CoreList-1:5.20190820-1.module_f29+5987+0ffb0315.noarch
+  - perl-Module-CoreList-1:5.20190820-1.module_f29+5987+0ffb0315.src
+  - perl-Module-CoreList-tools-1:5.20190820-1.module_f29+5987+0ffb0315.noarch
+  - perl-Module-Load-1:0.34-439.module_f29+5301+06000d52.noarch
+  - perl-Module-Load-1:0.34-439.module_f29+5301+06000d52.src
+  - perl-Module-Load-Conditional-0:0.68-439.module_f29+5301+06000d52.noarch
+  - perl-Module-Load-Conditional-0:0.68-439.module_f29+5301+06000d52.src
+  - perl-Module-Loaded-1:0.08-445.module_f29+6166+8b5ad319.noarch
+  - perl-Module-Metadata-0:1.000036-439.module_f29+5301+06000d52.noarch
+  - perl-Module-Metadata-0:1.000036-439.module_f29+5301+06000d52.src
+  - perl-Net-Ping-0:2.71-445.module_f29+6166+8b5ad319.noarch
+  - perl-Package-Generator-0:1.106-16.module_f29+5301+06000d52.noarch
+  - perl-Package-Generator-0:1.106-16.module_f29+5301+06000d52.src
+  - perl-Params-Check-1:0.38-439.module_f29+5301+06000d52.noarch
+  - perl-Params-Check-1:0.38-439.module_f29+5301+06000d52.src
+  - perl-Params-Util-0:1.07-28.module_f29+5301+06000d52.src
+  - perl-Params-Util-0:1.07-28.module_f29+5301+06000d52.x86_64
+  - perl-Params-Util-debuginfo-0:1.07-28.module_f29+5301+06000d52.x86_64
+  - perl-Params-Util-debugsource-0:1.07-28.module_f29+5301+06000d52.x86_64
+  - perl-PathTools-0:3.78-439.module_f29+5301+06000d52.src
+  - perl-PathTools-0:3.78-439.module_f29+5301+06000d52.x86_64
+  - perl-PathTools-debuginfo-0:3.78-439.module_f29+5301+06000d52.x86_64
+  - perl-PathTools-debugsource-0:3.78-439.module_f29+5301+06000d52.x86_64
+  - perl-Perl-OSType-0:1.010-440.module_f29+5301+06000d52.noarch
+  - perl-Perl-OSType-0:1.010-440.module_f29+5301+06000d52.src
+  - perl-PerlIO-via-QuotedPrint-0:0.08-439.module_f29+5301+06000d52.noarch
+  - perl-PerlIO-via-QuotedPrint-0:0.08-439.module_f29+5301+06000d52.src
+  - perl-Pod-Checker-4:1.73-439.module_f29+5301+06000d52.noarch
+  - perl-Pod-Checker-4:1.73-439.module_f29+5301+06000d52.src
+  - perl-Pod-Escapes-1:1.07-439.module_f29+5301+06000d52.noarch
+  - perl-Pod-Escapes-1:1.07-439.module_f29+5301+06000d52.src
+  - perl-Pod-Html-0:1.24-445.module_f29+6166+8b5ad319.noarch
+  - perl-Pod-Parser-0:1.63-440.module_f29+5301+06000d52.noarch
+  - perl-Pod-Parser-0:1.63-440.module_f29+5301+06000d52.src
+  - perl-Pod-Perldoc-0:3.28.01-442.module_f29+5987+0ffb0315.noarch
+  - perl-Pod-Perldoc-0:3.28.01-442.module_f29+5987+0ffb0315.src
+  - perl-Pod-Simple-1:3.39-2.module_f29+5301+06000d52.noarch
+  - perl-Pod-Simple-1:3.39-2.module_f29+5301+06000d52.src
+  - perl-Pod-Usage-4:1.69-439.module_f29+5301+06000d52.noarch
+  - perl-Pod-Usage-4:1.69-439.module_f29+5301+06000d52.src
+  - perl-Scalar-List-Utils-3:1.52-439.module_f29+5987+0ffb0315.src
+  - perl-Scalar-List-Utils-3:1.52-439.module_f29+5987+0ffb0315.x86_64
+  - perl-Scalar-List-Utils-debuginfo-3:1.52-439.module_f29+5987+0ffb0315.x86_64
+  - perl-Scalar-List-Utils-debugsource-3:1.52-439.module_f29+5987+0ffb0315.x86_64
+  - perl-SelfLoader-0:1.25-445.module_f29+6166+8b5ad319.noarch
+  - perl-Socket-4:2.029-4.module_f29+5301+06000d52.src
+  - perl-Socket-4:2.029-4.module_f29+5301+06000d52.x86_64
+  - perl-Socket-debuginfo-4:2.029-4.module_f29+5301+06000d52.x86_64
+  - perl-Socket-debugsource-4:2.029-4.module_f29+5301+06000d52.x86_64
+  - perl-Software-License-0:0.103014-5.module_f29+5301+06000d52.noarch
+  - perl-Software-License-0:0.103014-5.module_f29+5301+06000d52.src
+  - perl-Storable-1:3.15-441.module_f29+5987+0ffb0315.src
+  - perl-Storable-1:3.15-441.module_f29+5987+0ffb0315.x86_64
+  - perl-Storable-debuginfo-1:3.15-441.module_f29+5987+0ffb0315.x86_64
+  - perl-Storable-debugsource-1:3.15-441.module_f29+5987+0ffb0315.x86_64
+  - perl-Sub-Exporter-0:0.987-20.module_f29+5301+06000d52.noarch
+  - perl-Sub-Exporter-0:0.987-20.module_f29+5301+06000d52.src
+  - perl-Sub-Install-0:0.928-21.module_f29+5301+06000d52.noarch
+  - perl-Sub-Install-0:0.928-21.module_f29+5301+06000d52.src
+  - perl-Sys-Syslog-0:0.35-440.module_f29+5301+06000d52.src
+  - perl-Sys-Syslog-0:0.35-440.module_f29+5301+06000d52.x86_64
+  - perl-Sys-Syslog-debuginfo-0:0.35-440.module_f29+5301+06000d52.x86_64
+  - perl-Sys-Syslog-debugsource-0:0.35-440.module_f29+5301+06000d52.x86_64
+  - perl-Term-ANSIColor-0:4.06-440.module_f29+5301+06000d52.noarch
+  - perl-Term-ANSIColor-0:4.06-440.module_f29+5301+06000d52.src
+  - perl-Term-Cap-0:1.17-439.module_f29+5301+06000d52.noarch
+  - perl-Term-Cap-0:1.17-439.module_f29+5301+06000d52.src
+  - perl-Term-Table-0:0.013-4.module_f29+5301+06000d52.noarch
+  - perl-Term-Table-0:0.013-4.module_f29+5301+06000d52.src
+  - perl-Test-0:1.31-445.module_f29+6166+8b5ad319.noarch
+  - perl-Test-Harness-1:3.42-440.module_f29+5301+06000d52.noarch
+  - perl-Test-Harness-1:3.42-440.module_f29+5301+06000d52.src
+  - perl-Test-Simple-3:1.302167-1.module_f29+6166+8b5ad319.noarch
+  - perl-Test-Simple-3:1.302167-1.module_f29+6166+8b5ad319.src
+  - perl-Text-Balanced-0:2.03-439.module_f29+5301+06000d52.noarch
+  - perl-Text-Balanced-0:2.03-439.module_f29+5301+06000d52.src
+  - perl-Text-Diff-0:1.45-7.module_f29+5301+06000d52.noarch
+  - perl-Text-Diff-0:1.45-7.module_f29+5301+06000d52.src
+  - perl-Text-Glob-0:0.11-9.module_f29+5301+06000d52.noarch
+  - perl-Text-Glob-0:0.11-9.module_f29+5301+06000d52.src
+  - perl-Text-ParseWords-0:3.30-439.module_f29+5301+06000d52.noarch
+  - perl-Text-ParseWords-0:3.30-439.module_f29+5301+06000d52.src
+  - perl-Text-Tabs+Wrap-0:2013.0523-439.module_f29+5301+06000d52.noarch
+  - perl-Text-Tabs+Wrap-0:2013.0523-439.module_f29+5301+06000d52.src
+  - perl-Text-Template-0:1.56-2.module_f29+5301+06000d52.noarch
+  - perl-Text-Template-0:1.56-2.module_f29+5301+06000d52.src
+  - perl-Thread-Queue-0:3.13-439.module_f29+5301+06000d52.noarch
+  - perl-Thread-Queue-0:3.13-439.module_f29+5301+06000d52.src
+  - perl-Time-HiRes-0:1.9760-439.module_f29+5301+06000d52.src
+  - perl-Time-HiRes-0:1.9760-439.module_f29+5301+06000d52.x86_64
+  - perl-Time-HiRes-debuginfo-0:1.9760-439.module_f29+5301+06000d52.x86_64
+  - perl-Time-HiRes-debugsource-0:1.9760-439.module_f29+5301+06000d52.x86_64
+  - perl-Time-Local-2:1.280-439.module_f29+5301+06000d52.noarch
+  - perl-Time-Local-2:1.280-439.module_f29+5301+06000d52.src
+  - perl-Time-Piece-0:1.33-445.module_f29+6166+8b5ad319.x86_64
+  - perl-Time-Piece-debuginfo-0:1.33-445.module_f29+6166+8b5ad319.x86_64
+  - perl-URI-0:1.76-5.module_f29+5301+06000d52.noarch
+  - perl-URI-0:1.76-5.module_f29+5301+06000d52.src
+  - perl-Unicode-Collate-0:1.27-439.module_f29+5301+06000d52.src
+  - perl-Unicode-Collate-0:1.27-439.module_f29+5301+06000d52.x86_64
+  - perl-Unicode-Collate-debuginfo-0:1.27-439.module_f29+5301+06000d52.x86_64
+  - perl-Unicode-Collate-debugsource-0:1.27-439.module_f29+5301+06000d52.x86_64
+  - perl-Unicode-Normalize-0:1.26-439.module_f29+5301+06000d52.src
+  - perl-Unicode-Normalize-0:1.26-439.module_f29+5301+06000d52.x86_64
+  - perl-Unicode-Normalize-debuginfo-0:1.26-439.module_f29+5301+06000d52.x86_64
+  - perl-Unicode-Normalize-debugsource-0:1.26-439.module_f29+5301+06000d52.x86_64
+  - perl-autodie-0:2.29-440.module_f29+5301+06000d52.noarch
+  - perl-autodie-0:2.29-440.module_f29+5301+06000d52.src
+  - perl-bignum-0:0.51-439.module_f29+5301+06000d52.noarch
+  - perl-bignum-0:0.51-439.module_f29+5301+06000d52.src
+  - perl-constant-0:1.33-440.module_f29+5301+06000d52.noarch
+  - perl-constant-0:1.33-440.module_f29+5301+06000d52.src
+  - perl-debuginfo-4:5.30.0-445.module_f29+6166+8b5ad319.x86_64
+  - perl-debugsource-4:5.30.0-445.module_f29+6166+8b5ad319.x86_64
+  - perl-devel-4:5.30.0-445.module_f29+6166+8b5ad319.x86_64
+  - perl-encoding-4:2.22-439.module_f29+5301+06000d52.x86_64
+  - perl-experimental-0:0.020-439.module_f29+5301+06000d52.noarch
+  - perl-experimental-0:0.020-439.module_f29+5301+06000d52.src
+  - perl-generators-0:1.11-4.module_f29+5301+06000d52.noarch
+  - perl-generators-0:1.11-4.module_f29+5301+06000d52.src
+  - perl-homedir-0:2.000024-7.module_f29+5301+06000d52.noarch
+  - perl-inc-latest-2:0.500-14.module_f29+5301+06000d52.noarch
+  - perl-inc-latest-2:0.500-14.module_f29+5301+06000d52.src
+  - perl-interpreter-4:5.30.0-445.module_f29+6166+8b5ad319.x86_64
+  - perl-interpreter-debuginfo-4:5.30.0-445.module_f29+6166+8b5ad319.x86_64
+  - perl-libnet-0:3.11-440.module_f29+5301+06000d52.noarch
+  - perl-libnet-0:3.11-440.module_f29+5301+06000d52.src
+  - perl-libnetcfg-4:5.30.0-445.module_f29+6166+8b5ad319.noarch
+  - perl-libs-4:5.30.0-445.module_f29+6166+8b5ad319.x86_64
+  - perl-libs-debuginfo-4:5.30.0-445.module_f29+6166+8b5ad319.x86_64
+  - perl-local-lib-0:2.000024-7.module_f29+5301+06000d52.noarch
+  - perl-local-lib-0:2.000024-7.module_f29+5301+06000d52.src
+  - perl-macros-4:5.30.0-445.module_f29+6166+8b5ad319.x86_64
+  - perl-open-0:1.11-445.module_f29+6166+8b5ad319.noarch
+  - perl-parent-1:0.237-439.module_f29+5301+06000d52.noarch
+  - perl-parent-1:0.237-439.module_f29+5301+06000d52.src
+  - perl-perlfaq-0:5.20190126-439.module_f29+5301+06000d52.noarch
+  - perl-perlfaq-0:5.20190126-439.module_f29+5301+06000d52.src
+  - perl-podlators-1:4.12-2.module_f29+5301+06000d52.noarch
+  - perl-podlators-1:4.12-2.module_f29+5301+06000d52.src
+  - perl-tests-4:5.30.0-445.module_f29+6166+8b5ad319.x86_64
+  - perl-threads-1:2.22-439.module_f29+5301+06000d52.src
+  - perl-threads-1:2.22-439.module_f29+5301+06000d52.x86_64
+  - perl-threads-debuginfo-1:2.22-439.module_f29+5301+06000d52.x86_64
+  - perl-threads-debugsource-1:2.22-439.module_f29+5301+06000d52.x86_64
+  - perl-threads-shared-0:1.60-440.module_f29+5301+06000d52.src
+  - perl-threads-shared-0:1.60-440.module_f29+5301+06000d52.x86_64
+  - perl-threads-shared-debuginfo-0:1.60-440.module_f29+5301+06000d52.x86_64
+  - perl-threads-shared-debugsource-0:1.60-440.module_f29+5301+06000d52.x86_64
+  - perl-utils-0:5.30.0-445.module_f29+6166+8b5ad319.noarch
+  - perl-version-7:0.99.24-440.module_f29+5301+06000d52.src
+  - perl-version-7:0.99.24-440.module_f29+5301+06000d52.x86_64
+  - perl-version-debuginfo-7:0.99.24-440.module_f29+5301+06000d52.x86_64
+  - perl-version-debugsource-7:0.99.24-440.module_f29+5301+06000d52.x86_64
+  context: fafb7136
+  dependencies: []
+  name: perl
+  profiles:
+    default:
+      description: Interpreter and all Perl modules bundled within upstream Perl.
+      rpms:
+      - perl
+    minimal:
+      description: Only the interpreter as a standalone executable.
+      rpms:
+      - perl-interpreter
+  repository_memberships:
+  - dest1
+  stream: '5.30'
+  unit_id: (hidden)
+  version: 2920190905110320
+- _class: ModulemdUnit
+  arch: x86_64
+  artifacts:
+  - pg-semver-0:0.20.3-1.module_f29+3011+a1f580e1.src
+  - pg-semver-0:0.20.3-1.module_f29+3011+a1f580e1.x86_64
+  - pg-semver-debuginfo-0:0.20.3-1.module_f29+3011+a1f580e1.x86_64
+  - pg-semver-debugsource-0:0.20.3-1.module_f29+3011+a1f580e1.x86_64
+  - postgresql-0:11.5-1.module_f29+5993+a4d0abfe.src
+  - postgresql-0:11.5-1.module_f29+5993+a4d0abfe.x86_64
+  - postgresql-contrib-0:11.5-1.module_f29+5993+a4d0abfe.x86_64
+  - postgresql-contrib-debuginfo-0:11.5-1.module_f29+5993+a4d0abfe.x86_64
+  - postgresql-debuginfo-0:11.5-1.module_f29+5993+a4d0abfe.x86_64
+  - postgresql-debugsource-0:11.5-1.module_f29+5993+a4d0abfe.x86_64
+  - postgresql-devel-0:11.5-1.module_f29+5993+a4d0abfe.x86_64
+  - postgresql-devel-debuginfo-0:11.5-1.module_f29+5993+a4d0abfe.x86_64
+  - postgresql-docs-0:11.5-1.module_f29+5993+a4d0abfe.x86_64
+  - postgresql-docs-debuginfo-0:11.5-1.module_f29+5993+a4d0abfe.x86_64
+  - postgresql-ip4r-0:2.3-1.module_f29+3011+a1f580e1.src
+  - postgresql-ip4r-0:2.3-1.module_f29+3011+a1f580e1.x86_64
+  - postgresql-ip4r-debuginfo-0:2.3-1.module_f29+3011+a1f580e1.x86_64
+  - postgresql-ip4r-debugsource-0:2.3-1.module_f29+3011+a1f580e1.x86_64
+  - postgresql-libs-0:11.5-1.module_f29+5993+a4d0abfe.x86_64
+  - postgresql-libs-debuginfo-0:11.5-1.module_f29+5993+a4d0abfe.x86_64
+  - postgresql-pgpool-II-0:4.0.3-2.module_f29+5074+b42a4a43.src
+  - postgresql-pgpool-II-0:4.0.3-2.module_f29+5074+b42a4a43.x86_64
+  - postgresql-pgpool-II-debuginfo-0:4.0.3-2.module_f29+5074+b42a4a43.x86_64
+  - postgresql-pgpool-II-debugsource-0:4.0.3-2.module_f29+5074+b42a4a43.x86_64
+  - postgresql-pgpool-II-devel-0:4.0.3-2.module_f29+5074+b42a4a43.x86_64
+  - postgresql-pgpool-II-extensions-0:4.0.3-2.module_f29+5074+b42a4a43.x86_64
+  - postgresql-pgpool-II-extensions-debuginfo-0:4.0.3-2.module_f29+5074+b42a4a43.x86_64
+  - postgresql-plperl-0:11.5-1.module_f29+5993+a4d0abfe.x86_64
+  - postgresql-plperl-debuginfo-0:11.5-1.module_f29+5993+a4d0abfe.x86_64
+  - postgresql-plpython-0:11.5-1.module_f29+5993+a4d0abfe.x86_64
+  - postgresql-plpython-debuginfo-0:11.5-1.module_f29+5993+a4d0abfe.x86_64
+  - postgresql-plpython3-0:11.5-1.module_f29+5993+a4d0abfe.x86_64
+  - postgresql-plpython3-debuginfo-0:11.5-1.module_f29+5993+a4d0abfe.x86_64
+  - postgresql-pltcl-0:11.5-1.module_f29+5993+a4d0abfe.x86_64
+  - postgresql-pltcl-debuginfo-0:11.5-1.module_f29+5993+a4d0abfe.x86_64
+  - postgresql-server-0:11.5-1.module_f29+5993+a4d0abfe.x86_64
+  - postgresql-server-debuginfo-0:11.5-1.module_f29+5993+a4d0abfe.x86_64
+  - postgresql-static-0:11.5-1.module_f29+5993+a4d0abfe.x86_64
+  - postgresql-test-0:11.5-1.module_f29+5993+a4d0abfe.x86_64
+  - postgresql-test-debuginfo-0:11.5-1.module_f29+5993+a4d0abfe.x86_64
+  - postgresql-test-rpm-macros-0:11.5-1.module_f29+5993+a4d0abfe.x86_64
+  - postgresql-upgrade-0:11.5-1.module_f29+5993+a4d0abfe.x86_64
+  - postgresql-upgrade-debuginfo-0:11.5-1.module_f29+5993+a4d0abfe.x86_64
+  - postgresql-upgrade-devel-0:11.5-1.module_f29+5993+a4d0abfe.x86_64
+  - postgresql-upgrade-devel-debuginfo-0:11.5-1.module_f29+5993+a4d0abfe.x86_64
+  - timescaledb-0:1.3.1-1.module_f29+5023+d83c8b15.src
+  - timescaledb-0:1.3.1-1.module_f29+5023+d83c8b15.x86_64
+  - timescaledb-debuginfo-0:1.3.1-1.module_f29+5023+d83c8b15.x86_64
+  - timescaledb-debugsource-0:1.3.1-1.module_f29+5023+d83c8b15.x86_64
+  context: 6c81f848
+  dependencies: []
+  name: postgresql
+  profiles:
+    client:
+      rpms:
+      - postgresql
+    server:
+      rpms:
+      - postgresql-server
+  repository_memberships:
+  - dest1
+  stream: '11'
+  unit_id: (hidden)
+  version: 2920190822054051
+- _class: ModulemdUnit
+  arch: x86_64
+  artifacts:
+  - policycoreutils-0:2.8-11.module_2308+0b93c082.aarch64
+  - policycoreutils-0:2.8-11.module_2308+0b93c082.armv7hl
+  - policycoreutils-0:2.8-11.module_2308+0b93c082.ppc64le
+  - policycoreutils-0:2.8-11.module_2308+0b93c082.s390x
+  - policycoreutils-0:2.8-11.module_2308+0b93c082.src
+  - policycoreutils-0:2.8-11.module_2308+0b93c082.x86_64
+  - policycoreutils-dbus-0:2.8-11.module_2308+0b93c082.noarch
+  - policycoreutils-debuginfo-0:2.8-11.module_2308+0b93c082.aarch64
+  - policycoreutils-debuginfo-0:2.8-11.module_2308+0b93c082.armv7hl
+  - policycoreutils-debuginfo-0:2.8-11.module_2308+0b93c082.ppc64le
+  - policycoreutils-debuginfo-0:2.8-11.module_2308+0b93c082.s390x
+  - policycoreutils-debuginfo-0:2.8-11.module_2308+0b93c082.x86_64
+  - policycoreutils-debugsource-0:2.8-11.module_2308+0b93c082.aarch64
+  - policycoreutils-debugsource-0:2.8-11.module_2308+0b93c082.armv7hl
+  - policycoreutils-debugsource-0:2.8-11.module_2308+0b93c082.ppc64le
+  - policycoreutils-debugsource-0:2.8-11.module_2308+0b93c082.s390x
+  - policycoreutils-debugsource-0:2.8-11.module_2308+0b93c082.x86_64
+  - policycoreutils-devel-0:2.8-11.module_2308+0b93c082.aarch64
+  - policycoreutils-devel-0:2.8-11.module_2308+0b93c082.armv7hl
+  - policycoreutils-devel-0:2.8-11.module_2308+0b93c082.ppc64le
+  - policycoreutils-devel-0:2.8-11.module_2308+0b93c082.s390x
+  - policycoreutils-devel-0:2.8-11.module_2308+0b93c082.x86_64
+  - policycoreutils-devel-debuginfo-0:2.8-11.module_2308+0b93c082.aarch64
+  - policycoreutils-devel-debuginfo-0:2.8-11.module_2308+0b93c082.armv7hl
+  - policycoreutils-devel-debuginfo-0:2.8-11.module_2308+0b93c082.ppc64le
+  - policycoreutils-devel-debuginfo-0:2.8-11.module_2308+0b93c082.s390x
+  - policycoreutils-devel-debuginfo-0:2.8-11.module_2308+0b93c082.x86_64
+  - policycoreutils-gui-0:2.8-11.module_2308+0b93c082.noarch
+  - policycoreutils-newrole-0:2.8-11.module_2308+0b93c082.aarch64
+  - policycoreutils-newrole-0:2.8-11.module_2308+0b93c082.armv7hl
+  - policycoreutils-newrole-0:2.8-11.module_2308+0b93c082.ppc64le
+  - policycoreutils-newrole-0:2.8-11.module_2308+0b93c082.s390x
+  - policycoreutils-newrole-0:2.8-11.module_2308+0b93c082.x86_64
+  - policycoreutils-newrole-debuginfo-0:2.8-11.module_2308+0b93c082.aarch64
+  - policycoreutils-newrole-debuginfo-0:2.8-11.module_2308+0b93c082.armv7hl
+  - policycoreutils-newrole-debuginfo-0:2.8-11.module_2308+0b93c082.ppc64le
+  - policycoreutils-newrole-debuginfo-0:2.8-11.module_2308+0b93c082.s390x
+  - policycoreutils-newrole-debuginfo-0:2.8-11.module_2308+0b93c082.x86_64
+  - policycoreutils-python-utils-0:2.8-11.module_2308+0b93c082.noarch
+  - policycoreutils-restorecond-0:2.8-11.module_2308+0b93c082.aarch64
+  - policycoreutils-restorecond-0:2.8-11.module_2308+0b93c082.armv7hl
+  - policycoreutils-restorecond-0:2.8-11.module_2308+0b93c082.ppc64le
+  - policycoreutils-restorecond-0:2.8-11.module_2308+0b93c082.s390x
+  - policycoreutils-restorecond-0:2.8-11.module_2308+0b93c082.x86_64
+  - policycoreutils-restorecond-debuginfo-0:2.8-11.module_2308+0b93c082.aarch64
+  - policycoreutils-restorecond-debuginfo-0:2.8-11.module_2308+0b93c082.armv7hl
+  - policycoreutils-restorecond-debuginfo-0:2.8-11.module_2308+0b93c082.ppc64le
+  - policycoreutils-restorecond-debuginfo-0:2.8-11.module_2308+0b93c082.s390x
+  - policycoreutils-restorecond-debuginfo-0:2.8-11.module_2308+0b93c082.x86_64
+  - policycoreutils-sandbox-0:2.8-11.module_2308+0b93c082.aarch64
+  - policycoreutils-sandbox-0:2.8-11.module_2308+0b93c082.armv7hl
+  - policycoreutils-sandbox-0:2.8-11.module_2308+0b93c082.ppc64le
+  - policycoreutils-sandbox-0:2.8-11.module_2308+0b93c082.s390x
+  - policycoreutils-sandbox-0:2.8-11.module_2308+0b93c082.x86_64
+  - policycoreutils-sandbox-debuginfo-0:2.8-11.module_2308+0b93c082.aarch64
+  - policycoreutils-sandbox-debuginfo-0:2.8-11.module_2308+0b93c082.armv7hl
+  - policycoreutils-sandbox-debuginfo-0:2.8-11.module_2308+0b93c082.ppc64le
+  - policycoreutils-sandbox-debuginfo-0:2.8-11.module_2308+0b93c082.s390x
+  - policycoreutils-sandbox-debuginfo-0:2.8-11.module_2308+0b93c082.x86_64
+  - python2-policycoreutils-0:2.8-11.module_2308+0b93c082.noarch
+  - python3-policycoreutils-0:2.8-11.module_2308+0b93c082.noarch
+  - python3-setools-0:4.2.0-0.3.rc.module_2311+c02f072e.aarch64
+  - python3-setools-0:4.2.0-0.3.rc.module_2311+c02f072e.armv7hl
+  - python3-setools-0:4.2.0-0.3.rc.module_2311+c02f072e.ppc64le
+  - python3-setools-0:4.2.0-0.3.rc.module_2311+c02f072e.s390x
+  - python3-setools-0:4.2.0-0.3.rc.module_2311+c02f072e.x86_64
+  - python3-setools-debuginfo-0:4.2.0-0.3.rc.module_2311+c02f072e.aarch64
+  - python3-setools-debuginfo-0:4.2.0-0.3.rc.module_2311+c02f072e.armv7hl
+  - python3-setools-debuginfo-0:4.2.0-0.3.rc.module_2311+c02f072e.ppc64le
+  - python3-setools-debuginfo-0:4.2.0-0.3.rc.module_2311+c02f072e.s390x
+  - python3-setools-debuginfo-0:4.2.0-0.3.rc.module_2311+c02f072e.x86_64
+  - setools-0:4.2.0-0.3.rc.module_2311+c02f072e.aarch64
+  - setools-0:4.2.0-0.3.rc.module_2311+c02f072e.armv7hl
+  - setools-0:4.2.0-0.3.rc.module_2311+c02f072e.ppc64le
+  - setools-0:4.2.0-0.3.rc.module_2311+c02f072e.s390x
+  - setools-0:4.2.0-0.3.rc.module_2311+c02f072e.src
+  - setools-0:4.2.0-0.3.rc.module_2311+c02f072e.x86_64
+  - setools-console-0:4.2.0-0.3.rc.module_2311+c02f072e.aarch64
+  - setools-console-0:4.2.0-0.3.rc.module_2311+c02f072e.armv7hl
+  - setools-console-0:4.2.0-0.3.rc.module_2311+c02f072e.ppc64le
+  - setools-console-0:4.2.0-0.3.rc.module_2311+c02f072e.s390x
+  - setools-console-0:4.2.0-0.3.rc.module_2311+c02f072e.x86_64
+  - setools-console-analyses-0:4.2.0-0.3.rc.module_2311+c02f072e.aarch64
+  - setools-console-analyses-0:4.2.0-0.3.rc.module_2311+c02f072e.armv7hl
+  - setools-console-analyses-0:4.2.0-0.3.rc.module_2311+c02f072e.ppc64le
+  - setools-console-analyses-0:4.2.0-0.3.rc.module_2311+c02f072e.s390x
+  - setools-console-analyses-0:4.2.0-0.3.rc.module_2311+c02f072e.x86_64
+  - setools-debugsource-0:4.2.0-0.3.rc.module_2311+c02f072e.aarch64
+  - setools-debugsource-0:4.2.0-0.3.rc.module_2311+c02f072e.armv7hl
+  - setools-debugsource-0:4.2.0-0.3.rc.module_2311+c02f072e.ppc64le
+  - setools-debugsource-0:4.2.0-0.3.rc.module_2311+c02f072e.s390x
+  - setools-debugsource-0:4.2.0-0.3.rc.module_2311+c02f072e.x86_64
+  - setools-gui-0:4.2.0-0.3.rc.module_2311+c02f072e.aarch64
+  - setools-gui-0:4.2.0-0.3.rc.module_2311+c02f072e.armv7hl
+  - setools-gui-0:4.2.0-0.3.rc.module_2311+c02f072e.ppc64le
+  - setools-gui-0:4.2.0-0.3.rc.module_2311+c02f072e.s390x
+  - setools-gui-0:4.2.0-0.3.rc.module_2311+c02f072e.x86_64
+  context: 6c81f848
+  dependencies: []
+  name: setools
+  profiles:
+    default:
+      description: Standard installation
+      rpms:
+      - setools-console
+  repository_memberships:
+  - dest1
+  stream: 4.2.0
+  unit_id: (hidden)
+  version: 20181018141553
+- _class: ModulemdUnit
+  arch: x86_64
+  artifacts:
+  - postgresql-0:10.10-1.module_f29+5313+28ee801c.src
+  - postgresql-0:10.10-1.module_f29+5313+28ee801c.x86_64
+  - postgresql-contrib-0:10.10-1.module_f29+5313+28ee801c.x86_64
+  - postgresql-contrib-debuginfo-0:10.10-1.module_f29+5313+28ee801c.x86_64
+  - postgresql-debuginfo-0:10.10-1.module_f29+5313+28ee801c.x86_64
+  - postgresql-debugsource-0:10.10-1.module_f29+5313+28ee801c.x86_64
+  - postgresql-devel-0:10.10-1.module_f29+5313+28ee801c.x86_64
+  - postgresql-devel-debuginfo-0:10.10-1.module_f29+5313+28ee801c.x86_64
+  - postgresql-docs-0:10.10-1.module_f29+5313+28ee801c.x86_64
+  - postgresql-docs-debuginfo-0:10.10-1.module_f29+5313+28ee801c.x86_64
+  - postgresql-libs-0:10.10-1.module_f29+5313+28ee801c.x86_64
+  - postgresql-libs-debuginfo-0:10.10-1.module_f29+5313+28ee801c.x86_64
+  - postgresql-plperl-0:10.10-1.module_f29+5313+28ee801c.x86_64
+  - postgresql-plperl-debuginfo-0:10.10-1.module_f29+5313+28ee801c.x86_64
+  - postgresql-plpython-0:10.10-1.module_f29+5313+28ee801c.x86_64
+  - postgresql-plpython-debuginfo-0:10.10-1.module_f29+5313+28ee801c.x86_64
+  - postgresql-plpython3-0:10.10-1.module_f29+5313+28ee801c.x86_64
+  - postgresql-plpython3-debuginfo-0:10.10-1.module_f29+5313+28ee801c.x86_64
+  - postgresql-pltcl-0:10.10-1.module_f29+5313+28ee801c.x86_64
+  - postgresql-pltcl-debuginfo-0:10.10-1.module_f29+5313+28ee801c.x86_64
+  - postgresql-server-0:10.10-1.module_f29+5313+28ee801c.x86_64
+  - postgresql-server-debuginfo-0:10.10-1.module_f29+5313+28ee801c.x86_64
+  - postgresql-static-0:10.10-1.module_f29+5313+28ee801c.x86_64
+  - postgresql-test-0:10.10-1.module_f29+5313+28ee801c.x86_64
+  - postgresql-test-debuginfo-0:10.10-1.module_f29+5313+28ee801c.x86_64
+  - postgresql-test-rpm-macros-0:10.10-1.module_f29+5313+28ee801c.x86_64
+  - postgresql-upgrade-0:10.10-1.module_f29+5313+28ee801c.x86_64
+  - postgresql-upgrade-debuginfo-0:10.10-1.module_f29+5313+28ee801c.x86_64
+  - postgresql-upgrade-devel-0:10.10-1.module_f29+5313+28ee801c.x86_64
+  - postgresql-upgrade-devel-debuginfo-0:10.10-1.module_f29+5313+28ee801c.x86_64
+  context: 6c81f848
+  dependencies: []
+  name: postgresql
+  profiles:
+    client:
+      rpms:
+      - postgresql
+    server:
+      rpms:
+      - postgresql-server
+  repository_memberships:
+  - dest1
+  stream: '10'
+  unit_id: (hidden)
+  version: 2920190809122726
+- _class: ModulemdUnit
+  arch: x86_64
+  artifacts:
+  - postgresql-0:9.6.15-1.module_f29+5317+7856031b.src
+  - postgresql-0:9.6.15-1.module_f29+5317+7856031b.x86_64
+  - postgresql-contrib-0:9.6.15-1.module_f29+5317+7856031b.x86_64
+  - postgresql-contrib-debuginfo-0:9.6.15-1.module_f29+5317+7856031b.x86_64
+  - postgresql-debuginfo-0:9.6.15-1.module_f29+5317+7856031b.x86_64
+  - postgresql-debugsource-0:9.6.15-1.module_f29+5317+7856031b.x86_64
+  - postgresql-devel-0:9.6.15-1.module_f29+5317+7856031b.x86_64
+  - postgresql-devel-debuginfo-0:9.6.15-1.module_f29+5317+7856031b.x86_64
+  - postgresql-docs-0:9.6.15-1.module_f29+5317+7856031b.x86_64
+  - postgresql-docs-debuginfo-0:9.6.15-1.module_f29+5317+7856031b.x86_64
+  - postgresql-libs-0:9.6.15-1.module_f29+5317+7856031b.x86_64
+  - postgresql-libs-debuginfo-0:9.6.15-1.module_f29+5317+7856031b.x86_64
+  - postgresql-plperl-0:9.6.15-1.module_f29+5317+7856031b.x86_64
+  - postgresql-plperl-debuginfo-0:9.6.15-1.module_f29+5317+7856031b.x86_64
+  - postgresql-plpython-0:9.6.15-1.module_f29+5317+7856031b.x86_64
+  - postgresql-plpython-debuginfo-0:9.6.15-1.module_f29+5317+7856031b.x86_64
+  - postgresql-plpython3-0:9.6.15-1.module_f29+5317+7856031b.x86_64
+  - postgresql-plpython3-debuginfo-0:9.6.15-1.module_f29+5317+7856031b.x86_64
+  - postgresql-pltcl-0:9.6.15-1.module_f29+5317+7856031b.x86_64
+  - postgresql-pltcl-debuginfo-0:9.6.15-1.module_f29+5317+7856031b.x86_64
+  - postgresql-server-0:9.6.15-1.module_f29+5317+7856031b.x86_64
+  - postgresql-server-debuginfo-0:9.6.15-1.module_f29+5317+7856031b.x86_64
+  - postgresql-static-0:9.6.15-1.module_f29+5317+7856031b.x86_64
+  - postgresql-test-0:9.6.15-1.module_f29+5317+7856031b.x86_64
+  - postgresql-test-debuginfo-0:9.6.15-1.module_f29+5317+7856031b.x86_64
+  - postgresql-test-rpm-macros-0:9.6.15-1.module_f29+5317+7856031b.x86_64
+  - postgresql-upgrade-0:9.6.15-1.module_f29+5317+7856031b.x86_64
+  - postgresql-upgrade-debuginfo-0:9.6.15-1.module_f29+5317+7856031b.x86_64
+  - postgresql-upgrade-devel-0:9.6.15-1.module_f29+5317+7856031b.x86_64
+  - postgresql-upgrade-devel-debuginfo-0:9.6.15-1.module_f29+5317+7856031b.x86_64
+  context: 6c81f848
+  dependencies: []
+  name: postgresql
+  profiles:
+    client:
+      rpms:
+      - postgresql
+    server:
+      rpms:
+      - postgresql-server
+  repository_memberships:
+  - dest1
+  stream: '9.6'
+  unit_id: (hidden)
+  version: 2920190809122808
+- _class: ModulemdUnit
+  arch: x86_64
+  artifacts:
+  - pretty-git-prompt-0:0.2.0-10.module_f29+5037+d3752b80.x86_64
+  - pretty-git-prompt-debuginfo-0:0.2.0-10.module_f29+5037+d3752b80.x86_64
+  - rust-pretty-git-prompt-0:0.2.0-10.module_f29+5037+d3752b80.src
+  - rust-pretty-git-prompt-debugsource-0:0.2.0-10.module_f29+5037+d3752b80.x86_64
+  context: c5ebb199
+  dependencies: []
+  name: pretty-git-prompt
+  profiles:
+    default:
+      rpms:
+      - pretty-git-prompt
+  repository_memberships:
+  - dest1
+  stream: rolling
+  unit_id: (hidden)
+  version: 2920190714104357
+- _class: ModulemdUnit
+  arch: x86_64
+  artifacts:
+  - python-aexpect-0:1.5.1-5.module_f29+4305+946ad86e.src
+  - python-avocado-0:52.1-9.module_f29+4305+946ad86e.src
+  - python-avocado-examples-0:52.1-9.module_f29+4305+946ad86e.noarch
+  - python2-aexpect-0:1.5.1-5.module_f29+4305+946ad86e.noarch
+  - python2-avocado-0:52.1-9.module_f29+4305+946ad86e.noarch
+  - python2-avocado-plugins-output-html-0:52.1-9.module_f29+4305+946ad86e.noarch
+  - python2-avocado-plugins-resultsdb-0:52.1-9.module_f29+4305+946ad86e.noarch
+  - python2-avocado-plugins-runner-docker-0:52.1-9.module_f29+4305+946ad86e.noarch
+  - python2-avocado-plugins-runner-remote-0:52.1-9.module_f29+4305+946ad86e.noarch
+  - python2-avocado-plugins-runner-vm-0:52.1-9.module_f29+4305+946ad86e.noarch
+  - python2-avocado-plugins-varianter-yaml-to-mux-0:52.1-9.module_f29+4305+946ad86e.noarch
+  - python3-aexpect-0:1.5.1-5.module_f29+4305+946ad86e.noarch
+  context: 6c81f848
+  dependencies: []
+  name: avocado
+  profiles:
+    default:
+      description: Default profile installing the most commonly used avocado packages.
+      rpms:
+      - python2-avocado
+      - python2-avocado-plugins-output-html
+      - python2-avocado-plugins-varianter-yaml-to-mux
+    minimal:
+      description: Minimal profile installing only the main avocado package.
+      rpms:
+      - python2-avocado
+  repository_memberships:
+  - dest1
+  stream: stable
+  unit_id: (hidden)
+  version: 2920190514191910
+- _class: ModulemdUnit
+  arch: x86_64
+  artifacts:
+  - python-aexpect-0:1.5.1-5.module_f29+4308+c640739d.src
+  - python-avocado-0:52.1-9.module_f29+3731+39649fd6.src
+  - python-avocado-examples-0:52.1-9.module_f29+3731+39649fd6.noarch
+  - python2-aexpect-0:1.5.1-5.module_f29+4308+c640739d.noarch
+  - python2-avocado-0:52.1-9.module_f29+3731+39649fd6.noarch
+  - python2-avocado-plugins-output-html-0:52.1-9.module_f29+3731+39649fd6.noarch
+  - python2-avocado-plugins-resultsdb-0:52.1-9.module_f29+3731+39649fd6.noarch
+  - python2-avocado-plugins-runner-docker-0:52.1-9.module_f29+3731+39649fd6.noarch
+  - python2-avocado-plugins-runner-remote-0:52.1-9.module_f29+3731+39649fd6.noarch
+  - python2-avocado-plugins-runner-vm-0:52.1-9.module_f29+3731+39649fd6.noarch
+  - python2-avocado-plugins-varianter-yaml-to-mux-0:52.1-9.module_f29+3731+39649fd6.noarch
+  - python3-aexpect-0:1.5.1-5.module_f29+4308+c640739d.noarch
+  context: 6c81f848
+  dependencies: []
+  name: avocado
+  profiles:
+    default:
+      description: Default profile installing the most commonly used avocado packages.
+      rpms:
+      - python2-avocado
+      - python2-avocado-plugins-output-html
+      - python2-avocado-plugins-varianter-yaml-to-mux
+    minimal:
+      description: Minimal profile installing only the main avocado package.
+      rpms:
+      - python2-avocado
+  repository_memberships:
+  - dest1
+  stream: 52lts
+  unit_id: (hidden)
+  version: 2920190514181108
+- _class: ModulemdUnit
+  arch: x86_64
+  artifacts:
+  - python-aexpect-0:1.5.1-5.module_f29+4312+897b76cb.src
+  - python-avocado-0:69.1-1.module_f29+4748+5dc1f308.src
+  - python-avocado-bash-0:69.1-1.module_f29+4748+5dc1f308.noarch
+  - python-avocado-common-0:69.1-1.module_f29+4748+5dc1f308.noarch
+  - python-avocado-examples-0:69.1-1.module_f29+4748+5dc1f308.noarch
+  - python2-aexpect-0:1.5.1-5.module_f29+4312+897b76cb.noarch
+  - python2-avocado-0:69.1-1.module_f29+4748+5dc1f308.noarch
+  - python2-avocado-plugins-glib-0:69.1-1.module_f29+4748+5dc1f308.noarch
+  - python2-avocado-plugins-golang-0:69.1-1.module_f29+4748+5dc1f308.noarch
+  - python2-avocado-plugins-loader-yaml-0:69.1-1.module_f29+4748+5dc1f308.noarch
+  - python2-avocado-plugins-output-html-0:69.1-1.module_f29+4748+5dc1f308.noarch
+  - python2-avocado-plugins-result-upload-0:69.1-1.module_f29+4748+5dc1f308.noarch
+  - python2-avocado-plugins-resultsdb-0:69.1-1.module_f29+4748+5dc1f308.noarch
+  - python2-avocado-plugins-runner-docker-0:69.1-1.module_f29+4748+5dc1f308.noarch
+  - python2-avocado-plugins-runner-remote-0:69.1-1.module_f29+4748+5dc1f308.noarch
+  - python2-avocado-plugins-runner-vm-0:69.1-1.module_f29+4748+5dc1f308.noarch
+  - python2-avocado-plugins-varianter-cit-0:69.1-1.module_f29+4748+5dc1f308.noarch
+  - python2-avocado-plugins-varianter-pict-0:69.1-1.module_f29+4748+5dc1f308.noarch
+  - python2-avocado-plugins-varianter-yaml-to-mux-0:69.1-1.module_f29+4748+5dc1f308.noarch
+  - python3-aexpect-0:1.5.1-5.module_f29+4312+897b76cb.noarch
+  - python3-avocado-0:69.1-1.module_f29+4748+5dc1f308.noarch
+  - python3-avocado-plugins-glib-0:69.1-1.module_f29+4748+5dc1f308.noarch
+  - python3-avocado-plugins-golang-0:69.1-1.module_f29+4748+5dc1f308.noarch
+  - python3-avocado-plugins-loader-yaml-0:69.1-1.module_f29+4748+5dc1f308.noarch
+  - python3-avocado-plugins-output-html-0:69.1-1.module_f29+4748+5dc1f308.noarch
+  - python3-avocado-plugins-result-upload-0:69.1-1.module_f29+4748+5dc1f308.noarch
+  - python3-avocado-plugins-resultsdb-0:69.1-1.module_f29+4748+5dc1f308.noarch
+  - python3-avocado-plugins-runner-docker-0:69.1-1.module_f29+4748+5dc1f308.noarch
+  - python3-avocado-plugins-runner-remote-0:69.1-1.module_f29+4748+5dc1f308.noarch
+  - python3-avocado-plugins-runner-vm-0:69.1-1.module_f29+4748+5dc1f308.noarch
+  - python3-avocado-plugins-varianter-cit-0:69.1-1.module_f29+4748+5dc1f308.noarch
+  - python3-avocado-plugins-varianter-pict-0:69.1-1.module_f29+4748+5dc1f308.noarch
+  - python3-avocado-plugins-varianter-yaml-to-mux-0:69.1-1.module_f29+4748+5dc1f308.noarch
+  context: 6c81f848
+  dependencies: []
+  name: avocado
+  profiles:
+    default:
+      description: Default profile installing the most commonly used avocado packages.
+      rpms:
+      - python3-avocado
+      - python3-avocado-plugins-output-html
+      - python3-avocado-plugins-varianter-yaml-to-mux
+    minimal:
+      description: Minimal profile installing only the main avocado package.
+      rpms:
+      - python3-avocado
+  repository_memberships:
+  - dest1
+  stream: 69lts
+  unit_id: (hidden)
+  version: 2920190618191913
+- _class: ModulemdUnit
+  arch: x86_64
+  artifacts:
+  - python-aexpect-0:1.5.1-5.module_f29+5335+39e91fb5.src
+  - python-avocado-0:71.0-1.module_f29+6097+2c631343.src
+  - python-avocado-bash-0:71.0-1.module_f29+6097+2c631343.noarch
+  - python-avocado-common-0:71.0-1.module_f29+6097+2c631343.noarch
+  - python-avocado-examples-0:71.0-1.module_f29+6097+2c631343.noarch
+  - python2-aexpect-0:1.5.1-5.module_f29+5335+39e91fb5.noarch
+  - python3-aexpect-0:1.5.1-5.module_f29+5335+39e91fb5.noarch
+  - python3-avocado-0:71.0-1.module_f29+6097+2c631343.noarch
+  - python3-avocado-plugins-glib-0:71.0-1.module_f29+6097+2c631343.noarch
+  - python3-avocado-plugins-golang-0:71.0-1.module_f29+6097+2c631343.noarch
+  - python3-avocado-plugins-loader-yaml-0:71.0-1.module_f29+6097+2c631343.noarch
+  - python3-avocado-plugins-output-html-0:71.0-1.module_f29+6097+2c631343.noarch
+  - python3-avocado-plugins-result-upload-0:71.0-1.module_f29+6097+2c631343.noarch
+  - python3-avocado-plugins-resultsdb-0:71.0-1.module_f29+6097+2c631343.noarch
+  - python3-avocado-plugins-runner-docker-0:71.0-1.module_f29+6097+2c631343.noarch
+  - python3-avocado-plugins-runner-remote-0:71.0-1.module_f29+6097+2c631343.noarch
+  - python3-avocado-plugins-runner-vm-0:71.0-1.module_f29+6097+2c631343.noarch
+  - python3-avocado-plugins-varianter-cit-0:71.0-1.module_f29+6097+2c631343.noarch
+  - python3-avocado-plugins-varianter-pict-0:71.0-1.module_f29+6097+2c631343.noarch
+  - python3-avocado-plugins-varianter-yaml-to-mux-0:71.0-1.module_f29+6097+2c631343.noarch
+  context: 6c81f848
+  dependencies: []
+  name: avocado
+  profiles:
+    default:
+      description: Default profile installing the most commonly used avocado packages.
+      rpms:
+      - python3-avocado
+      - python3-avocado-plugins-output-html
+      - python3-avocado-plugins-varianter-yaml-to-mux
+    minimal:
+      description: Minimal profile installing only the main avocado package.
+      rpms:
+      - python3-avocado
+  repository_memberships:
+  - dest1
+  stream: latest
+  unit_id: (hidden)
+  version: 2920190828134736
+- _class: ModulemdUnit
+  arch: x86_64
+  artifacts:
+  - python-django-0:1.6.11.8-1.module_f29+5286+50b99d6f.src
+  - python-django-bash-completion-0:1.6.11.8-1.module_f29+5286+50b99d6f.noarch
+  - python2-django-0:1.6.11.8-1.module_f29+5286+50b99d6f.noarch
+  context: 6c81f848
+  dependencies: []
+  name: django
+  profiles:
+    default:
+      rpms:
+      - python2-django
+    python2_development:
+      rpms:
+      - python2-django
+  repository_memberships:
+  - dest1
+  stream: '1.6'
+  unit_id: (hidden)
+  version: 2920190805151106
+- _class: ModulemdUnit
+  arch: x86_64
+  artifacts:
+  - ripgrep-0:11.0.2-1.module_f29+5276+eaac41e0.x86_64
+  - ripgrep-debuginfo-0:11.0.2-1.module_f29+5276+eaac41e0.x86_64
+  - rust-ripgrep-0:11.0.2-1.module_f29+5276+eaac41e0.src
+  - rust-ripgrep-debugsource-0:11.0.2-1.module_f29+5276+eaac41e0.x86_64
+  context: c5ebb199
+  dependencies: []
+  name: ripgrep
+  profiles:
+    default:
+      rpms:
+      - ripgrep
+  repository_memberships:
+  - dest1
+  stream: latest
+  unit_id: (hidden)
+  version: 2920190803131619
+- _class: ModulemdUnit
+  arch: x86_64
+  artifacts:
+  - rpick-0:0.4.0-1.module_f29+4292+309d505f.x86_64
+  - rpick-debuginfo-0:0.4.0-1.module_f29+4292+309d505f.x86_64
+  - rust-rpick-0:0.4.0-1.module_f29+4292+309d505f.src
+  - rust-rpick-debugsource-0:0.4.0-1.module_f29+4292+309d505f.x86_64
+  context: b8a06959
+  dependencies: []
+  name: rpick
+  profiles:
+    default:
+      rpms:
+      - rpick
+  repository_memberships:
+  - dest1
+  stream: latest
+  unit_id: (hidden)
+  version: 2920190515141045
+- _class: ModulemdUnit
+  arch: x86_64
+  artifacts:
+  - ruby-0:2.5.5-105.module_f29+4257+f7b00971.i686
+  - ruby-0:2.5.5-105.module_f29+4257+f7b00971.src
+  - ruby-0:2.5.5-105.module_f29+4257+f7b00971.x86_64
+  - ruby-debuginfo-0:2.5.5-105.module_f29+4257+f7b00971.i686
+  - ruby-debuginfo-0:2.5.5-105.module_f29+4257+f7b00971.x86_64
+  - ruby-debugsource-0:2.5.5-105.module_f29+4257+f7b00971.i686
+  - ruby-debugsource-0:2.5.5-105.module_f29+4257+f7b00971.x86_64
+  - ruby-devel-0:2.5.5-105.module_f29+4257+f7b00971.i686
+  - ruby-devel-0:2.5.5-105.module_f29+4257+f7b00971.x86_64
+  - ruby-doc-0:2.5.5-105.module_f29+4257+f7b00971.noarch
+  - ruby-irb-0:2.5.5-105.module_f29+4257+f7b00971.noarch
+  - ruby-libs-0:2.5.5-105.module_f29+4257+f7b00971.i686
+  - ruby-libs-0:2.5.5-105.module_f29+4257+f7b00971.x86_64
+  - ruby-libs-debuginfo-0:2.5.5-105.module_f29+4257+f7b00971.i686
+  - ruby-libs-debuginfo-0:2.5.5-105.module_f29+4257+f7b00971.x86_64
+  - rubygem-abrt-0:0.3.0-6.module_f29+4257+f7b00971.noarch
+  - rubygem-abrt-0:0.3.0-6.module_f29+4257+f7b00971.src
+  - rubygem-abrt-doc-0:0.3.0-6.module_f29+4257+f7b00971.noarch
+  - rubygem-bigdecimal-0:1.3.4-105.module_f29+4257+f7b00971.i686
+  - rubygem-bigdecimal-0:1.3.4-105.module_f29+4257+f7b00971.x86_64
+  - rubygem-bigdecimal-debuginfo-0:1.3.4-105.module_f29+4257+f7b00971.i686
+  - rubygem-bigdecimal-debuginfo-0:1.3.4-105.module_f29+4257+f7b00971.x86_64
+  - rubygem-bson-0:4.3.0-6.module_f29+4257+f7b00971.src
+  - rubygem-bson-0:4.3.0-6.module_f29+4257+f7b00971.x86_64
+  - rubygem-bson-debuginfo-0:4.3.0-6.module_f29+4257+f7b00971.x86_64
+  - rubygem-bson-debugsource-0:4.3.0-6.module_f29+4257+f7b00971.x86_64
+  - rubygem-bson-doc-0:4.3.0-6.module_f29+4257+f7b00971.noarch
+  - rubygem-bundler-0:1.16.1-5.module_f29+4257+f7b00971.noarch
+  - rubygem-bundler-0:1.16.1-5.module_f29+4257+f7b00971.src
+  - rubygem-bundler-doc-0:1.16.1-5.module_f29+4257+f7b00971.noarch
+  - rubygem-did_you_mean-0:1.2.0-105.module_f29+4257+f7b00971.noarch
+  - rubygem-io-console-0:0.4.6-105.module_f29+4257+f7b00971.i686
+  - rubygem-io-console-0:0.4.6-105.module_f29+4257+f7b00971.x86_64
+  - rubygem-io-console-debuginfo-0:0.4.6-105.module_f29+4257+f7b00971.i686
+  - rubygem-io-console-debuginfo-0:0.4.6-105.module_f29+4257+f7b00971.x86_64
+  - rubygem-json-0:2.1.0-105.module_f29+4257+f7b00971.i686
+  - rubygem-json-0:2.1.0-105.module_f29+4257+f7b00971.x86_64
+  - rubygem-json-debuginfo-0:2.1.0-105.module_f29+4257+f7b00971.i686
+  - rubygem-json-debuginfo-0:2.1.0-105.module_f29+4257+f7b00971.x86_64
+  - rubygem-minitest-0:5.10.3-105.module_f29+4257+f7b00971.noarch
+  - rubygem-mongo-0:2.6.2-3.module_f29+4257+f7b00971.noarch
+  - rubygem-mongo-0:2.6.2-3.module_f29+4257+f7b00971.src
+  - rubygem-mongo-doc-0:2.6.2-3.module_f29+4257+f7b00971.noarch
+  - rubygem-mysql2-0:0.5.2-3.module_f29+4257+f7b00971.src
+  - rubygem-mysql2-0:0.5.2-3.module_f29+4257+f7b00971.x86_64
+  - rubygem-mysql2-debuginfo-0:0.5.2-3.module_f29+4257+f7b00971.x86_64
+  - rubygem-mysql2-debugsource-0:0.5.2-3.module_f29+4257+f7b00971.x86_64
+  - rubygem-mysql2-doc-0:0.5.2-3.module_f29+4257+f7b00971.noarch
+  - rubygem-net-telnet-0:0.1.1-105.module_f29+4257+f7b00971.noarch
+  - rubygem-openssl-0:2.1.2-105.module_f29+4257+f7b00971.i686
+  - rubygem-openssl-0:2.1.2-105.module_f29+4257+f7b00971.x86_64
+  - rubygem-openssl-debuginfo-0:2.1.2-105.module_f29+4257+f7b00971.i686
+  - rubygem-openssl-debuginfo-0:2.1.2-105.module_f29+4257+f7b00971.x86_64
+  - rubygem-pg-0:1.1.4-3.module_f29+4257+f7b00971.src
+  - rubygem-pg-0:1.1.4-3.module_f29+4257+f7b00971.x86_64
+  - rubygem-pg-debuginfo-0:1.1.4-3.module_f29+4257+f7b00971.x86_64
+  - rubygem-pg-debugsource-0:1.1.4-3.module_f29+4257+f7b00971.x86_64
+  - rubygem-pg-doc-0:1.1.4-3.module_f29+4257+f7b00971.noarch
+  - rubygem-power_assert-0:1.1.1-105.module_f29+4257+f7b00971.noarch
+  - rubygem-psych-0:3.0.2-105.module_f29+4257+f7b00971.i686
+  - rubygem-psych-0:3.0.2-105.module_f29+4257+f7b00971.x86_64
+  - rubygem-psych-debuginfo-0:3.0.2-105.module_f29+4257+f7b00971.i686
+  - rubygem-psych-debuginfo-0:3.0.2-105.module_f29+4257+f7b00971.x86_64
+  - rubygem-rake-0:12.3.0-105.module_f29+4257+f7b00971.noarch
+  - rubygem-rdoc-0:6.0.1-105.module_f29+4257+f7b00971.noarch
+  - rubygem-test-unit-0:3.2.7-105.module_f29+4257+f7b00971.noarch
+  - rubygem-xmlrpc-0:0.3.0-105.module_f29+4257+f7b00971.noarch
+  - rubygems-0:2.7.6.2-105.module_f29+4257+f7b00971.noarch
+  - rubygems-devel-0:2.7.6.2-105.module_f29+4257+f7b00971.noarch
+  context: 6c81f848
+  dependencies: []
+  name: ruby
+  profiles:
+    default:
+      rpms:
+      - ruby
+  repository_memberships:
+  - dest1
+  stream: '2.5'
+  unit_id: (hidden)
+  version: 2920190514135654
+- _class: ModulemdUnit
+  arch: x86_64
+  artifacts:
+  - ruby-0:2.6.3-120.module_f29+4418+a52419e1.i686
+  - ruby-0:2.6.3-120.module_f29+4418+a52419e1.src
+  - ruby-0:2.6.3-120.module_f29+4418+a52419e1.x86_64
+  - ruby-debuginfo-0:2.6.3-120.module_f29+4418+a52419e1.i686
+  - ruby-debuginfo-0:2.6.3-120.module_f29+4418+a52419e1.x86_64
+  - ruby-debugsource-0:2.6.3-120.module_f29+4418+a52419e1.i686
+  - ruby-debugsource-0:2.6.3-120.module_f29+4418+a52419e1.x86_64
+  - ruby-devel-0:2.6.3-120.module_f29+4418+a52419e1.i686
+  - ruby-devel-0:2.6.3-120.module_f29+4418+a52419e1.x86_64
+  - ruby-doc-0:2.6.3-120.module_f29+4418+a52419e1.noarch
+  - ruby-libs-0:2.6.3-120.module_f29+4418+a52419e1.i686
+  - ruby-libs-0:2.6.3-120.module_f29+4418+a52419e1.x86_64
+  - ruby-libs-debuginfo-0:2.6.3-120.module_f29+4418+a52419e1.i686
+  - ruby-libs-debuginfo-0:2.6.3-120.module_f29+4418+a52419e1.x86_64
+  - rubygem-abrt-0:0.3.0-6.module_f29+3028+8256bd1e.noarch
+  - rubygem-abrt-0:0.3.0-6.module_f29+3028+8256bd1e.src
+  - rubygem-abrt-doc-0:0.3.0-6.module_f29+3028+8256bd1e.noarch
+  - rubygem-bigdecimal-0:1.4.1-120.module_f29+4418+a52419e1.i686
+  - rubygem-bigdecimal-0:1.4.1-120.module_f29+4418+a52419e1.x86_64
+  - rubygem-bigdecimal-debuginfo-0:1.4.1-120.module_f29+4418+a52419e1.i686
+  - rubygem-bigdecimal-debuginfo-0:1.4.1-120.module_f29+4418+a52419e1.x86_64
+  - rubygem-bson-0:4.5.0-1.module_f29+4418+a52419e1.src
+  - rubygem-bson-0:4.5.0-1.module_f29+4418+a52419e1.x86_64
+  - rubygem-bson-debuginfo-0:4.5.0-1.module_f29+4418+a52419e1.x86_64
+  - rubygem-bson-debugsource-0:4.5.0-1.module_f29+4418+a52419e1.x86_64
+  - rubygem-bson-doc-0:4.5.0-1.module_f29+4418+a52419e1.noarch
+  - rubygem-bundler-0:1.17.2-120.module_f29+4418+a52419e1.noarch
+  - rubygem-did_you_mean-0:1.3.0-120.module_f29+4418+a52419e1.noarch
+  - rubygem-io-console-0:0.4.7-120.module_f29+4418+a52419e1.i686
+  - rubygem-io-console-0:0.4.7-120.module_f29+4418+a52419e1.x86_64
+  - rubygem-io-console-debuginfo-0:0.4.7-120.module_f29+4418+a52419e1.i686
+  - rubygem-io-console-debuginfo-0:0.4.7-120.module_f29+4418+a52419e1.x86_64
+  - rubygem-irb-0:1.0.0-120.module_f29+4418+a52419e1.noarch
+  - rubygem-json-0:2.1.0-120.module_f29+4418+a52419e1.i686
+  - rubygem-json-0:2.1.0-120.module_f29+4418+a52419e1.x86_64
+  - rubygem-json-debuginfo-0:2.1.0-120.module_f29+4418+a52419e1.i686
+  - rubygem-json-debuginfo-0:2.1.0-120.module_f29+4418+a52419e1.x86_64
+  - rubygem-minitest-0:5.11.3-120.module_f29+4418+a52419e1.noarch
+  - rubygem-mongo-0:2.8.0-1.module_f29+4418+a52419e1.noarch
+  - rubygem-mongo-0:2.8.0-1.module_f29+4418+a52419e1.src
+  - rubygem-mongo-doc-0:2.8.0-1.module_f29+4418+a52419e1.noarch
+  - rubygem-mysql2-0:0.5.2-3.module_f29+4418+a52419e1.src
+  - rubygem-mysql2-0:0.5.2-3.module_f29+4418+a52419e1.x86_64
+  - rubygem-mysql2-debuginfo-0:0.5.2-3.module_f29+4418+a52419e1.x86_64
+  - rubygem-mysql2-debugsource-0:0.5.2-3.module_f29+4418+a52419e1.x86_64
+  - rubygem-mysql2-doc-0:0.5.2-3.module_f29+4418+a52419e1.noarch
+  - rubygem-net-telnet-0:0.2.0-120.module_f29+4418+a52419e1.noarch
+  - rubygem-openssl-0:2.1.2-120.module_f29+4418+a52419e1.i686
+  - rubygem-openssl-0:2.1.2-120.module_f29+4418+a52419e1.x86_64
+  - rubygem-openssl-debuginfo-0:2.1.2-120.module_f29+4418+a52419e1.i686
+  - rubygem-openssl-debuginfo-0:2.1.2-120.module_f29+4418+a52419e1.x86_64
+  - rubygem-pg-0:1.1.4-3.module_f29+4418+a52419e1.src
+  - rubygem-pg-0:1.1.4-3.module_f29+4418+a52419e1.x86_64
+  - rubygem-pg-debuginfo-0:1.1.4-3.module_f29+4418+a52419e1.x86_64
+  - rubygem-pg-debugsource-0:1.1.4-3.module_f29+4418+a52419e1.x86_64
+  - rubygem-pg-doc-0:1.1.4-3.module_f29+4418+a52419e1.noarch
+  - rubygem-power_assert-0:1.1.3-120.module_f29+4418+a52419e1.noarch
+  - rubygem-psych-0:3.1.0-120.module_f29+4418+a52419e1.i686
+  - rubygem-psych-0:3.1.0-120.module_f29+4418+a52419e1.x86_64
+  - rubygem-psych-debuginfo-0:3.1.0-120.module_f29+4418+a52419e1.i686
+  - rubygem-psych-debuginfo-0:3.1.0-120.module_f29+4418+a52419e1.x86_64
+  - rubygem-rake-0:12.3.2-120.module_f29+4418+a52419e1.noarch
+  - rubygem-rdoc-0:6.1.0-120.module_f29+4418+a52419e1.noarch
+  - rubygem-test-unit-0:3.2.9-120.module_f29+4418+a52419e1.noarch
+  - rubygem-xmlrpc-0:0.3.0-120.module_f29+4418+a52419e1.noarch
+  - rubygems-0:3.0.3-120.module_f29+4418+a52419e1.noarch
+  - rubygems-devel-0:3.0.3-120.module_f29+4418+a52419e1.noarch
+  context: 6c81f848
+  dependencies: []
+  name: ruby
+  profiles:
+    default:
+      rpms:
+      - ruby
+  repository_memberships:
+  - dest1
+  stream: master
+  unit_id: (hidden)
+  version: 2920190529125549
+- _class: ModulemdUnit
+  arch: x86_64
+  artifacts:
+  - ruby-0:2.6.3-120.module_f29+4420+eea93459.i686
+  - ruby-0:2.6.3-120.module_f29+4420+eea93459.src
+  - ruby-0:2.6.3-120.module_f29+4420+eea93459.x86_64
+  - ruby-debuginfo-0:2.6.3-120.module_f29+4420+eea93459.i686
+  - ruby-debuginfo-0:2.6.3-120.module_f29+4420+eea93459.x86_64
+  - ruby-debugsource-0:2.6.3-120.module_f29+4420+eea93459.i686
+  - ruby-debugsource-0:2.6.3-120.module_f29+4420+eea93459.x86_64
+  - ruby-devel-0:2.6.3-120.module_f29+4420+eea93459.i686
+  - ruby-devel-0:2.6.3-120.module_f29+4420+eea93459.x86_64
+  - ruby-doc-0:2.6.3-120.module_f29+4420+eea93459.noarch
+  - ruby-libs-0:2.6.3-120.module_f29+4420+eea93459.i686
+  - ruby-libs-0:2.6.3-120.module_f29+4420+eea93459.x86_64
+  - ruby-libs-debuginfo-0:2.6.3-120.module_f29+4420+eea93459.i686
+  - ruby-libs-debuginfo-0:2.6.3-120.module_f29+4420+eea93459.x86_64
+  - rubygem-abrt-0:0.3.0-6.module_f29+3836+4592e78f.noarch
+  - rubygem-abrt-0:0.3.0-6.module_f29+3836+4592e78f.src
+  - rubygem-abrt-doc-0:0.3.0-6.module_f29+3836+4592e78f.noarch
+  - rubygem-bigdecimal-0:1.4.1-120.module_f29+4420+eea93459.i686
+  - rubygem-bigdecimal-0:1.4.1-120.module_f29+4420+eea93459.x86_64
+  - rubygem-bigdecimal-debuginfo-0:1.4.1-120.module_f29+4420+eea93459.i686
+  - rubygem-bigdecimal-debuginfo-0:1.4.1-120.module_f29+4420+eea93459.x86_64
+  - rubygem-bson-0:4.5.0-1.module_f29+4420+eea93459.src
+  - rubygem-bson-0:4.5.0-1.module_f29+4420+eea93459.x86_64
+  - rubygem-bson-debuginfo-0:4.5.0-1.module_f29+4420+eea93459.x86_64
+  - rubygem-bson-debugsource-0:4.5.0-1.module_f29+4420+eea93459.x86_64
+  - rubygem-bson-doc-0:4.5.0-1.module_f29+4420+eea93459.noarch
+  - rubygem-bundler-0:1.17.2-120.module_f29+4420+eea93459.noarch
+  - rubygem-did_you_mean-0:1.3.0-120.module_f29+4420+eea93459.noarch
+  - rubygem-io-console-0:0.4.7-120.module_f29+4420+eea93459.i686
+  - rubygem-io-console-0:0.4.7-120.module_f29+4420+eea93459.x86_64
+  - rubygem-io-console-debuginfo-0:0.4.7-120.module_f29+4420+eea93459.i686
+  - rubygem-io-console-debuginfo-0:0.4.7-120.module_f29+4420+eea93459.x86_64
+  - rubygem-irb-0:1.0.0-120.module_f29+4420+eea93459.noarch
+  - rubygem-json-0:2.1.0-120.module_f29+4420+eea93459.i686
+  - rubygem-json-0:2.1.0-120.module_f29+4420+eea93459.x86_64
+  - rubygem-json-debuginfo-0:2.1.0-120.module_f29+4420+eea93459.i686
+  - rubygem-json-debuginfo-0:2.1.0-120.module_f29+4420+eea93459.x86_64
+  - rubygem-minitest-0:5.11.3-120.module_f29+4420+eea93459.noarch
+  - rubygem-mongo-0:2.8.0-1.module_f29+4420+eea93459.noarch
+  - rubygem-mongo-0:2.8.0-1.module_f29+4420+eea93459.src
+  - rubygem-mongo-doc-0:2.8.0-1.module_f29+4420+eea93459.noarch
+  - rubygem-mysql2-0:0.5.2-3.module_f29+4420+eea93459.src
+  - rubygem-mysql2-0:0.5.2-3.module_f29+4420+eea93459.x86_64
+  - rubygem-mysql2-debuginfo-0:0.5.2-3.module_f29+4420+eea93459.x86_64
+  - rubygem-mysql2-debugsource-0:0.5.2-3.module_f29+4420+eea93459.x86_64
+  - rubygem-mysql2-doc-0:0.5.2-3.module_f29+4420+eea93459.noarch
+  - rubygem-net-telnet-0:0.2.0-120.module_f29+4420+eea93459.noarch
+  - rubygem-openssl-0:2.1.2-120.module_f29+4420+eea93459.i686
+  - rubygem-openssl-0:2.1.2-120.module_f29+4420+eea93459.x86_64
+  - rubygem-openssl-debuginfo-0:2.1.2-120.module_f29+4420+eea93459.i686
+  - rubygem-openssl-debuginfo-0:2.1.2-120.module_f29+4420+eea93459.x86_64
+  - rubygem-pg-0:1.1.4-3.module_f29+4420+eea93459.src
+  - rubygem-pg-0:1.1.4-3.module_f29+4420+eea93459.x86_64
+  - rubygem-pg-debuginfo-0:1.1.4-3.module_f29+4420+eea93459.x86_64
+  - rubygem-pg-debugsource-0:1.1.4-3.module_f29+4420+eea93459.x86_64
+  - rubygem-pg-doc-0:1.1.4-3.module_f29+4420+eea93459.noarch
+  - rubygem-power_assert-0:1.1.3-120.module_f29+4420+eea93459.noarch
+  - rubygem-psych-0:3.1.0-120.module_f29+4420+eea93459.i686
+  - rubygem-psych-0:3.1.0-120.module_f29+4420+eea93459.x86_64
+  - rubygem-psych-debuginfo-0:3.1.0-120.module_f29+4420+eea93459.i686
+  - rubygem-psych-debuginfo-0:3.1.0-120.module_f29+4420+eea93459.x86_64
+  - rubygem-rake-0:12.3.2-120.module_f29+4420+eea93459.noarch
+  - rubygem-rdoc-0:6.1.0-120.module_f29+4420+eea93459.noarch
+  - rubygem-test-unit-0:3.2.9-120.module_f29+4420+eea93459.noarch
+  - rubygem-xmlrpc-0:0.3.0-120.module_f29+4420+eea93459.noarch
+  - rubygems-0:3.0.3-120.module_f29+4420+eea93459.noarch
+  - rubygems-devel-0:3.0.3-120.module_f29+4420+eea93459.noarch
+  context: 6c81f848
+  dependencies: []
+  name: ruby
+  profiles:
+    default:
+      rpms:
+      - ruby
+  repository_memberships:
+  - dest1
+  stream: '2.6'
+  unit_id: (hidden)
+  version: 2920190529151200
+- _class: ModulemdUnit
+  arch: x86_64
+  artifacts:
+  - rust-sd-0:0.6.5-2.module_f29+5118+c475a2db.src
+  - rust-sd-debugsource-0:0.6.5-2.module_f29+5118+c475a2db.x86_64
+  - sd-0:0.6.5-2.module_f29+5118+c475a2db.x86_64
+  - sd-debuginfo-0:0.6.5-2.module_f29+5118+c475a2db.x86_64
+  context: c5ebb199
+  dependencies: []
+  name: sd
+  profiles:
+    default:
+      rpms:
+      - sd
+  repository_memberships:
+  - dest1
+  stream: rolling
+  unit_id: (hidden)
+  version: 2920190720191144
+- _class: ModulemdUnit
+  arch: x86_64
+  artifacts:
+  - rust-silver-0:1.0.7-4.module_f29+5221+f180b836.src
+  - rust-silver-debugsource-0:1.0.7-4.module_f29+5221+f180b836.x86_64
+  - silver-0:1.0.7-4.module_f29+5221+f180b836.x86_64
+  - silver-debuginfo-0:1.0.7-4.module_f29+5221+f180b836.x86_64
+  context: c5ebb199
+  dependencies: []
+  name: silver
+  profiles:
+    default:
+      rpms:
+      - silver
+  repository_memberships:
+  - dest1
+  stream: rolling
+  unit_id: (hidden)
+  version: 2920190728135623
+- _class: ModulemdUnit
+  arch: x86_64
+  artifacts:
+  - rust-skim-0:0.6.8-1.module_f29+5107+9d8bef60.src
+  - rust-skim-debugsource-0:0.6.8-1.module_f29+5107+9d8bef60.x86_64
+  - skim-0:0.6.8-1.module_f29+5107+9d8bef60.x86_64
+  - skim-debuginfo-0:0.6.8-1.module_f29+5107+9d8bef60.x86_64
+  context: c5ebb199
+  dependencies: []
+  name: skim
+  profiles:
+    default:
+      rpms:
+      - skim
+  repository_memberships:
+  - dest1
+  stream: rolling
+  unit_id: (hidden)
+  version: 2920190720171217
+- _class: ModulemdUnit
+  arch: x86_64
+  artifacts:
+  - rust-tokei-0:10.0.1-1.module_f29+5043+3b024f6d.src
+  - rust-tokei-debugsource-0:10.0.1-1.module_f29+5043+3b024f6d.x86_64
+  - tokei-0:10.0.1-1.module_f29+5043+3b024f6d.x86_64
+  - tokei-debuginfo-0:10.0.1-1.module_f29+5043+3b024f6d.x86_64
+  context: c5ebb199
+  dependencies: []
+  name: tokei
+  profiles:
+    default:
+      rpms:
+      - tokei
+  repository_memberships:
+  - dest1
+  stream: rolling
+  unit_id: (hidden)
+  version: 2920190714161140
+- _class: ModulemdUnit
+  arch: x86_64
+  artifacts:
+  - skychart-0:4.1.1-3.3925svn.module_f29+4085+3bdaa607.src
+  - skychart-0:4.1.1-3.3925svn.module_f29+4085+3bdaa607.x86_64
+  - skychart-data-dso-0:4.1.1-3.3925svn.module_f29+4085+3bdaa607.noarch
+  - skychart-data-stars-0:4.1.1-3.3925svn.module_f29+4085+3bdaa607.noarch
+  - skychart-debuginfo-0:4.1.1-3.3925svn.module_f29+4085+3bdaa607.x86_64
+  - skychart-debugsource-0:4.1.1-3.3925svn.module_f29+4085+3bdaa607.x86_64
+  - skychart-doc-0:4.1.1-3.3925svn.module_f29+4085+3bdaa607.noarch
+  context: 6c81f848
+  dependencies: []
+  name: skychart
+  profiles:
+    additional-dso:
+      description: Core program, documentation and additional Deep Sky catalogs.
+      rpms:
+      - skychart
+      - skychart-data-dso
+      - skychart-doc
+    additional-stars:
+      description: Core program, documentation and additional star catalogs.
+      rpms:
+      - skychart
+      - skychart-data-stars
+      - skychart-doc
+    default:
+      description: Minimal installation with default catalogs and documentation.
+      rpms:
+      - skychart
+      - skychart-doc
+    full:
+      description: Core program, documentation and all available additional catalogs.
+      rpms:
+      - skychart
+      - skychart-data-dso
+      - skychart-data-stars
+      - skychart-doc
+  repository_memberships:
+  - dest1
+  stream: devel
+  unit_id: (hidden)
+  version: 2920190427155219
+- _class: ModulemdUnit
+  arch: x86_64
+  artifacts:
+  - standard-test-roles-0:4.3-1.module_f29+5936+702ded50.noarch
+  - standard-test-roles-0:4.3-1.module_f29+5936+702ded50.src
+  - standard-test-roles-inventory-docker-0:4.3-1.module_f29+5936+702ded50.noarch
+  - standard-test-roles-inventory-qemu-0:4.3-1.module_f29+5936+702ded50.noarch
+  context: 6c81f848
+  dependencies: []
+  name: standard-test-roles
+  profiles:
+    default:
+      description: A standard installation.
+      rpms:
+      - standard-test-roles
+    provisioner-qemu:
+      description: A standalone provisioner for qemu
+      rpms:
+      - standard-test-roles-inventory-qemu
+  repository_memberships:
+  - dest1
+  stream: '3.0'
+  unit_id: (hidden)
+  version: 2920190815111247
+- _class: ModulemdUnit
+  arch: x86_64
+  artifacts:
+  - stratis-cli-0:1.0.2-1.module_f29+4063+cc7eea31.src
+  - stratis-cli-0:1.0.2-1.module_f29+4063+cc7eea31.x86_64
+  - stratisd-0:1.0.4-1.module_f29+4199+c4ae1ed0.src
+  - stratisd-0:1.0.4-1.module_f29+4199+c4ae1ed0.x86_64
+  - stratisd-debuginfo-0:1.0.4-1.module_f29+4199+c4ae1ed0.x86_64
+  - stratisd-debugsource-0:1.0.4-1.module_f29+4199+c4ae1ed0.x86_64
+  context: b8a06959
+  dependencies: []
+  name: stratis
+  profiles:
+    default:
+      rpms:
+      - stratis-cli
+      - stratisd
+  repository_memberships:
+  - dest1
+  stream: '1'
+  unit_id: (hidden)
+  version: 2920190507073310
+- _class: ModulemdUnit
+  arch: x86_64
+  artifacts:
+  - zola-0:0.8.0-3.module_f29+5156+8ed26fa4.src
+  - zola-0:0.8.0-3.module_f29+5156+8ed26fa4.x86_64
+  - zola-debuginfo-0:0.8.0-3.module_f29+5156+8ed26fa4.x86_64
+  - zola-debugsource-0:0.8.0-3.module_f29+5156+8ed26fa4.x86_64
+  context: c5ebb199
+  dependencies: []
+  name: zola
+  profiles:
+    default:
+      rpms:
+      - zola
+  repository_memberships:
+  - dest1
+  stream: rolling
+  unit_id: (hidden)
+  version: 2920190721175731
+- _class: RpmUnit
+  arch: noarch
+  cdn_path: /content/origin/rpms/walrus/5.21/1/f78fb195/walrus-5.21-1.noarch.rpm
+  filename: walrus-5.21-1.noarch.rpm
+  md5sum: 6a3eec6d45e0ea80eab05870bf7a8d4b
+  name: walrus
+  provides:
+  - _class: RpmDependency
+    epoch: '0'
+    flags: EQ
+    name: walrus
+    release: '1'
+    version: '5.21'
+  release: '1'
+  repository_memberships:
+  - all-rpm-content
+  - dest2
+  requires:
+  - _class: RpmDependency
+    epoch: '0'
+    flags: LE
+    name: rpmlib(CompressedFileNames)
+    release: '1'
+    version: 3.0.4
+  - _class: RpmDependency
+    epoch: '0'
+    flags: LE
+    name: rpmlib(PayloadFilesHavePrefix)
+    release: '1'
+    version: '4.0'
+  sha1sum: 8dea2b64fc52062d79d5f96ba6415bffae4d2153
+  sha256sum: e837a635cc99f967a70f34b268baa52e0f412c1502e08e924ff5b09f1f9573f2
+  signing_key: f78fb195
+  sourcerpm: walrus-5.21-1.src.rpm
+  unit_id: (hidden)
+  version: '5.21'
+- _class: RpmUnit
+  arch: src
+  cdn_path: /content/origin/rpms/test-srpm01/1.0/1/none/test-srpm01-1.0-1.src.rpm
+  filename: test-srpm01-1.0-1.src.rpm
+  md5sum: ba9257ced24f77f4d777e399e67924f5
+  name: test-srpm01
+  provides: []
+  release: '1'
+  repository_memberships:
+  - all-rpm-content
+  - dest1
+  requires:
+  - _class: RpmDependency
+    epoch: '0'
+    flags: LE
+    name: rpmlib(FileDigests)
+    release: '1'
+    version: 4.6.0
+  - _class: RpmDependency
+    epoch: '0'
+    flags: LE
+    name: rpmlib(CompressedFileNames)
+    release: '1'
+    version: 3.0.4
+  sha1sum: d9629c034fed3a2f47870fc6fdc78a30c5556e1d
+  sha256sum: 54cc4713fe704dfc7a4fd5b398f834ceb6a692f53b0c6aefaf89d88417b4c51d
+  unit_id: (hidden)
+  version: '1.0'
+- _class: YumRepoMetadataFileUnit
+  data_type: productid
+  repository_memberships:
+  - dest1
+  sha256sum: 5b290c0e700df6f4b4669d9e7366f6aa4b6817f96e1dcb9b81284409ae640972
+  unit_id: (hidden)

--- a/tests/push/test_association_race.py
+++ b/tests/push/test_association_race.py
@@ -1,0 +1,110 @@
+import functools
+import os
+from unittest import mock
+
+import pytest
+import attr
+
+from pushsource import Source, FilePushItem
+from pubtools.pulplib import FileUnit
+
+from pubtools._pulp.tasks.push import entry_point
+from pubtools._pulp.tasks.push.phase.associate import Associate
+from .util import hide_unit_ids
+
+
+def test_association_race(
+    fake_controller,
+    data_path,
+    fake_push,
+    fake_state_path,
+    command_tester,
+    stub_collector,
+    caplog,
+):
+    """
+    We check that even if some items are moved from one repo to another during
+    the association phase, they still get correctly copied into all desired
+    repos.
+    """
+
+    # Sanity check that the Pulp server is, initially, empty.
+    client = fake_controller.client
+    assert list(client.search_content()) == []
+
+    # Set it up to find content from our staging dir, which contains a mixture
+    # of just about every content type
+    stagedir = os.path.join(data_path, "staged-mixed")
+
+    # Modify the constructor for Associate phase so that it changes the
+    # repository of one rpm item from in_queue (walrus rpm) to one that does
+    # not contain it
+    old_iter = Associate.iter_for_associate
+
+    def new_iter(self):
+        for batch in old_iter(self):
+            # find walrus rpm in batch
+            indices = [
+                x[0]
+                for x in enumerate(batch)
+                if getattr(x[1], "rpm_nvr", ()) == ("walrus", "5.21", "1")
+            ]
+            # modify (each) walrus package, so that it is presumed to be in
+            # an incorrect repository
+            for index in indices:
+                walrus_item = batch[index]
+                batch[index] = attr.evolve(
+                    walrus_item,
+                    pulp_unit=attr.evolve(
+                        walrus_item.pulp_unit, repository_memberships=["dest1"]
+                    ),
+                )
+            yield batch
+
+    with mock.patch(
+        "pubtools._pulp.tasks.push.phase.Associate.iter_for_associate", new_iter
+    ):
+        compare_extra = {
+            "pulp.yaml": {
+                "filename": fake_state_path,
+                "normalize": hide_unit_ids,
+            }
+        }
+        args = [
+            "",
+            "--skip",
+            "publish",
+            "--source",
+            "staged:%s" % stagedir,
+            "--allow-unsigned",
+            "--pulp-url",
+            "https://pulp.example.com/",
+        ]
+
+        run = functools.partial(entry_point, cls=lambda: fake_push)
+
+        # It should be able to run without crashing.
+        command_tester.test(
+            run,
+            args,
+            compare_plaintext=False,
+            compare_jsonl=False,
+            # This will ensure the Pulp state matches the baseline.
+            compare_extra=compare_extra,
+        )
+
+    # We can determine that publish didn't occur by checking all
+    # encountered states of push items.
+    all_states = set([item["state"] for item in stub_collector])
+
+    # Everything should be either PENDING (before upload to Pulp)
+    # or EXISTS (after upload), but nothing should be PUSHED since
+    # publish didn't happen.
+    assert all_states == set(["PENDING", "EXISTS"])
+
+    # Assert there was exactly one retry of association.
+    msg = "Retrying association for 1 item(s). Attempt 1/2"
+    assert msg in caplog.text
+
+    msg = "Retrying association for 1 item(s). Attempt 2/2"
+    assert msg not in caplog.text


### PR DESCRIPTION
During the association phase of push we first list the origin repos and then a while later we attempt to copy the items from origin repos to all other desired repos. Since the items can meanwhile be moved between repos, the association can fail on missing items.

We fix this by retrying the copy operation with up-to-date data from pulp.
