### PR TITLE
Add all-erratum-content to publish exclusions

### DIFF
--- a/pubtools/_pulp/tasks/push/items/erratum.py
+++ b/pubtools/_pulp/tasks/push/items/erratum.py
@@ -86,7 +86,8 @@ class PulpErratumPushItem(PulpPushItem):
             #
             # Also note that there's an entire family of these repos, hence the
             # startswith rather than plain equality check.
-            if not repo_id.startswith("all-rpm-content"):
+            if not (repo_id.startswith("all-rpm-content")
+                    or repo_id.startswith("all-erratum-content")):
                 out.add(repo_id)
 
         return sorted(out)

--- a/pubtools/_pulp/tasks/push/items/erratum.py
+++ b/pubtools/_pulp/tasks/push/items/erratum.py
@@ -86,8 +86,10 @@ class PulpErratumPushItem(PulpPushItem):
             #
             # Also note that there's an entire family of these repos, hence the
             # startswith rather than plain equality check.
-            if not (repo_id.startswith("all-rpm-content")
-                    or repo_id.startswith("all-erratum-content")):
+            if not (
+                repo_id.startswith("all-rpm-content")
+                or repo_id.startswith("all-erratum-content")
+            ):
                 out.add(repo_id)
 
         return sorted(out)

--- a/tests/push/test_pulperratumpushitem.py
+++ b/tests/push/test_pulperratumpushitem.py
@@ -23,6 +23,7 @@ def test_erratum_publishes_all_repos():
             repository_memberships=[
                 "all-rpm-content",
                 "all-rpm-content-ff",
+                "all-erratum-content-2019",
                 "existing1",
                 "existing2",
             ],

--- a/tests/push/test_push.py
+++ b/tests/push/test_push.py
@@ -131,7 +131,7 @@ def test_typical_push(
     )
 
     # It should have invoked hook(s).
-    assert len(hookspy) == 29
+    assert len(hookspy) == 25
     (hook_name, hook_kwargs) = hookspy[0]
     assert hook_name == "task_start"
     (hook_name, hook_kwargs) = hookspy[1]


### PR DESCRIPTION
While investigating another issue I stumbled across this logic. I imagine it'd be the same case for the new all-erratum-content repos