### PR TITLE
Publish all affected repos while deleting modules [RHELDST-13651]

### DIFF
--- a/tests/logs/delete/test_delete_packages/test_delete_modules.jsonl
+++ b/tests/logs/delete/test_delete_packages/test_delete_modules.jsonl
@@ -18,6 +18,14 @@
 {"event": {"type": "record-push-items-start"}}
 {"event": {"type": "record-push-items-end"}}
 {"event": {"type": "delete-rpms-end"}}
+{"event": {"type": "delete-rpms-start"}}
+{"event": {"type": "get-rpms-start"}}
+{"event": {"type": "get-rpms-end"}}
+{"event": {"type": "unassociate-rpms-start"}}
+{"event": {"type": "unassociate-rpms-end"}}
+{"event": {"type": "record-push-items-start"}}
+{"event": {"type": "record-push-items-end"}}
+{"event": {"type": "delete-rpms-end"}}
 {"event": {"type": "remove-artifacts-from-modules-end"}}
 {"event": {"type": "unassociate-modules-start"}}
 {"event": {"type": "unassociate-modules-end"}}

--- a/tests/logs/delete/test_delete_packages/test_delete_modules.txt
+++ b/tests/logs/delete/test_delete_packages/test_delete_modules.txt
@@ -1,9 +1,9 @@
 [    INFO] Delete files: started
 [    INFO] Get files: started
-[ WARNING] Requested unit(s) don't exist as file: mymod:s1:123:a1c2:s390x
+[ WARNING] Requested unit(s) don't exist as file: mymod:s1:123:a1c2:s390x, othermod:s2:123:a1c2:x86_64
 [    INFO] 0 unit(s) found for deletion
 [    INFO] Get files: finished
-[ WARNING] No units to remove from other-yumrepo, some-yumrepo
+[ WARNING] No units to remove from another-yumrepo, other-yumrepo, some-yumrepo
 [    INFO] Unassociate files: started
 [ WARNING] Nothing mapped for removal
 [    INFO] Unassociate files: finished
@@ -12,19 +12,27 @@
 [    INFO] Delete files: finished
 [    INFO] Delete modules: started
 [    INFO] Get modules: started
-[    INFO] 1 unit(s) found for deletion
+[    INFO] 2 unit(s) found for deletion
 [    INFO] Get modules: finished
+[ WARNING] mymod:s1:123:a1c2:s390x is not present in another-yumrepo
 [ WARNING] mymod:s1:123:a1c2:s390x is not present in other-yumrepo
-[ WARNING] No units to remove from other-yumrepo
+[ WARNING] othermod:s2:123:a1c2:x86_64 is not present in another-yumrepo
+[ WARNING] othermod:s2:123:a1c2:x86_64 is not present in other-yumrepo
+[ WARNING] No units to remove from another-yumrepo, other-yumrepo
 [    INFO] Deleting mymod:s1:123:a1c2:s390x from some-yumrepo
+[    INFO] Deleting othermod:s2:123:a1c2:x86_64 from some-yumrepo
 [    INFO] Remove artifacts from modules: started
 [    INFO] Delete RPMs: started
 [    INFO] Get RPMs: started
 [    INFO] 3 unit(s) found for deletion
 [    INFO] Get RPMs: finished
+[ WARNING] bash-1.23-1.test8_x86_64.rpm is not present in another-yumrepo
 [ WARNING] bash-1.23-1.test8_x86_64.rpm is not present in other-yumrepo
+[ WARNING] dash-1.23-1.test8_x86_64.rpm is not present in another-yumrepo
 [ WARNING] dash-1.23-1.test8_x86_64.rpm is not present in other-yumrepo
+[ WARNING] smash-0.24-1.test8_x86_64.rpm is not present in another-yumrepo
 [ WARNING] smash-0.24-1.test8_x86_64.rpm is not present in some-yumrepo
+[ WARNING] No units to remove from another-yumrepo
 [    INFO] Deleting bash-1.23-1.test8_x86_64.rpm from some-yumrepo
 [    INFO] Deleting dash-1.23-1.test8_x86_64.rpm from some-yumrepo
 [    INFO] Deleting smash-0.24-1.test8_x86_64.rpm from other-yumrepo
@@ -35,14 +43,30 @@
 [    INFO] Record push items: started
 [    INFO] Record push items: finished
 [    INFO] Delete RPMs: finished
+[    INFO] Delete RPMs: started
+[    INFO] Get RPMs: started
+[    INFO] 1 unit(s) found for deletion
+[    INFO] Get RPMs: finished
+[ WARNING] crash-2.23-1.test8_x86_64.rpm is not present in other-yumrepo
+[ WARNING] crash-2.23-1.test8_x86_64.rpm is not present in some-yumrepo
+[ WARNING] No units to remove from other-yumrepo, some-yumrepo
+[    INFO] Deleting crash-2.23-1.test8_x86_64.rpm from another-yumrepo
+[    INFO] Unassociate RPMs: started
+[    INFO] another-yumrepo: removed 1 rpm(s), tasks: d4713d60-c8a7-0639-eb11-67b367a9c378
+[    INFO] Unassociate RPMs: finished
+[    INFO] Record push items: started
+[    INFO] Record push items: finished
+[    INFO] Delete RPMs: finished
 [    INFO] Remove artifacts from modules: finished
 [    INFO] Unassociate modules: started
-[    INFO] some-yumrepo: removed 1 modulemd(s), tasks: d4713d60-c8a7-0639-eb11-67b367a9c378
+[    INFO] some-yumrepo: removed 2 modulemd(s), tasks: 23a7711a-8133-2876-37eb-dcd9e87a1613
 [    INFO] Unassociate modules: finished
 [    INFO] Record push items: started
 [    INFO] Record push items: finished
 [    INFO] Delete modules: finished
 [    INFO] Publish: started
+[    INFO] Publishing another-yumrepo
+[    INFO] Publishing other-yumrepo
 [    INFO] Publishing some-yumrepo
 [    INFO] Publish: finished
 [    INFO] Set cdn_published: started


### PR DESCRIPTION
Repos with modules were only getting published after deleting the modules. However, there were artifacts from the modules that were deleted from other repos as well. Hence, include those repos to publish when modules are deleted.