### PR TITLE
Restore garbage-collect arc_threshold to 30 (days) [RHELDST-22676]

### DIFF
--- a/pubtools/_pulp/tasks/garbage_collect.py
+++ b/pubtools/_pulp/tasks/garbage_collect.py
@@ -38,7 +38,7 @@ class GarbageCollect(PulpClientService, PulpTask):
             "--arc-threshold",
             help="delete all-rpm-content older than this many days",
             type=int,
-            default=14,
+            default=30,
         )
 
     def run(self):

--- a/tests/garbage_collect/test_garbage_collect.py
+++ b/tests/garbage_collect/test_garbage_collect.py
@@ -320,4 +320,4 @@ def test_arc_garbage_collect_0items(mock_logger):
             gc.main()
     updated_rpm = list(client.get_repository("all-rpm-content").search_content())
     assert len(updated_rpm) == 1
-    mock_logger.info.assert_any_call("No all-rpm-content found older than %s", 14)
+    mock_logger.info.assert_any_call("No all-rpm-content found older than %s", 30)


### PR DESCRIPTION
In commit 545991d4e5106f52cee22c55e46f1eab34f823ae the arc_threshold was reduced as a temporary solution for accumulation of content in all-rpm-content repos. Now that a permanent solution has been implemented, let's revert it to the original value.