### PR TITLE
Make --cdn-arl-template argument work as expected by Pub [RHELDST-20512]

### DIFF
--- a/pubtools/_pulp/services/cdn.py
+++ b/pubtools/_pulp/services/cdn.py
@@ -45,6 +45,13 @@ class CdnClientService(Service):
             "--cdn-arl-template",
             help="ARL template used for flushing cache by ARL",
             nargs="*",
+            # FIXME: combination of nargs='*' and action='append' will
+            # generate a list of lists, but we just want one flat list.
+            # We flatten this elsewhere.
+            #
+            # When minimum python is >= 3.8, replace this with action="extend"
+            action="append",
+            default=[],
         )
 
     @property
@@ -61,6 +68,11 @@ class CdnClientService(Service):
 
     def __get_instance(self):
         args = self._service_args
+
+        # FIXME: see above comment about action="extend" for python >= 3.8
+        # This flattens the list-of-list.
+        args.cdn_arl_template = [x for y in args.cdn_arl_template for x in y]
+
         if not args.cdn_url:
             # disable requests made to CDN
             return None

--- a/tests/logs/publish/test_publish/test_repo_publish_cache_cleanup_with_arl.txt
+++ b/tests/logs/publish/test_publish/test_repo_publish_cache_cleanup_with_arl.txt
@@ -5,6 +5,10 @@
 [    INFO] Publish: finished
 [    INFO] Flush CDN cache: started
 [    INFO] Flushing cache for repo1:
+[    INFO]    /bar/fake-ttl/content/unit/1/client/mutable1
+[    INFO]    /bar/fake-ttl/content/unit/1/client/mutable2
+[    INFO]    /baz/fake-ttl/content/unit/1/client/mutable1
+[    INFO]    /baz/fake-ttl/content/unit/1/client/mutable2
 [    INFO]    /foo/fake-ttl/content/unit/1/client/mutable1
 [    INFO]    /foo/fake-ttl/content/unit/1/client/mutable2
 [    INFO]    https://cdn.example.com/content/unit/1/client/mutable1

--- a/tests/publish/test_publish.py
+++ b/tests/publish/test_publish.py
@@ -268,6 +268,9 @@ def test_repo_publish_cache_cleanup_with_arl(command_tester):
                 "https://cdn.example.com/",
                 "--cdn-arl-template",
                 "/foo/{ttl}/{path}",
+                "--cdn-arl-template",
+                "/bar/{ttl}/{path}",
+                "/baz/{ttl}/{path}",
                 "--cdn-cert",
                 "/some/path/to/cert",
                 "--cdn-key",
@@ -279,6 +282,10 @@ def test_repo_publish_cache_cleanup_with_arl(command_tester):
     assert [hist.repository.id for hist in fake_pulp.publish_history] == ["repo1"]
     # flushed the urls and the arls
     assert sorted(fake_publish.fastpurge_client.purged_urls) == [
+        "/bar/fake-ttl/content/unit/1/client/mutable1",
+        "/bar/fake-ttl/content/unit/1/client/mutable2",
+        "/baz/fake-ttl/content/unit/1/client/mutable1",
+        "/baz/fake-ttl/content/unit/1/client/mutable2",
         "/foo/fake-ttl/content/unit/1/client/mutable1",
         "/foo/fake-ttl/content/unit/1/client/mutable2",
         "https://cdn.example.com/content/unit/1/client/mutable1",


### PR DESCRIPTION
The --cdn-arl-template argument can be used to pass multiple ARL templates, which in practice is needed.

The argument was declared as nargs='*', which means the way it's expected to be used is:

    --cdn-arl-template arg1 arg2 arg3 ...

However, the usual convention[1] for list-style arguments in our tools, and the one expected by Pub, is instead:

    --cdn-arl-template arg1 \
    --cdn-arl-template arg2 \
    --cdn-arl-template arg3 ...

So that's how arguments were being passed.

Problem: the latter argument style was accepted, but *only the last argument had any effect*. This meant, for any target configured with multiple ARL templates, only the last one in the list was being used.

Fix the argument handling to support the usual convention (while remaining backwards-compatible).

This issue has always been present but could be missed until now because:

- pubtools-pulp never logged the URLs/ARLs flushed, so the mistake can't be noticed from the logs; fixed by [2]

- there was no test covering the case of multiple ARL templates; fixed here

- technically the need to flush by multiple ARLs has not been particularly important until recenty, when more CDN origins have been integrated into each environment.

[1] https://release-engineering.github.io/pubtools/devguide.html#arguments-with-multiple-values
[2] https://github.com/release-engineering/pubtools-pulp/pull/240