### PR TITLE
copy-repo makes only two copy calls for a repo pair [RHELDST-28235]

### DIFF
--- a/tests/logs/copy_repo/test_copy_repo/test_copy_invalid_content_type.txt
+++ b/tests/logs/copy_repo/test_copy_repo/test_copy_invalid_content_type.txt
@@ -1,6 +1,6 @@
 [    INFO] Check repos: started
 [    INFO] Check repos: finished
 [    INFO] Copy content: started
-[   ERROR] Unsupported content type: container
+[   ERROR] Unsupported content type(s): container
 [   ERROR] Copy content: failed
 # Raised: 30

--- a/tests/logs/copy_repo/test_copy_repo/test_copy_repo_criteria.txt
+++ b/tests/logs/copy_repo/test_copy_repo/test_copy_repo_criteria.txt
@@ -1,7 +1,7 @@
 [    INFO] Check repos: started
 [    INFO] Check repos: finished
 [    INFO] Copy content: started
-[ WARNING] another-yumrepo: no content copied, tasks: 23a7711a-8133-2876-37eb-dcd9e87a1613, 82e2e662-f728-b4fa-4248-5e3a0a5d2f34, d4713d60-c8a7-0639-eb11-67b367a9c378, e3e70682-c209-4cac-629f-6fbed82c07cd, e6f4590b-9a16-4106-cf6a-659eb4862b21
+[ WARNING] another-yumrepo: no content copied, tasks: 82e2e662-f728-b4fa-4248-5e3a0a5d2f34, e3e70682-c209-4cac-629f-6fbed82c07cd
 [    INFO] Copy content: finished
 [    INFO] Record push items: started
 [    INFO] Record push items: finished

--- a/tests/logs/copy_repo/test_copy_repo/test_copy_repo_multiple_content_types.txt
+++ b/tests/logs/copy_repo/test_copy_repo/test_copy_repo_multiple_content_types.txt
@@ -1,7 +1,8 @@
 [    INFO] Check repos: started
 [    INFO] Check repos: finished
 [    INFO] Copy content: started
-[    INFO] another-yumrepo: copied 1 modulemd(s), 1 rpm(s), tasks: 23a7711a-8133-2876-37eb-dcd9e87a1613, 82e2e662-f728-b4fa-4248-5e3a0a5d2f34, d4713d60-c8a7-0639-eb11-67b367a9c378, e3e70682-c209-4cac-629f-6fbed82c07cd
+[    INFO] yet-another-yumrepo: copied 1 modulemd(s), 1 rpm(s), tasks: 82e2e662-f728-b4fa-4248-5e3a0a5d2f34, e3e70682-c209-4cac-629f-6fbed82c07cd
+[    INFO] another-yumrepo: copied 1 modulemd(s), 1 rpm(s), tasks: 23a7711a-8133-2876-37eb-dcd9e87a1613, d4713d60-c8a7-0639-eb11-67b367a9c378
 [    INFO] Copy content: finished
 [    INFO] Record push items: started
 [    INFO] Record push items: finished

--- a/tests/logs/copy_repo/test_copy_repo/test_invalid_content_type.txt
+++ b/tests/logs/copy_repo/test_copy_repo/test_invalid_content_type.txt
@@ -1,6 +1,6 @@
 [    INFO] Check repos: started
 [    INFO] Check repos: finished
 [    INFO] Copy content: started
-[   ERROR] Unsupported content type: container
+[   ERROR] Unsupported content type(s): container
 [   ERROR] Copy content: failed
 # Raised: 30


### PR DESCRIPTION
Copy-repo previously made copy calls for each content type. Lots of Pulp tasks were spawned with this creating a big queue and slowing down the operations. Hence, this updates copy-repo to make only two copy calls, one for rpm and other for non-rpm content types.

Non-rpm content type units are smaller in count and unit_fields are smaller in size, hence they are all clubbed in the same call ignoring the unit_fields.

Also, non-rpm content type units are copied first as they may have modulemd units, which should be copied before the corresponding modular rpm units to avoid those rpms being visible to user without modulemd units in case of failure or partial copy.