### PR TITLE
Add Codecov token for uploading coverage reports

### DIFF
--- a/.github/workflows/tox-test.yml
+++ b/.github/workflows/tox-test.yml
@@ -57,6 +57,8 @@ jobs:
         run: tox -e cov
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v2
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:
           fail_ci_if_error: true
           verbose: true


### PR DESCRIPTION
Jobs failed while uploading the coverage report to Codecov as it failed to get build info from Github. There have been some rate-limiting by Github on
tokenless access by Github, hence Codecov couldn't get the required info from the APIs. So, add the
Codecov token to upload the reports smoothly.