### PR TITLE
Fix missing coverage in fakepulp

### DIFF
--- a/pubtools/_pulp/services/fakepulp.py
+++ b/pubtools/_pulp/services/fakepulp.py
@@ -40,7 +40,7 @@ def serialize(value):
     if isinstance(value, list):
         return [serialize(elem) for elem in value]
 
-    if isinstance(value, dict):
+    if isinstance(value, (dict, frozendict)):
         out = {}
         for key, elem in value.items():
             out[key] = serialize(elem)


### PR DESCRIPTION
frozendict is only an instance of dict *sometimes* (depending on whether the pure-python implementation is used), so for this branch to consistently apply on all kinds of dict we need to match on both frozendict and dict.