### PR TITLE
Fixed copy_repo copied all content types when copying only rpms

### DIFF
--- a/src/pubtools/_pulp/tasks/copy_repo.py
+++ b/src/pubtools/_pulp/tasks/copy_repo.py
@@ -148,11 +148,14 @@ class CopyRepo(CollectorService, PulpClientService, PulpRepositoryOperation):
             # criteria for all non-rpm content types
             # unit_fields are ignored as they are small in size and the repos have
             # small unit counts for non-rpm content types
-            criteria.append(
-                Criteria.with_field(
-                    "content_type_id", Matcher.in_(sorted(non_rpm_content_types))
+            if non_rpm_content_types:
+                # type_id filter with empty list includes all the content types.
+                # hence, check for the presence of non-rpm content types.
+                criteria.append(
+                    Criteria.with_field(
+                        "content_type_id", Matcher.in_(sorted(non_rpm_content_types))
+                    )
                 )
-            )
 
             # criteria for rpm content types
             # unit_fields to keep a check on memory consumption with large rpm unit


### PR DESCRIPTION
copy_repo creates a criteria matching the content_type_id for non-rpm content types. However, in Pulp the type_ids filter with empty type_ids list included all the content types in the result. Hence, the copy-repo copied all the content types when requested only for rpms, as it generated an empty type_ids list for non-rpms. Hence, this adds a check to skip empty type_ids/content_type_id list.