### PR TITLE
Log URLs/ARLs during Akamai cache flush

### DIFF
--- a/pubtools/_pulp/cdn.py
+++ b/pubtools/_pulp/cdn.py
@@ -88,7 +88,7 @@ class CdnClient(object):
     def _get_headers_for_path(self, path, headers):
         url = os.path.join(self._url, path)
 
-        LOG.info("Getting headers %s for %s", list(headers.values()), url)
+        LOG.debug("Getting headers %s for %s", list(headers.values()), url)
 
         out = self._executor.submit(self._head, url, headers=headers)
         out = f_map(

--- a/pubtools/_pulp/tasks/common.py
+++ b/pubtools/_pulp/tasks/common.py
@@ -62,10 +62,18 @@ class CDNCache(FastPurgeClientService, CdnClientService):
                     )
                     to_flush.extend(arl_fts)
 
-            flush = f_flat_map(f_sequence(to_flush), self.fastpurge_client.purge_by_url)
+            flush = f_flat_map(
+                f_sequence(to_flush), lambda urls: self.purge_urls(repo.id, urls)
+            )
             return f_map(flush, lambda _: repo)
 
         return [purge_repo(r) for r in repos if r.relative_url]
+
+    def purge_urls(self, repo_id: str, urls: list):
+        LOG.info("Flushing cache for %s:", repo_id)
+        for url in sorted(urls):
+            LOG.info("   %s", url)
+        return self.fastpurge_client.purge_by_url(urls)
 
 
 class UdCache(UdCacheClientService):

--- a/tests/cdn/test_cdn_client.py
+++ b/tests/cdn/test_cdn_client.py
@@ -7,7 +7,7 @@ from pubtools._pulp.cdn import CdnClient
 
 def test_format_arl_template(requests_mock, caplog):
     """Client formats ARL template with live TTL."""
-    caplog.set_level(logging.INFO)
+    caplog.set_level(logging.DEBUG)
 
     # test templates also with invalid template which should be skipped from processing
     templates = [
@@ -50,12 +50,13 @@ def test_format_arl_template(requests_mock, caplog):
     assert sorted(fetched_urls) == [url for url, _ in url_ttl]
 
     # It should log 'Getting headers...' for each path
-    assert caplog.messages == [
+    for message in [
         "Getting headers ['akamai-x-get-cache-key'] for "
         "https://cdn.example.com/content/foo/test-path-1/repomd.xml",
         "Getting headers ['akamai-x-get-cache-key'] for "
         "https://cdn.example.com/content/foo/test-path-2/other-file.xml",
-    ]
+    ]:
+        assert message in caplog.messages
 
 
 def test_retries(requests_mock):
@@ -99,7 +100,7 @@ def test_retries(requests_mock):
 def test_logs(requests_mock, caplog):
     """Client produces logs before/after requests."""
 
-    caplog.set_level(logging.INFO)
+    caplog.set_level(logging.DEBUG)
 
     templates = [
         "/fake/template-1/{ttl}/{path}",
@@ -118,12 +119,13 @@ def test_logs(requests_mock, caplog):
         arl = [item.result() for item in as_completed(arls_ft)][0]
 
     # It should have logged what it was doing and what failed
-    assert caplog.messages == [
+    for message in [
         "Getting headers ['akamai-x-get-cache-key'] for "
         "https://cdn.example.com/content/foo/test-path-1/some-file",
         "Requesting header ['akamai-x-get-cache-key'] failed: 500 Server Error: None "
         "for url: https://cdn.example.com/content/foo/test-path-1/some-file",
-    ]
+    ]:
+        assert message in caplog.messages
 
     # Eventually it should fallback to default ttl value
     assert arl == "/fake/template-1/30d/content/foo/test-path-1/some-file"

--- a/tests/logs/clear_repo/test_clear_repo/test_clear_file_repo.txt
+++ b/tests/logs/clear_repo/test_clear_repo/test_clear_file_repo.txt
@@ -10,4 +10,7 @@
 [    INFO] Flush UD cache: started
 [    INFO] Flush UD cache: finished
 [    INFO] Flush CDN cache: started
+[    INFO] Flushing cache for some-filerepo:
+[    INFO]    https://cdn.example.com/some/publish/url/mutable1
+[    INFO]    https://cdn.example.com/some/publish/url/mutable2
 [    INFO] Flush CDN cache: finished

--- a/tests/logs/clear_repo/test_clear_repo/test_clear_yum_repo.txt
+++ b/tests/logs/clear_repo/test_clear_repo/test_clear_yum_repo.txt
@@ -11,4 +11,6 @@
 [    INFO] UD cache flush is not enabled.
 [    INFO] Flush UD cache: finished
 [    INFO] Flush CDN cache: started
+[    INFO] Flushing cache for some-yumrepo:
+[    INFO]    https://cdn.example2.com/some/publish/url/repomd.xml
 [    INFO] Flush CDN cache: finished

--- a/tests/logs/delete/test_delete_advisory/test_delete_advisory.txt
+++ b/tests/logs/delete/test_delete_advisory/test_delete_advisory.txt
@@ -52,6 +52,8 @@
 [    INFO] Publishing some-yumrepo
 [    INFO] Publish: finished
 [    INFO] Flush CDN cache: started
+[    INFO] Flushing cache for some-yumrepo:
+[    INFO]    https://cdn.example2.com/some/publish/url/repomd.xml
 [    INFO] Flush CDN cache: finished
 [    INFO] Set cdn_published: started
 [    INFO] Set cdn_published: finished

--- a/tests/logs/delete/test_delete_advisory/test_delete_advisory_in_multiple_repos.txt
+++ b/tests/logs/delete/test_delete_advisory/test_delete_advisory_in_multiple_repos.txt
@@ -22,6 +22,8 @@
 [    INFO] Publishing some-yumrepo
 [    INFO] Publish: finished
 [    INFO] Flush CDN cache: started
+[    INFO] Flushing cache for some-yumrepo:
+[    INFO]    https://cdn.example2.com/some/publish/url/repomd.xml
 [    INFO] Flush CDN cache: finished
 [    INFO] Set cdn_published: started
 [    INFO] Set cdn_published: finished

--- a/tests/logs/delete/test_delete_advisory/test_delete_advisory_no_repos_provided.txt
+++ b/tests/logs/delete/test_delete_advisory/test_delete_advisory_no_repos_provided.txt
@@ -24,6 +24,10 @@
 [    INFO] Publishing some-yumrepo
 [    INFO] Publish: finished
 [    INFO] Flush CDN cache: started
+[    INFO] Flushing cache for other-yumrepo:
+[    INFO]    https://cdn.example2.com/other/publish/url/repomd.xml
+[    INFO] Flushing cache for some-yumrepo:
+[    INFO]    https://cdn.example2.com/some/publish/url/repomd.xml
 [    INFO] Flush CDN cache: finished
 [    INFO] Set cdn_published: started
 [    INFO] Set cdn_published: finished

--- a/tests/logs/delete/test_delete_packages/test_delete_files.txt
+++ b/tests/logs/delete/test_delete_packages/test_delete_files.txt
@@ -17,6 +17,9 @@
 [    INFO] Publishing some-filerepo
 [    INFO] Publish: finished
 [    INFO] Flush CDN cache: started
+[    INFO] Flushing cache for some-filerepo:
+[    INFO]    https://cdn.example2.com/some/publish/url/mutable1
+[    INFO]    https://cdn.example2.com/some/publish/url/mutable2
 [    INFO] Flush CDN cache: finished
 [    INFO] Set cdn_published: started
 [    INFO] Set cdn_published: finished

--- a/tests/logs/delete/test_delete_packages/test_delete_modules.txt
+++ b/tests/logs/delete/test_delete_packages/test_delete_modules.txt
@@ -39,6 +39,8 @@
 [    INFO] Publishing some-yumrepo
 [    INFO] Publish: finished
 [    INFO] Flush CDN cache: started
+[    INFO] Flushing cache for some-yumrepo:
+[    INFO]    https://cdn.example2.com/some/publish/url/repomd.xml
 [    INFO] Flush CDN cache: finished
 [    INFO] Set cdn_published: started
 [    INFO] Set cdn_published: finished

--- a/tests/logs/delete/test_delete_packages/test_delete_rpms.txt
+++ b/tests/logs/delete/test_delete_packages/test_delete_rpms.txt
@@ -39,6 +39,10 @@
 [    INFO] Publishing some-yumrepo
 [    INFO] Publish: finished
 [    INFO] Flush CDN cache: started
+[    INFO] Flushing cache for other-yumrepo:
+[    INFO]    https://cdn.example2.com/other/publish/url/repomd.xml
+[    INFO] Flushing cache for some-yumrepo:
+[    INFO]    https://cdn.example2.com/some/publish/url/repomd.xml
 [    INFO] Flush CDN cache: finished
 [    INFO] Set cdn_published: started
 [    INFO] Set cdn_published: finished

--- a/tests/logs/delete/test_delete_packages/test_delete_unsigned_rpms.txt
+++ b/tests/logs/delete/test_delete_packages/test_delete_unsigned_rpms.txt
@@ -26,6 +26,8 @@
 [    INFO] Publishing some-yumrepo
 [    INFO] Publish: finished
 [    INFO] Flush CDN cache: started
+[    INFO] Flushing cache for some-yumrepo:
+[    INFO]    https://cdn.example2.com/some/publish/url/repomd.xml
 [    INFO] Flush CDN cache: finished
 [    INFO] Set cdn_published: started
 [    INFO] Set cdn_published: finished

--- a/tests/logs/fix_cves/test_fix_cves/test_fix_cves_with_cache_cleanup.txt
+++ b/tests/logs/fix_cves/test_fix_cves/test_fix_cves_with_cache_cleanup.txt
@@ -18,6 +18,12 @@
 [    INFO] Publishing repo
 [    INFO] Publish: finished
 [    INFO] Flush CDN cache: started
+[    INFO] Flushing cache for all-rpm-content:
+[    INFO]    https://cdn.example.com/content/unit/1/all-rpm/mutable1
+[    INFO]    https://cdn.example.com/content/unit/1/all-rpm/mutable2
+[    INFO] Flushing cache for repo:
+[    INFO]    https://cdn.example.com/content/unit/1/client/mutable1
+[    INFO]    https://cdn.example.com/content/unit/1/client/mutable2
 [    INFO] Flush CDN cache: finished
 [    INFO] Set cdn_published: started
 [    INFO] Set cdn_published: finished

--- a/tests/logs/publish/test_publish/test_repo_publish_cache_cleanup.txt
+++ b/tests/logs/publish/test_publish/test_repo_publish_cache_cleanup.txt
@@ -4,6 +4,9 @@
 [    INFO] Publishing repo1
 [    INFO] Publish: finished
 [    INFO] Flush CDN cache: started
+[    INFO] Flushing cache for repo1:
+[    INFO]    https://cdn.example.com/content/unit/1/client/mutable1
+[    INFO]    https://cdn.example.com/content/unit/1/client/mutable2
 [    INFO] Flush CDN cache: finished
 [    INFO] Set cdn_published: started
 [    INFO] Set cdn_published: finished

--- a/tests/logs/publish/test_publish/test_repo_publish_cache_cleanup_with_arl.txt
+++ b/tests/logs/publish/test_publish/test_repo_publish_cache_cleanup_with_arl.txt
@@ -4,6 +4,11 @@
 [    INFO] Publishing repo1
 [    INFO] Publish: finished
 [    INFO] Flush CDN cache: started
+[    INFO] Flushing cache for repo1:
+[    INFO]    /foo/fake-ttl/content/unit/1/client/mutable1
+[    INFO]    /foo/fake-ttl/content/unit/1/client/mutable2
+[    INFO]    https://cdn.example.com/content/unit/1/client/mutable1
+[    INFO]    https://cdn.example.com/content/unit/1/client/mutable2
 [    INFO] Flush CDN cache: finished
 [    INFO] Set cdn_published: started
 [    INFO] Set cdn_published: finished


### PR DESCRIPTION
Even though cache flush logs enabled right now are quite verbose, they're missing the most vital info: for which URLs and ARLs did we flush cache.

Log those at INFO level, and decrease a less useful log down to DEBUG level.