### PR TITLE
Generate consistent repo sequence in publish test logs

### DIFF
--- a/tests/publish/test_publish.py
+++ b/tests/publish/test_publish.py
@@ -94,6 +94,12 @@ class FakePublish(Publish):
         # We'll substitute our own, only if cdn client is being used
         return self._cdn_client if from_super else None
 
+    # override to generate consistent repo sequence in the logs
+    def publish_with_cache_flush(self, repos, *args, **kwargs):
+        return super(FakePublish, self).publish_with_cache_flush(
+            sorted(repos), *args, **kwargs
+        )
+
 
 def _add_repo(controller):
     # test repos added to the controller


### PR DESCRIPTION
Multiple repos in the publish and cache flush step may generate a different sequence of logs in different runs, that fails the tests. Hence, this patch ensures to sort the repos to publish step generating a consistent log.