### PR TITLE
Remove EngID flush [RHELDST-29701]

### DIFF
--- a/src/pubtools/_pulp/tasks/common.py
+++ b/src/pubtools/_pulp/tasks/common.py
@@ -42,9 +42,9 @@ class UdCache(UdCacheClientService):
         for repo in repos:
             # RHELDST-24551: UD can't flush cache of repos that have no eng product ID.
             # Ensure this condition is met before flushing.
+            # RHELDST-29701: Flushing repos only is sufficient to keep UD up to date.
             if repo.eng_product_id:
                 out.append(client.flush_repo(repo.id))
-                out.append(client.flush_product(repo.eng_product_id))
 
         out.extend([client.flush_erratum(erratum.id) for erratum in (errata or [])])
 

--- a/src/pubtools/_pulp/ud.py
+++ b/src/pubtools/_pulp/ud.py
@@ -105,7 +105,9 @@ class UdCacheClient(object):
             Future[None]
                 A future resolved once flush has completed.
         """
-        warnings.warn("`flush_product()` function will be deprecated.", DeprecationWarning)
+        warnings.warn(
+            "`flush_product()` function will be deprecated.", DeprecationWarning
+        )
         return self._flush_object("eng-product", product_id)
 
     def flush_repo(self, repo_id):

--- a/src/pubtools/_pulp/ud.py
+++ b/src/pubtools/_pulp/ud.py
@@ -1,6 +1,8 @@
 import threading
 import os
 import logging
+import warnings
+
 
 import requests
 from more_executors import Executors
@@ -103,6 +105,7 @@ class UdCacheClient(object):
             Future[None]
                 A future resolved once flush has completed.
         """
+        warnings.warn("`flush_product()` function will be deprecated.", DeprecationWarning)
         return self._flush_object("eng-product", product_id)
 
     def flush_repo(self, repo_id):

--- a/tests/clear_repo/test_clear_repo.py
+++ b/tests/clear_repo/test_clear_repo.py
@@ -21,14 +21,9 @@ from pubtools._pulp.ud import UdCacheClient
 class FakeUdCache(object):
     def __init__(self):
         self.flushed_repos = []
-        self.flushed_products = []
 
     def flush_repo(self, repo_id):
         self.flushed_repos.append(repo_id)
-        return f_return()
-
-    def flush_product(self, product_id):
-        self.flushed_products.append(product_id)
         return f_return()
 
 
@@ -163,7 +158,6 @@ def test_clear_file_repo(command_tester, fake_collector):
 
     # It should have flushed these UD objects
     assert task_instance.udcache_client.flushed_repos == ["some-filerepo"]
-    assert task_instance.udcache_client.flushed_products == [123]
 
 
 def test_clear_file_skip_publish(command_tester):

--- a/tests/copy_repo/test_copy_repo.py
+++ b/tests/copy_repo/test_copy_repo.py
@@ -262,6 +262,7 @@ def test_copy_repo(command_tester, fake_collector):
         "another-yumrepo",
     ]
 
+
 def test_copy_file_skip_publish(command_tester):
     """Copying a repo with file content while skipping publish succeeds."""
 

--- a/tests/copy_repo/test_copy_repo.py
+++ b/tests/copy_repo/test_copy_repo.py
@@ -21,14 +21,9 @@ from pubtools._pulp.ud import UdCacheClient
 class FakeUdCache(object):
     def __init__(self):
         self.flushed_repos = []
-        self.flushed_products = []
 
     def flush_repo(self, repo_id):
         self.flushed_repos.append(repo_id)
-        return f_return()
-
-    def flush_product(self, product_id):
-        self.flushed_products.append(product_id)
         return f_return()
 
 
@@ -266,8 +261,6 @@ def test_copy_repo(command_tester, fake_collector):
         "another-filerepo",
         "another-yumrepo",
     ]
-    assert task_instance.udcache_client.flushed_products == [456, 890]
-
 
 def test_copy_file_skip_publish(command_tester):
     """Copying a repo with file content while skipping publish succeeds."""

--- a/tests/delete/test_delete_advisory.py
+++ b/tests/delete/test_delete_advisory.py
@@ -22,14 +22,9 @@ from pubtools._pulp.tasks.delete import Delete
 class FakeUdCache(object):
     def __init__(self):
         self.flushed_repos = []
-        self.flushed_products = []
 
     def flush_repo(self, repo_id):
         self.flushed_repos.append(repo_id)
-        return f_return()
-
-    def flush_product(self, product_id):
-        self.flushed_products.append(product_id)
         return f_return()
 
 

--- a/tests/delete/test_delete_packages.py
+++ b/tests/delete/test_delete_packages.py
@@ -20,14 +20,9 @@ from pubtools._pulp.ud import UdCacheClient
 class FakeUdCache(object):
     def __init__(self):
         self.flushed_repos = []
-        self.flushed_products = []
 
     def flush_repo(self, repo_id):
         self.flushed_repos.append(repo_id)
-        return f_return()
-
-    def flush_product(self, product_id):
-        self.flushed_products.append(product_id)
         return f_return()
 
 

--- a/tests/fix_cves/test_fix_cves.py
+++ b/tests/fix_cves/test_fix_cves.py
@@ -19,15 +19,10 @@ from pubtools._pulp.tasks.fix_cves import FixCves, entry_point
 class FakeUdCache(object):
     def __init__(self):
         self.flushed_repos = []
-        self.flushed_products = []
         self.flushed_errata = []
 
     def flush_repo(self, repo_id):
         self.flushed_repos.append(repo_id)
-        return f_return()
-
-    def flush_product(self, product_id):
-        self.flushed_products.append(product_id)
         return f_return()
 
     def flush_erratum(self, erratum_id):
@@ -175,7 +170,6 @@ def test_fix_cves_with_cache_cleanup(command_tester):
         ud_client = fake_fix_cves.udcache_client
 
         assert ud_client.flushed_repos == ["all-rpm-content", "repo"]
-        assert ud_client.flushed_products == [100, 101]
         assert ud_client.flushed_errata == ["RHSA-1234:56"]
 
 

--- a/tests/publish/test_publish.py
+++ b/tests/publish/test_publish.py
@@ -12,14 +12,9 @@ from pubtools._pulp.tasks.publish import Publish, entry_point
 class FakeUdCache(object):
     def __init__(self):
         self.flushed_repos = []
-        self.flushed_products = []
 
     def flush_repo(self, repo_id):
         self.flushed_repos.append(repo_id)
-        return f_return()
-
-    def flush_product(self, product_id):
-        self.flushed_products.append(product_id)
         return f_return()
 
 

--- a/tests/ud/test_ud_cache_client.py
+++ b/tests/ud/test_ud_cache_client.py
@@ -1,4 +1,5 @@
 import logging
+import pytest
 
 
 from pubtools._pulp.ud import UdCacheClient
@@ -20,7 +21,8 @@ def test_flush(requests_mock, caplog):
             requests_mock.register_uri("GET", url)
 
         # It should succeed
-        client.flush_product(1234).result()
+        with pytest.deprecated_call():
+            client.flush_product(1234).result()
         client.flush_repo("some-repo").result()
         client.flush_erratum("RHBA-1234").result()
 


### PR DESCRIPTION
Previously, during each Flush UD cache step, the Eng ID for each flushed repository was also flushed. This resulted in repeated flushes of the same Eng ID.
It turns out that flushing the Eng ID is not necessary at all, and that just flushing the repos should be enough to keep the UD up to date.