### PR TITLE
Add docs page for copy-repo [RHELDST-28512]

### DIFF
--- a/docs/copy-repo.rst
+++ b/docs/copy-repo.rst
@@ -1,0 +1,31 @@
+copy-repo
+=========
+
+.. argparse::
+   :module: pubtools._pulp.tasks.copy_repo
+   :func: doc_parser
+   :prog: pubtools-pulp-copy-repo
+
+
+Examples
+........
+
+Copy content from one repository to another:
+
+.. code-block::
+
+   pubtools-pulp-copy-repo \
+      --content-type rpm,srpm \
+      repo-A,repo-B
+
+This command copies RPM and SRPM content from repository `repo-A` to `repo-B`.
+If the user provides a non existing repo, the command fails.
+
+Provide multiple repository pairs to copy them in one command:
+
+.. code-block::
+
+   pubtools-pulp-copy-repo \
+      --content-type iso \
+      repo-1,repo-2 repo-3,repo-4
+

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -11,6 +11,7 @@ content via `Pulp <https://pulpproject.org/>`_.
    :caption: Command Reference:
 
    clear-repo
+   copy-repo
    delete
    fix-cves
    garbage-collect


### PR DESCRIPTION
Add documentation page for the copy-repo task in the pubtools-pulp docs.