### PR TITLE
Update codecov-action to v4 for tokenless uploads from PR on forked repos

### DIFF
--- a/.github/workflows/tox-test.yml
+++ b/.github/workflows/tox-test.yml
@@ -56,7 +56,7 @@ jobs:
       - name: Run Tox
         run: tox -e cov
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v2
+        uses: codecov/codecov-action@v4
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:


### PR DESCRIPTION
Codecov-action v4 requires token for upload. However,
it supports tokenless uploads for the PRs on forks to
upstream public repos.