### PR TITLE
Reduce default arc_threshold of garbage collect [RHELDST-22675]

### DIFF
--- a/pubtools/_pulp/tasks/garbage_collect.py
+++ b/pubtools/_pulp/tasks/garbage_collect.py
@@ -1,12 +1,11 @@
 import logging
-from datetime import datetime, timedelta
 import os
+from datetime import datetime, timedelta
 
 from pubtools.pulplib import Criteria, Matcher, RpmUnit
 
-from pubtools._pulp.task import PulpTask
 from pubtools._pulp.services import PulpClientService
-
+from pubtools._pulp.task import PulpTask
 
 LOG = logging.getLogger("pubtools.pulp")
 step = PulpTask.step
@@ -39,7 +38,7 @@ class GarbageCollect(PulpClientService, PulpTask):
             "--arc-threshold",
             help="delete all-rpm-content older than this many days",
             type=int,
-            default=30,
+            default=14,
         )
 
     def run(self):

--- a/tests/garbage_collect/test_garbage_collect.py
+++ b/tests/garbage_collect/test_garbage_collect.py
@@ -1,22 +1,12 @@
-import os
+import datetime
 
 import pytest
-import datetime
-from mock import Mock, patch
+from mock import patch
 from more_executors.futures import f_return
+from pubtools.pulplib import FakeController, Repository, RpmUnit, Task
 
-from pubtools.pulplib import (
-    FakeController,
-    Repository,
-    RpmUnit,
-    RpmDependency,
-    YumRepository,
-    Task,
-    InvalidDataException,
-)
-
-from pubtools._pulp.tasks.garbage_collect import GarbageCollect, entry_point
 import pubtools._pulp.tasks.garbage_collect as gc_module
+from pubtools._pulp.tasks.garbage_collect import GarbageCollect, entry_point
 
 
 @pytest.fixture
@@ -330,4 +320,4 @@ def test_arc_garbage_collect_0items(mock_logger):
             gc.main()
     updated_rpm = list(client.get_repository("all-rpm-content").search_content())
     assert len(updated_rpm) == 1
-    mock_logger.info.assert_any_call("No all-rpm-content found older than %s", 30)
+    mock_logger.info.assert_any_call("No all-rpm-content found older than %s", 14)


### PR DESCRIPTION
While ideally we'll only clean up all-rpm-content older than 30 days, to be sure pre-push content is available, let's shorten it to 14 days to alleviate the build-up in all-rpm-content repos until a long-term solution for that is in place.