### PR TITLE
Use pushitem content to upload

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -2,5 +2,5 @@ pubtools>=0.3.0
 pubtools-pulplib>=2.36.0
 more_executors>=2.7.0
 pushcollector>=1.2.0
-pushsource>=2.45.0
+pushsource>=2.51.0
 monotonic; python_version < '3.3'

--- a/src/pubtools/_pulp/tasks/push/items/comps.py
+++ b/src/pubtools/_pulp/tasks/push/items/comps.py
@@ -11,4 +11,4 @@ class PulpCompsXmlPushItem(PulpDirectUploadPushItem):
     """Handler for comps.xml files which are uploaded directly to each dest repo."""
 
     def upload_to_repo(self, repo):
-        return repo.upload_comps_xml(self.pushsource_item.src)
+        return repo.upload_comps_xml(self.pushsource_item.content())

--- a/src/pubtools/_pulp/tasks/push/items/file.py
+++ b/src/pubtools/_pulp/tasks/push/items/file.py
@@ -72,7 +72,7 @@ class PulpFilePushItem(PulpPushItem):
 
     def upload_to_repo(self, repo):
         return repo.upload_file(
-            self.pushsource_item.src,
+            self.pushsource_item.content(),
             relative_url=self.pushsource_item.name,
             description=self.pushsource_item.description,
             version=self.pushsource_item.version,

--- a/src/pubtools/_pulp/tasks/push/items/modulemd.py
+++ b/src/pubtools/_pulp/tasks/push/items/modulemd.py
@@ -11,4 +11,4 @@ class PulpModuleMdPushItem(PulpDirectUploadPushItem):
     """Handler for modulemd YAML files which are uploaded directly to each dest repo."""
 
     def upload_to_repo(self, repo):
-        return repo.upload_modules(self.pushsource_item.src)
+        return repo.upload_modules(self.pushsource_item.content())

--- a/src/pubtools/_pulp/tasks/push/items/productid.py
+++ b/src/pubtools/_pulp/tasks/push/items/productid.py
@@ -84,7 +84,9 @@ class PulpProductIdPushItem(PulpDirectUploadPushItem):
         return []
 
     def upload_to_repo(self, repo):
-        return repo.upload_metadata(self.pushsource_item.src, metadata_type="productid")
+        return repo.upload_metadata(
+            self.pushsource_item.content(), metadata_type="productid"
+        )
 
     def ensure_uploaded(self, ctx, repo_f=None):
         # Overridden to add the post-upload step of product_versions update.

--- a/src/pubtools/_pulp/tasks/push/items/rpm.py
+++ b/src/pubtools/_pulp/tasks/push/items/rpm.py
@@ -143,4 +143,4 @@ class PulpRpmPushItem(PulpPushItem):
         return super(PulpRpmPushItem, self).ensure_uploaded(ctx, ctx.upload_repo)
 
     def upload_to_repo(self, repo):
-        return repo.upload_rpm(self.pushsource_item.src, cdn_path=self.cdn_path)
+        return repo.upload_rpm(self.pushsource_item.content(), cdn_path=self.cdn_path)

--- a/tests/push/test_upload_sharing.py
+++ b/tests/push/test_upload_sharing.py
@@ -19,9 +19,12 @@ class RepoWrapper(object):
         self.delegate = delegate
         self.uploads = uploads
 
-    def upload_rpm(self, path, *args, **kwargs):
-        self.uploads.append(("rpm", path))
-        return self.delegate.upload_rpm(path, *args, **kwargs)
+    def upload_rpm(self, rpm, *args, **kwargs):
+        # get the path/name if it's the file object as rpm
+        # instead of rpm path
+        rpm = rpm if isinstance(rpm, str) else rpm.name
+        self.uploads.append(("rpm", rpm))
+        return self.delegate.upload_rpm(rpm, *args, **kwargs)
 
 
 class ClientWrapper(object):


### PR DESCRIPTION
pushitem content method added in latest pushsource update returns a file-like object with the item bits that may be used for upload. This decouples the source of the items and expectation to exist as a file on local fs.

Note: This PR will be applicable after the changes to `pushsource` are merged
https://github.com/release-engineering/pushsource/pull/643