### PR TITLE
Implement copy_repo entry point [RHELDST-549]

### DIFF
--- a/pubtools/_pulp/tasks/common.py
+++ b/pubtools/_pulp/tasks/common.py
@@ -6,13 +6,20 @@ import sys
 
 import attr
 from more_executors.futures import f_flat_map, f_map, f_return, f_sequence
-from pubtools.pulplib import (ErratumUnit, FileUnit, ModulemdUnit,
-                              PublishOptions, RpmUnit)
-from pushsource import (ErratumPushItem, FilePushItem, ModuleMdPushItem,
-                        RpmPushItem)
+from pubtools.pulplib import (
+    ErratumUnit,
+    FileUnit,
+    ModulemdUnit,
+    PublishOptions,
+    RpmUnit,
+)
+from pushsource import ErratumPushItem, FilePushItem, ModuleMdPushItem, RpmPushItem
 
-from pubtools._pulp.services import (CdnClientService, FastPurgeClientService,
-                                     UdCacheClientService)
+from pubtools._pulp.services import (
+    CdnClientService,
+    FastPurgeClientService,
+    UdCacheClientService,
+)
 from pubtools._pulp.task import PulpTask
 
 from ..hooks import pm

--- a/pubtools/_pulp/tasks/copy_repo.py
+++ b/pubtools/_pulp/tasks/copy_repo.py
@@ -1,0 +1,202 @@
+import logging
+from functools import partial
+
+import attr
+from more_executors.futures import f_map, f_sequence
+from pubtools.pulplib import (ContainerImageRepository, Criteria, ErratumUnit,
+                              FileUnit, ModulemdUnit, RpmUnit)
+
+from pubtools._pulp.arguments import SplitAndExtend
+from pubtools._pulp.services import CollectorService, PulpClientService
+from pubtools._pulp.task import PulpTask
+from pubtools._pulp.tasks.common import PulpRepositoryOperation
+
+step = PulpTask.step
+
+LOG = logging.getLogger("pubtools.pulp")
+
+
+@attr.s(slots=True)
+class RepoCopy(object):
+    """Represents a copy of a single repo."""
+
+    tasks = attr.ib()
+    """The completed Pulp tasks for copying."""
+
+    repo = attr.ib()
+    """The repo to which content was copied."""
+
+
+class CopyRepo(CollectorService, PulpClientService, PulpRepositoryOperation):
+    @property
+    def content_type(self):
+        # Only return non-None if there were really any types given.
+        # Otherwise, return None to let library defaults apply
+        c = self.args.content_type or None
+        # Normalize content types (e.g., "ISO" -> "iso").
+        if c:
+            c = [t.lower() for t in c]
+        return c
+
+    @property
+    def repo_pairs(self):
+        out = []
+        for pair in self.args.repopairs:
+            pair = list(map(str, pair.split(",")))
+            if not len(pair) == 2 or any([not r_id.strip() for r_id in pair]):
+                self.fail(
+                    "Pair(s) must contain two repository IDs, source and destination. Got: %s",
+                    pair,
+                )
+            out.append(pair)
+        return out
+
+    def add_args(self):
+        super(CopyRepo, self).add_args()
+
+        self.parser.add_argument(
+            "--content-type",
+            help="copy only content of these comma-separated type(s). e.g. --content-type=(rpm, srpm, modulemd, iso, erratum)",
+            type=str,
+            action=SplitAndExtend,
+            split_on=",",
+        )
+        self.parser.add_argument(
+            "repopairs",
+            help="repository pair(s) (source, destination) to be copied. e.g. repo-A,repo-B repo-C,repo-D",
+            type=str,
+            nargs="+",
+        )
+
+    @step("Check repos")
+    def get_repos(self):
+        # Returns all repo pairs to be operated on by this task.
+        # Eagerly loads the repos so we fail early if the user passed any nonexistent
+        # repo.
+        repo_ids = []
+        found_repos = []
+        repo_pairs = []
+
+        # Eagerly load all repos to fail early if the user passed any nonexistent repo.
+        for id_pair in self.repo_pairs:
+            # We'll need a flat list of given IDs later.
+            repo_ids.extend(id_pair)
+
+            search = self.pulp_client.search_repository(Criteria.with_id(id_pair))
+
+            src = None
+            dest = None
+            for repo in search.result():
+                # We'll need a flat list of all search results later.
+                found_repos.append(repo)
+
+                if repo.id == id_pair[0]:
+                    src = repo
+                if repo.id == id_pair[1]:
+                    dest = repo
+
+            repo_pairs.append((src, dest))
+
+        # Bail out if user requested repos which don't exist
+        missing = set(repo_ids) - {repo.id for repo in found_repos}
+        missing = sorted(list(missing))
+        if missing:
+            self.fail("Requested repo(s) don't exist: %s", ", ".join(missing))
+
+        # Bail out if we'd be processing any container image repos.
+        # We don't support this now because:
+        #
+        # - recording push items isn't implemented yet and it's not clear
+        #   how to implement it (as we traditionally used docker-image-*.tar.gz
+        #   filenames from brew as push item filename, but those aren't available
+        #   in pulp metadata)
+        #
+        # - no known use-case for copying them
+        container_repo_ids = sorted(
+            [
+                repo.id
+                for repo in found_repos
+                if isinstance(repo, ContainerImageRepository)
+            ]
+        )
+        if container_repo_ids:
+            self.fail(
+                "Container image repo(s) provided, not supported: %s"
+                % ", ".join(sorted(container_repo_ids))
+            )
+
+        return repo_pairs
+
+    @step("Copy content")
+    def copy_content(self, src_repo, dest_repo):
+        futures = []
+        content_types = self.content_type or ["None"]
+        for t in content_types:
+            crit = None
+            if t == "iso":
+                crit = Criteria.with_unit_type(FileUnit)
+            if t in ("rpm", "srpm"):
+                crit = Criteria.with_unit_type(RpmUnit)
+            if t == "erratum":
+                crit = Criteria.with_unit_type(ErratumUnit)
+            if t == "modulemd":
+                crit = Criteria.with_unit_type(ModulemdUnit)
+
+            f = self.pulp_client.copy_content(src_repo, dest_repo, criteria=crit)
+            f = f_map(f, partial(RepoCopy, repo=dest_repo))
+            f = f_map(f, self.log_copy)
+            futures.append(f)
+
+        return futures
+
+    def run(self):
+        # Get a list of repo pairs we'll be dealing with.
+        # This is blocking so we'll fail early on missing/bad repos.
+        repo_pairs = self.get_repos()
+
+        # Start copying repos.
+        repos_to_flush = []
+        repo_copies_fs = []
+
+        for pair in repo_pairs:
+            repo_copies_fs.extend(self.copy_content(pair[0], pair[1]))
+
+            # We shouldn't need to flush the source repos, just the updated dest.
+            repos_to_flush.append(pair[1])
+
+        # As copying completes, record pushitem info on what was copied.
+        # We don't have to wait on this before continuing.
+        to_await = self.record_push_items(repo_copies_fs, "PUSHED")
+
+        # Don't need the repo copying tasks for anything more.
+        repos_fs = [f_map(f, lambda cr: cr.repo) for f in repo_copies_fs]
+
+        # Now move repos into the desired state:
+
+        # They should be published.
+        publish_fs = self.publish(repos_fs)
+
+        # Wait for all repo publishes to complete before continuing.
+        # Why: cache flush is what makes changes visible, and we want that to be
+        # as near atomic as we can get (i.e. changes appear in every repo "at once",
+        # rather than as each repo is published).
+        f_sequence(publish_fs).result()
+
+        # They should have UD cache flushed.
+        to_await.extend(self.flush_ud(repos_to_flush))
+
+        # They should have CDN cache flushed.
+        to_await.extend(self.flush_cdn(repos_to_flush))
+
+        # Now make sure we wait for everything to finish.
+        for f in to_await:
+            f.result()
+
+
+def entry_point(cls=CopyRepo):
+    with cls() as instance:
+        instance.main()
+
+
+def doc_parser():
+    return CopyRepo().parser

--- a/pubtools/_pulp/tasks/copy_repo.py
+++ b/pubtools/_pulp/tasks/copy_repo.py
@@ -3,8 +3,14 @@ from functools import partial
 
 import attr
 from more_executors.futures import f_map, f_sequence
-from pubtools.pulplib import (ContainerImageRepository, Criteria, ErratumUnit,
-                              FileUnit, ModulemdUnit, RpmUnit)
+from pubtools.pulplib import (
+    ContainerImageRepository,
+    Criteria,
+    ErratumUnit,
+    FileUnit,
+    ModulemdUnit,
+    RpmUnit,
+)
 
 from pubtools._pulp.arguments import SplitAndExtend
 from pubtools._pulp.services import CollectorService, PulpClientService

--- a/pubtools/_pulp/tasks/delete.py
+++ b/pubtools/_pulp/tasks/delete.py
@@ -1,32 +1,25 @@
 import logging
 import re
 import sys
-import attr
-
 from functools import partial
 
-from more_executors.futures import (
-    f_map,
-    f_flat_map,
-    f_zip,
-    f_return,
-    f_sequence,
-)
-from pushsource import FilePushItem, ModuleMdPushItem, RpmPushItem
+import attr
+from more_executors.futures import f_flat_map, f_map, f_return, f_sequence, f_zip
 from pubtools.pulplib import (
     Criteria,
-    Matcher,
-    RpmUnit,
-    ModulemdUnit,
-    FileUnit,
     ErratumUnit,
+    FileUnit,
+    Matcher,
+    ModulemdUnit,
+    RpmUnit,
 )
+from pushsource import FilePushItem, ModuleMdPushItem, RpmPushItem
 
-from pubtools._pulp.services.pulp import PulpClientService
+from pubtools._pulp.arguments import SplitAndExtend
 from pubtools._pulp.services.collector import CollectorService
+from pubtools._pulp.services.pulp import PulpClientService
 from pubtools._pulp.task import PulpTask
 from pubtools._pulp.tasks.common import Publisher
-from pubtools._pulp.arguments import SplitAndExtend
 
 LOG = logging.getLogger("pubtools.pulp")
 

--- a/setup.py
+++ b/setup.py
@@ -47,6 +47,7 @@ setup(
             "pubtools-pulp-push = pubtools._pulp.tasks.push:entry_point",
             "pubtools-pulp-fix-cves = pubtools._pulp.tasks.fix_cves:entry_point",
             "pubtools-pulp-delete = pubtools._pulp.tasks.delete:entry_point",
+            "pubtools-pulp-copy-repo = pubtools._pulp.tasks.copy_repo:entry_point",
         ]
     },
     project_urls={

--- a/tests/copy_repo/test_copy_repo.py
+++ b/tests/copy_repo/test_copy_repo.py
@@ -1,0 +1,420 @@
+from more_executors.futures import f_return
+from pubtools.pulplib import (Client, ContainerImageRepository, ErratumUnit,
+                              FakeController, FileRepository, FileUnit,
+                              ModulemdUnit, RpmUnit, YumRepository)
+
+import pubtools._pulp.tasks.copy_repo
+from pubtools._pulp.tasks.copy_repo import CopyRepo
+from pubtools._pulp.ud import UdCacheClient
+
+
+class FakeUdCache(object):
+    def __init__(self):
+        self.flushed_repos = []
+        self.flushed_products = []
+
+    def flush_repo(self, repo_id):
+        self.flushed_repos.append(repo_id)
+        return f_return()
+
+    def flush_product(self, product_id):
+        self.flushed_products.append(product_id)
+        return f_return()
+
+
+class FakeCopyRepo(CopyRepo):
+    """copy-repo with services overridden for test"""
+
+    def __init__(self, *args, **kwargs):
+        super(FakeCopyRepo, self).__init__(*args, **kwargs)
+        self.pulp_client_controller = FakeController()
+        self._udcache_client = FakeUdCache()
+
+    @property
+    def pulp_client(self):
+        # Super should give a Pulp client
+        assert isinstance(super(FakeCopyRepo, self).pulp_client, Client)
+        # But we'll substitute our own
+        return self.pulp_client_controller.client
+
+    @property
+    def udcache_client(self):
+        # Super may or may not give a UD client, depends on arguments
+        from_super = super(FakeCopyRepo, self).udcache_client
+        if from_super:
+            # If it did create one, it should be this
+            assert isinstance(from_super, UdCacheClient)
+
+        # We'll substitute our own, only if UD client is being used
+        return self._udcache_client if from_super else None
+
+
+def test_missing_repos(command_tester):
+    """Command fails when pointed at nonexistent repos."""
+    # This one test covers the entry point
+
+    command_tester.test(
+        lambda: pubtools._pulp.tasks.copy_repo.entry_point(FakeCopyRepo),
+        [
+            "test-copy-repo",
+            "--pulp-url",
+            "https://pulp.example.com/",
+            "repo1,repo2",
+            "repo3,repo4",
+        ],
+    )
+
+
+def test_invalid_repo_pair(command_tester, caplog):
+    command_tester.test(
+        lambda: pubtools._pulp.tasks.copy_repo.entry_point(FakeCopyRepo),
+        [
+            "test-copy-repo",
+            "--pulp-url",
+            "https://pulp.example.com/",
+            "repo1, ",
+        ],
+    )
+    assert (
+        "Pair(s) must contain two repository IDs, source and destination. Got: ['repo1', ' ']"
+        in caplog.text
+    )
+
+
+def test_copy_empty_repo(command_tester, fake_collector):
+    """Copying a repo which is empty succeeds."""
+
+    with FakeCopyRepo() as task_instance:
+        repoA = FileRepository(id="some-filerepo")
+        repoB = FileRepository(id="another-filerepo")
+
+        task_instance.pulp_client_controller.insert_repository(repoA)
+        task_instance.pulp_client_controller.insert_repository(repoB)
+
+        command_tester.test(
+            task_instance.main,
+            [
+                "test-copy-repo",
+                "--pulp-url",
+                "https://pulp.example.com/",
+                "some-filerepo,another-filerepo",
+            ],
+        )
+
+    # No push items recorded
+    assert not fake_collector.items
+
+
+def test_copy_file_repo(command_tester, fake_collector):
+    """Copying a repo with file content succeeds."""
+
+    repoA = FileRepository(
+        id="some-filerepo",
+        eng_product_id=123,
+        relative_url="some/publish/url",
+        mutable_urls=["mutable1", "mutable2"],
+    )
+    repoB = FileRepository(
+        id="another-filerepo",
+        eng_product_id=456,
+        relative_url="another/publish/url",
+        mutable_urls=["mutable1", "mutable2"],
+    )
+
+    files = [
+        FileUnit(path="hello.txt", size=123, sha256sum="a" * 64),
+        FileUnit(path="with/subdir.json", size=0, sha256sum="b" * 64),
+    ]
+
+    with FakeCopyRepo() as task_instance:
+        fakepulp = task_instance.pulp_client_controller
+        fakepulp.insert_repository(repoA)
+        fakepulp.insert_repository(repoB)
+        # Populate source repository.
+        fakepulp.insert_units(repoA, files)
+
+        # It should run with expected output.
+        command_tester.test(
+            task_instance.main,
+            [
+                "test-copy-repo",
+                "--pulp-url",
+                "https://pulp.example.com/",
+                "--pulp-insecure",
+                "--udcache-url",
+                "https://ud.example.com/",
+                "some-filerepo,another-filerepo",
+            ],
+        )
+
+    # It should record that it copied these push items:
+    assert sorted(fake_collector.items, key=lambda pi: pi["filename"]) == [
+        {
+            "state": "PUSHED",
+            "origin": "pulp",
+            "src": None,
+            "dest": "another-filerepo",
+            "filename": "hello.txt",
+            "checksums": {"sha256": "a" * 64},
+            "build": None,
+            "signing_key": None,
+        },
+        {
+            "state": "PUSHED",
+            "origin": "pulp",
+            "src": None,
+            "dest": "another-filerepo",
+            "filename": "with/subdir.json",
+            "checksums": {"sha256": "b" * 64},
+            "build": None,
+            "signing_key": None,
+        },
+    ]
+
+    # It should have published the copied Pulp repo
+    assert [hist.repository.id for hist in fakepulp.publish_history] == [
+        "another-filerepo",
+    ]
+
+    # It should have flushed the copied UD object
+    assert task_instance.udcache_client.flushed_repos == [
+        "another-filerepo",
+    ]
+    assert task_instance.udcache_client.flushed_products == [456]
+
+
+def test_copy_file_skip_publish(command_tester):
+    """Copying a repo with file content while skipping publish succeeds."""
+
+    repoA = FileRepository(
+        id="some-filerepo",
+        eng_product_id=123,
+        relative_url="some/publish/url",
+        mutable_urls=[],
+    )
+    repoB = FileRepository(
+        id="another-filerepo",
+        eng_product_id=456,
+        relative_url="another/publish/url",
+        mutable_urls=[],
+    )
+
+    files = [FileUnit(path="hello.txt", size=123, sha256sum="a" * 64)]
+
+    with FakeCopyRepo() as task_instance:
+        fakepulp = task_instance.pulp_client_controller
+        fakepulp.insert_repository(repoA)
+        fakepulp.insert_repository(repoB)
+        # Populate source repository.
+        fakepulp.insert_units(repoA, files)
+
+        # It should run with expected output.
+        command_tester.test(
+            task_instance.main,
+            [
+                "test-copy-repo",
+                "--pulp-url",
+                "https://pulp.example.com/",
+                "--skip",
+                "foo,publish,bar",
+                "some-filerepo,another-filerepo",
+            ],
+        )
+
+    # It should not have published Pulp repos
+    assert task_instance.pulp_client_controller.publish_history == []
+
+
+def test_copy_yum_repo(command_tester, fake_collector, monkeypatch):
+    """Copying a repo with yum content succeeds."""
+
+    repoA = YumRepository(
+        id="some-yumrepo",
+        relative_url="some/publish/url",
+        mutable_urls=["repomd.xml"],
+    )
+    repoB = YumRepository(
+        id="another-yumrepo",
+        relative_url="another/publish/url",
+        mutable_urls=["repomd.xml"],
+    )
+
+    files = [
+        RpmUnit(
+            name="bash",
+            version="1.23",
+            release="1.test8",
+            arch="x86_64",
+            sha256sum="a" * 64,
+            md5sum="b" * 32,
+            signing_key="aabbcc",
+        ),
+        ModulemdUnit(
+            name="mymod", stream="s1", version=123, context="a1c2", arch="s390x"
+        ),
+        ErratumUnit(
+            id="RHSA-2021:0672",
+            # ...and the advisory already exists in some Pulp, repos, maybe with
+            # some overlap
+            repository_memberships=[
+                "all-rpm-content",
+                "all-rpm-content-ff",
+                "existing1",
+                "existing2",
+            ],
+        ),
+    ]
+
+    with FakeCopyRepo() as task_instance:
+        fakepulp = task_instance.pulp_client_controller
+        fakepulp.insert_repository(repoA)
+        fakepulp.insert_repository(repoB)
+        # Populate source repository.
+        fakepulp.insert_units(repoA, files)
+
+        # It should run with expected output.
+        command_tester.test(
+            task_instance.main,
+            [
+                "test-copy-repo",
+                "--pulp-url",
+                "https://pulp.example.com/",
+                "some-yumrepo,another-yumrepo",
+            ],
+        )
+
+    # It should record that it copied these push items:
+    assert sorted(fake_collector.items, key=lambda pi: pi["filename"]) == [
+        {
+            "state": "PUSHED",
+            "origin": "pulp",
+            "src": None,
+            "dest": "another-yumrepo",
+            "filename": "RHSA-2021:0672",
+            "checksums": None,
+            "signing_key": None,
+            "build": None,
+        },
+        {
+            "state": "PUSHED",
+            "origin": "pulp",
+            "src": None,
+            "dest": "another-yumrepo",
+            "filename": "bash-1.23-1.test8.x86_64.rpm",
+            "checksums": {"sha256": "a" * 64},
+            "signing_key": None,
+            "build": None,
+        },
+        {
+            "state": "PUSHED",
+            "origin": "pulp",
+            "src": None,
+            "dest": "another-yumrepo",
+            "filename": "mymod:s1:123:a1c2:s390x",
+            "checksums": None,
+            "signing_key": None,
+            "build": None,
+        },
+    ]
+
+
+def test_copy_container_repo(command_tester):
+    """Copying a container image repo is not allowed."""
+
+    with FakeCopyRepo() as task_instance:
+        repoA = ContainerImageRepository(id="some-containerrepo")
+        repoB = ContainerImageRepository(id="another-containerrepo")
+
+        task_instance.pulp_client_controller.insert_repository(repoA)
+        task_instance.pulp_client_controller.insert_repository(repoB)
+
+        # It should run with expected output.
+        command_tester.test(
+            task_instance.main,
+            [
+                "test-copy-repo",
+                "--pulp-url",
+                "https://pulp.example.com/",
+                "some-containerrepo,another-containerrepo",
+            ],
+        )
+
+
+def test_copy_repo_multiple_content_types(command_tester, fake_collector):
+    """Test copying a Yum repo given multiple content type values."""
+
+    repoA = YumRepository(
+        id="some-yumrepo", relative_url="some/publish/url", mutable_urls=["repomd.xml"]
+    )
+    repoB = YumRepository(
+        id="another-yumrepo",
+        relative_url="another/publish/url",
+        mutable_urls=["repomd.xml"],
+    )
+
+    files = [
+        RpmUnit(
+            name="bash",
+            version="1.23",
+            release="1.test8",
+            arch="x86_64",
+            sha256sum="a" * 64,
+            md5sum="b" * 32,
+            signing_key="aabbcc",
+        ),
+        ModulemdUnit(
+            name="mymod", stream="s1", version=123, context="a1c2", arch="s390x"
+        ),
+    ]
+
+    with FakeCopyRepo() as task_instance:
+        task_instance.pulp_client_controller.insert_repository(repoA)
+        task_instance.pulp_client_controller.insert_repository(repoB)
+        task_instance.pulp_client_controller.insert_units(repoA, files)
+
+        # It should run with expected output.
+        command_tester.test(
+            task_instance.main,
+            [
+                "test-copy-repo",
+                "--pulp-url",
+                "https://pulp.example.com/",
+                "--content-type",
+                "rpm",
+                "--content-type",
+                "modulemd",
+                "--content-type",
+                "iso",
+                "--content-type",
+                "erratum",
+                "some-yumrepo,another-yumrepo",
+            ],
+        )
+
+    # test the new ClearRepo argument handling for --content-type
+    # produces the expected output
+    assert task_instance.args.content_type == ["rpm", "modulemd", "iso", "erratum"]
+
+    # It should record that it copied these push items:
+    assert sorted(fake_collector.items, key=lambda pi: pi["filename"]) == [
+        {
+            "state": "PUSHED",
+            "origin": "pulp",
+            "src": None,
+            "dest": "another-yumrepo",
+            "filename": "bash-1.23-1.test8.x86_64.rpm",
+            "checksums": {"sha256": "a" * 64},
+            "signing_key": None,
+            "build": None,
+        },
+        {
+            "state": "PUSHED",
+            "origin": "pulp",
+            "src": None,
+            "dest": "another-yumrepo",
+            "filename": "mymod:s1:123:a1c2:s390x",
+            "checksums": None,
+            "signing_key": None,
+            "build": None,
+        },
+    ]

--- a/tests/copy_repo/test_copy_repo.py
+++ b/tests/copy_repo/test_copy_repo.py
@@ -1,7 +1,15 @@
 from more_executors.futures import f_return
-from pubtools.pulplib import (Client, ContainerImageRepository, ErratumUnit,
-                              FakeController, FileRepository, FileUnit,
-                              ModulemdUnit, RpmUnit, YumRepository)
+from pubtools.pulplib import (
+    Client,
+    ContainerImageRepository,
+    ErratumUnit,
+    FakeController,
+    FileRepository,
+    FileUnit,
+    ModulemdUnit,
+    RpmUnit,
+    YumRepository,
+)
 
 import pubtools._pulp.tasks.copy_repo
 from pubtools._pulp.tasks.copy_repo import CopyRepo

--- a/tests/fix_cves/test_fix_cves.py
+++ b/tests/fix_cves/test_fix_cves.py
@@ -207,7 +207,7 @@ def test_fix_cves_with_cache_cleanup(command_tester):
         ud_client = fake_fix_cves.udcache_client
 
         assert ud_client.flushed_repos == ["all-rpm-content", "repo"]
-        assert ud_client.flushed_products == []
+        assert ud_client.flushed_products == [100, 101]
         assert ud_client.flushed_errata == ["RHSA-1234:56"]
 
         fastpurge_client = fake_fix_cves.fastpurge_client

--- a/tests/shared/test_pulp_repo_op_task.py
+++ b/tests/shared/test_pulp_repo_op_task.py
@@ -1,0 +1,10 @@
+import pytest
+
+from pubtools._pulp.tasks.common import PulpRepositoryOperation
+
+
+def test_task_run():
+    """raises if run() is not implemented"""
+    task = PulpRepositoryOperation()
+    with pytest.raises(NotImplementedError):
+        task.run()

--- a/tests/shared/test_pulp_task.py
+++ b/tests/shared/test_pulp_task.py
@@ -1,7 +1,7 @@
 import sys
 import pytest
 
-from mock import Mock, patch
+from mock import patch
 
 from pubtools.pulplib import Client
 from pubtools._pulp.task import PulpTask, task_context

--- a/tests/shared/test_task_interface.py
+++ b/tests/shared/test_task_interface.py
@@ -9,6 +9,7 @@ import pytest
     params=[
         "pubtools._pulp.tasks.garbage_collect",
         "pubtools._pulp.tasks.clear_repo",
+        "pubtools._pulp.tasks.copy_repo",
         "pubtools._pulp.tasks.set_maintenance.set_maintenance_on",
         "pubtools._pulp.tasks.set_maintenance.set_maintenance_off",
         "pubtools._pulp.tasks.publish",


### PR DESCRIPTION
Given a list of comma-separated pairs of repos, copy-repo will copy content from the first to the second in the pair. Supports --skip and --content-type.

`copy-repo --target <x> src_a,dst_a src_b,dst_b`