### PR TITLE
Fix CopyRepo task [RHELDST-23737, RHELDST-23709] 

### DIFF
--- a/tests/logs/copy_repo/test_copy_repo/test_copy_container_repo.jsonl
+++ b/tests/logs/copy_repo/test_copy_repo/test_copy_container_repo.jsonl
@@ -1,0 +1,2 @@
+{"event": {"type": "check-repos-start"}}
+{"event": {"type": "check-repos-error"}}

--- a/tests/logs/copy_repo/test_copy_repo/test_copy_container_repo.txt
+++ b/tests/logs/copy_repo/test_copy_repo/test_copy_container_repo.txt
@@ -1,0 +1,4 @@
+[    INFO] Check repos: started
+[   ERROR] Container image repo(s) provided, not supported: another-container-repo, some-container-repo
+[   ERROR] Check repos: failed
+# Raised: 30

--- a/tests/logs/copy_repo/test_copy_repo/test_copy_empty_repo.jsonl
+++ b/tests/logs/copy_repo/test_copy_repo/test_copy_empty_repo.jsonl
@@ -1,0 +1,12 @@
+{"event": {"type": "check-repos-start"}}
+{"event": {"type": "check-repos-end"}}
+{"event": {"type": "copy-content-start"}}
+{"event": {"type": "copy-content-end"}}
+{"event": {"type": "record-push-items-start"}}
+{"event": {"type": "record-push-items-end"}}
+{"event": {"type": "publish-start"}}
+{"event": {"type": "publish-end"}}
+{"event": {"type": "flush-ud-cache-start"}}
+{"event": {"type": "flush-ud-cache-end"}}
+{"event": {"type": "flush-cdn-cache-start"}}
+{"event": {"type": "flush-cdn-cache-end"}}

--- a/tests/logs/copy_repo/test_copy_repo/test_copy_empty_repo.txt
+++ b/tests/logs/copy_repo/test_copy_repo/test_copy_empty_repo.txt
@@ -1,0 +1,15 @@
+[    INFO] Check repos: started
+[    INFO] Check repos: finished
+[    INFO] Copy content: started
+[ WARNING] another-filerepo: no content copied, tasks: e3e70682-c209-4cac-629f-6fbed82c07cd
+[    INFO] Copy content: finished
+[    INFO] Record push items: started
+[    INFO] Record push items: finished
+[    INFO] Publish: started
+[    INFO] Publish: finished
+[    INFO] Flush UD cache: started
+[    INFO] UD cache flush is not enabled.
+[    INFO] Flush UD cache: finished
+[    INFO] Flush CDN cache: started
+[    INFO] CDN cache flush is not enabled.
+[    INFO] Flush CDN cache: finished

--- a/tests/logs/copy_repo/test_copy_repo/test_copy_file_repo.jsonl
+++ b/tests/logs/copy_repo/test_copy_repo/test_copy_file_repo.jsonl
@@ -1,0 +1,12 @@
+{"event": {"type": "check-repos-start"}}
+{"event": {"type": "check-repos-end"}}
+{"event": {"type": "copy-content-start"}}
+{"event": {"type": "copy-content-end"}}
+{"event": {"type": "record-push-items-start"}}
+{"event": {"type": "record-push-items-end"}}
+{"event": {"type": "publish-start"}}
+{"event": {"type": "publish-end"}}
+{"event": {"type": "flush-ud-cache-start"}}
+{"event": {"type": "flush-ud-cache-end"}}
+{"event": {"type": "flush-cdn-cache-start"}}
+{"event": {"type": "flush-cdn-cache-end"}}

--- a/tests/logs/copy_repo/test_copy_repo/test_copy_file_repo.txt
+++ b/tests/logs/copy_repo/test_copy_repo/test_copy_file_repo.txt
@@ -1,0 +1,14 @@
+[    INFO] Check repos: started
+[    INFO] Check repos: finished
+[    INFO] Copy content: started
+[    INFO] another-filerepo: copied 2 iso(s), tasks: e3e70682-c209-4cac-629f-6fbed82c07cd
+[    INFO] Copy content: finished
+[    INFO] Record push items: started
+[    INFO] Record push items: finished
+[    INFO] Publish: started
+[    INFO] Publish: finished
+[    INFO] Flush UD cache: started
+[    INFO] Flush UD cache: finished
+[    INFO] Flush CDN cache: started
+[    INFO] CDN cache flush is not enabled.
+[    INFO] Flush CDN cache: finished

--- a/tests/logs/copy_repo/test_copy_repo/test_copy_file_skip_publish.jsonl
+++ b/tests/logs/copy_repo/test_copy_repo/test_copy_file_skip_publish.jsonl
@@ -1,0 +1,10 @@
+{"event": {"type": "check-repos-start"}}
+{"event": {"type": "check-repos-end"}}
+{"event": {"type": "copy-content-start"}}
+{"event": {"type": "copy-content-end"}}
+{"event": {"type": "record-push-items-start"}}
+{"event": {"type": "record-push-items-end"}}
+{"event": {"type": "publish-skip"}}
+{"event": {"type": "flush-ud-cache-start"}}
+{"event": {"type": "flush-ud-cache-end"}}
+{"event": {"type": "flush-cdn-cache-skip"}}

--- a/tests/logs/copy_repo/test_copy_repo/test_copy_file_skip_publish.txt
+++ b/tests/logs/copy_repo/test_copy_repo/test_copy_file_skip_publish.txt
@@ -1,0 +1,12 @@
+[    INFO] Check repos: started
+[    INFO] Check repos: finished
+[    INFO] Copy content: started
+[    INFO] another-filerepo: copied 1 iso(s), tasks: e3e70682-c209-4cac-629f-6fbed82c07cd
+[    INFO] Copy content: finished
+[    INFO] Record push items: started
+[    INFO] Record push items: finished
+[    INFO] Publish: skipped
+[    INFO] Flush UD cache: started
+[    INFO] UD cache flush is not enabled.
+[    INFO] Flush UD cache: finished
+[    INFO] Flush CDN cache: skipped

--- a/tests/logs/copy_repo/test_copy_repo/test_copy_repo_criteria.jsonl
+++ b/tests/logs/copy_repo/test_copy_repo/test_copy_repo_criteria.jsonl
@@ -1,0 +1,12 @@
+{"event": {"type": "check-repos-start"}}
+{"event": {"type": "check-repos-end"}}
+{"event": {"type": "copy-content-start"}}
+{"event": {"type": "copy-content-end"}}
+{"event": {"type": "record-push-items-start"}}
+{"event": {"type": "record-push-items-end"}}
+{"event": {"type": "publish-start"}}
+{"event": {"type": "publish-end"}}
+{"event": {"type": "flush-ud-cache-start"}}
+{"event": {"type": "flush-ud-cache-end"}}
+{"event": {"type": "flush-cdn-cache-start"}}
+{"event": {"type": "flush-cdn-cache-end"}}

--- a/tests/logs/copy_repo/test_copy_repo/test_copy_repo_criteria.txt
+++ b/tests/logs/copy_repo/test_copy_repo/test_copy_repo_criteria.txt
@@ -1,0 +1,15 @@
+[    INFO] Check repos: started
+[    INFO] Check repos: finished
+[    INFO] Copy content: started
+[ WARNING] another-yumrepo: no content copied, tasks: 23a7711a-8133-2876-37eb-dcd9e87a1613, 82e2e662-f728-b4fa-4248-5e3a0a5d2f34, d4713d60-c8a7-0639-eb11-67b367a9c378, e3e70682-c209-4cac-629f-6fbed82c07cd, e6f4590b-9a16-4106-cf6a-659eb4862b21
+[    INFO] Copy content: finished
+[    INFO] Record push items: started
+[    INFO] Record push items: finished
+[    INFO] Publish: started
+[    INFO] Publish: finished
+[    INFO] Flush UD cache: started
+[    INFO] UD cache flush is not enabled.
+[    INFO] Flush UD cache: finished
+[    INFO] Flush CDN cache: started
+[    INFO] CDN cache flush is not enabled.
+[    INFO] Flush CDN cache: finished

--- a/tests/logs/copy_repo/test_copy_repo/test_copy_repo_multiple_content_types.jsonl
+++ b/tests/logs/copy_repo/test_copy_repo/test_copy_repo_multiple_content_types.jsonl
@@ -1,0 +1,12 @@
+{"event": {"type": "check-repos-start"}}
+{"event": {"type": "check-repos-end"}}
+{"event": {"type": "copy-content-start"}}
+{"event": {"type": "copy-content-end"}}
+{"event": {"type": "record-push-items-start"}}
+{"event": {"type": "record-push-items-end"}}
+{"event": {"type": "publish-start"}}
+{"event": {"type": "publish-end"}}
+{"event": {"type": "flush-ud-cache-start"}}
+{"event": {"type": "flush-ud-cache-end"}}
+{"event": {"type": "flush-cdn-cache-start"}}
+{"event": {"type": "flush-cdn-cache-end"}}

--- a/tests/logs/copy_repo/test_copy_repo/test_copy_repo_multiple_content_types.txt
+++ b/tests/logs/copy_repo/test_copy_repo/test_copy_repo_multiple_content_types.txt
@@ -1,0 +1,15 @@
+[    INFO] Check repos: started
+[    INFO] Check repos: finished
+[    INFO] Copy content: started
+[    INFO] another-yumrepo: copied 1 modulemd(s), 1 rpm(s), tasks: 23a7711a-8133-2876-37eb-dcd9e87a1613, 82e2e662-f728-b4fa-4248-5e3a0a5d2f34, d4713d60-c8a7-0639-eb11-67b367a9c378, e3e70682-c209-4cac-629f-6fbed82c07cd
+[    INFO] Copy content: finished
+[    INFO] Record push items: started
+[    INFO] Record push items: finished
+[    INFO] Publish: started
+[    INFO] Publish: finished
+[    INFO] Flush UD cache: started
+[    INFO] UD cache flush is not enabled.
+[    INFO] Flush UD cache: finished
+[    INFO] Flush CDN cache: started
+[    INFO] CDN cache flush is not enabled.
+[    INFO] Flush CDN cache: finished

--- a/tests/logs/copy_repo/test_copy_repo/test_copy_yum_repo.jsonl
+++ b/tests/logs/copy_repo/test_copy_repo/test_copy_yum_repo.jsonl
@@ -1,0 +1,12 @@
+{"event": {"type": "check-repos-start"}}
+{"event": {"type": "check-repos-end"}}
+{"event": {"type": "copy-content-start"}}
+{"event": {"type": "copy-content-end"}}
+{"event": {"type": "record-push-items-start"}}
+{"event": {"type": "record-push-items-end"}}
+{"event": {"type": "publish-start"}}
+{"event": {"type": "publish-end"}}
+{"event": {"type": "flush-ud-cache-start"}}
+{"event": {"type": "flush-ud-cache-end"}}
+{"event": {"type": "flush-cdn-cache-start"}}
+{"event": {"type": "flush-cdn-cache-end"}}

--- a/tests/logs/copy_repo/test_copy_repo/test_copy_yum_repo.txt
+++ b/tests/logs/copy_repo/test_copy_repo/test_copy_yum_repo.txt
@@ -1,0 +1,15 @@
+[    INFO] Check repos: started
+[    INFO] Check repos: finished
+[    INFO] Copy content: started
+[    INFO] another-yumrepo: copied 1 erratum(s), 1 modulemd(s), 1 rpm(s), tasks: e3e70682-c209-4cac-629f-6fbed82c07cd
+[    INFO] Copy content: finished
+[    INFO] Record push items: started
+[    INFO] Record push items: finished
+[    INFO] Publish: started
+[    INFO] Publish: finished
+[    INFO] Flush UD cache: started
+[    INFO] UD cache flush is not enabled.
+[    INFO] Flush UD cache: finished
+[    INFO] Flush CDN cache: started
+[    INFO] CDN cache flush is not enabled.
+[    INFO] Flush CDN cache: finished

--- a/tests/logs/copy_repo/test_copy_repo/test_invalid_content_type.jsonl
+++ b/tests/logs/copy_repo/test_copy_repo/test_invalid_content_type.jsonl
@@ -1,0 +1,4 @@
+{"event": {"type": "check-repos-start"}}
+{"event": {"type": "check-repos-end"}}
+{"event": {"type": "copy-content-start"}}
+{"event": {"type": "copy-content-error"}}

--- a/tests/logs/copy_repo/test_copy_repo/test_invalid_content_type.txt
+++ b/tests/logs/copy_repo/test_copy_repo/test_invalid_content_type.txt
@@ -1,0 +1,6 @@
+[    INFO] Check repos: started
+[    INFO] Check repos: finished
+[    INFO] Copy content: started
+[   ERROR] Unsupported content type: container
+[   ERROR] Copy content: failed
+# Raised: 30

--- a/tests/logs/copy_repo/test_copy_repo/test_invalid_repo_pair.jsonl
+++ b/tests/logs/copy_repo/test_copy_repo/test_invalid_repo_pair.jsonl
@@ -1,0 +1,2 @@
+{"event": {"type": "check-repos-start"}}
+{"event": {"type": "check-repos-error"}}

--- a/tests/logs/copy_repo/test_copy_repo/test_invalid_repo_pair.txt
+++ b/tests/logs/copy_repo/test_copy_repo/test_invalid_repo_pair.txt
@@ -1,0 +1,4 @@
+[    INFO] Check repos: started
+[   ERROR] Pair(s) must contain two repository IDs, source and destination. Got: 'repo1, '
+[   ERROR] Check repos: failed
+# Raised: 30

--- a/tests/logs/copy_repo/test_copy_repo/test_missing_repos.jsonl
+++ b/tests/logs/copy_repo/test_copy_repo/test_missing_repos.jsonl
@@ -1,0 +1,2 @@
+{"event": {"type": "check-repos-start"}}
+{"event": {"type": "check-repos-error"}}

--- a/tests/logs/copy_repo/test_copy_repo/test_missing_repos.txt
+++ b/tests/logs/copy_repo/test_copy_repo/test_missing_repos.txt
@@ -1,0 +1,4 @@
+[    INFO] Check repos: started
+[   ERROR] Requested repo(s) don't exist: repo1, repo2, repo3, repo4
+[   ERROR] Check repos: failed
+# Raised: 30


### PR DESCRIPTION
Most notable fixes and changes:
* added support for all content types - because of that we need to use
  different `Criteria` for `copy_content()` call. We can't use
 `Criteria.with_unit_type()` for all types because we don't currently support
  class->content_type mapping for all content types in pubtools-pulplib. 
  So there is a hybrid approach for content types supporting `with_unit_type`
  `Criteria` and those types that don't support that where we use `with_field`
  variant. 
* previously when unsupported content type was passed, `copy_content()`
  was called with `criteria=None` which lead to copying of all content
  from repo + flawed `if` conditions called `copy_content()` multiple
  time (one extra call for each unknown content type)
* now we use one `copy_content()` call for one repo pair but because there can
   be spawned more that one pulp task for we split criteria
* where supported we use `unit_fields` for `Criteria` in order to
   lower RAM requirements
* all repo copies are properly aggregated in one `Copy content` step.
* added test logs for tests