### PR TITLE
Do not record push items for copy repo task [RHELDST-30557]

### DIFF
--- a/src/pubtools/_pulp/tasks/copy_repo.py
+++ b/src/pubtools/_pulp/tasks/copy_repo.py
@@ -304,10 +304,6 @@ class CopyRepo(CollectorService, PulpClientService, PulpRepositoryOperation):
         # Start copying repos.
         repo_copies_fs = self.copy_content(repo_pairs)
 
-        # As copying completes, record pushitem info on what was copied.
-        # We don't have to wait on this before continuing.
-        to_await = self.record_push_items(repo_copies_fs, "PUSHED")
-
         # Don't need the repo copying tasks for anything more.
         repos_fs = [f_proxy(f_map(f, lambda cr: cr.repo)) for f in repo_copies_fs]
 
@@ -322,10 +318,10 @@ class CopyRepo(CollectorService, PulpClientService, PulpRepositoryOperation):
         f_sequence(publish_fs).result()
 
         # They should have UD cache flushed.
-        to_await.extend(self.flush_ud(repos_fs))
+        flush_fs = self.flush_ud(repos_fs)
 
         # Now make sure we wait for everything to finish.
-        for f in to_await:
+        for f in flush_fs:
             f.result()
 
 

--- a/tests/copy_repo/test_copy_repo.py
+++ b/tests/copy_repo/test_copy_repo.py
@@ -206,49 +206,8 @@ def test_copy_repo(command_tester, fake_collector):
             ],
         )
 
-    # It should record that it copied these push items:
-    assert sorted(fake_collector.items, key=lambda pi: pi["filename"]) == [
-        {
-            "build": None,
-            "checksums": {"sha256": "a" * 64},
-            "dest": "another-yumrepo",
-            "filename": "bash-1.23-1.test8.x86_64.rpm",
-            "origin": "pulp",
-            "signing_key": None,
-            "src": None,
-            "state": "PUSHED",
-        },
-        {
-            "state": "PUSHED",
-            "origin": "pulp",
-            "src": None,
-            "dest": "another-filerepo",
-            "filename": "hello.txt",
-            "checksums": {"sha256": "a" * 64},
-            "build": None,
-            "signing_key": None,
-        },
-        {
-            "build": None,
-            "checksums": None,
-            "dest": "another-yumrepo",
-            "filename": "mymod:s1:123:a1c2:s390x",
-            "origin": "pulp",
-            "signing_key": None,
-            "src": None,
-            "state": "PUSHED",
-        },
-        {
-            "state": "PUSHED",
-            "origin": "pulp",
-            "src": None,
-            "dest": "another-filerepo",
-            "filename": "with/subdir.json",
-            "checksums": {"sha256": "b" * 64},
-            "build": None,
-            "signing_key": None,
-        },
-    ]
+    # It shouldn't record any push items:
+    assert fake_collector.items  == []
 
     # It should have published the copied Pulp repo
     assert [hist.repository.id for hist in fakepulp.publish_history] == [
@@ -363,39 +322,8 @@ def test_copy_yum_repo(command_tester, fake_collector, monkeypatch):
             ],
         )
 
-    # It should record that it copied these push items:
-    assert sorted(fake_collector.items, key=lambda pi: pi["filename"]) == [
-        {
-            "state": "PUSHED",
-            "origin": "pulp",
-            "src": None,
-            "dest": "another-yumrepo",
-            "filename": "RHSA-2021:0672",
-            "checksums": None,
-            "signing_key": None,
-            "build": None,
-        },
-        {
-            "state": "PUSHED",
-            "origin": "pulp",
-            "src": None,
-            "dest": "another-yumrepo",
-            "filename": "bash-1.23-1.test8.x86_64.rpm",
-            "checksums": {"sha256": "a" * 64},
-            "signing_key": None,
-            "build": None,
-        },
-        {
-            "state": "PUSHED",
-            "origin": "pulp",
-            "src": None,
-            "dest": "another-yumrepo",
-            "filename": "mymod:s1:123:a1c2:s390x",
-            "checksums": None,
-            "signing_key": None,
-            "build": None,
-        },
-    ]
+    # It shouldn't record any push items:
+    assert fake_collector.items == []
 
 
 def test_copy_container_repo(command_tester):
@@ -503,49 +431,8 @@ def test_copy_repo_multiple_content_types(command_tester, fake_collector):
     # produces the expected output
     assert task_instance.args.content_type == ["rpm", "modulemd", "iso", "erratum"]
 
-    # It should record that it copied these push items:
-    assert sorted(fake_collector.items, key=lambda pi: pi["filename"]) == [
-        {
-            "state": "PUSHED",
-            "origin": "pulp",
-            "src": None,
-            "dest": "another-yumrepo",
-            "filename": "bash-1.23-1.test8.x86_64.rpm",
-            "checksums": {"sha256": "a" * 64},
-            "signing_key": None,
-            "build": None,
-        },
-        {
-            "state": "PUSHED",
-            "origin": "pulp",
-            "src": None,
-            "dest": "yet-another-yumrepo",
-            "filename": "dash-1.24-1.test8.x86_64.rpm",
-            "checksums": {"sha256": "a" * 64},
-            "signing_key": None,
-            "build": None,
-        },
-        {
-            "state": "PUSHED",
-            "origin": "pulp",
-            "src": None,
-            "dest": "another-yumrepo",
-            "filename": "mymod:s1:123:a1c2:s390x",
-            "checksums": None,
-            "signing_key": None,
-            "build": None,
-        },
-        {
-            "state": "PUSHED",
-            "origin": "pulp",
-            "src": None,
-            "dest": "yet-another-yumrepo",
-            "filename": "othermod:s1:123:a1c2:s390x",
-            "checksums": None,
-            "signing_key": None,
-            "build": None,
-        },
-    ]
+    # It shouldn't record any push item:
+    assert fake_collector.items == []
 
 
 def test_copy_repo_criteria(command_tester):

--- a/tests/logs/copy_repo/test_copy_repo/test_copy_empty_repo.jsonl
+++ b/tests/logs/copy_repo/test_copy_repo/test_copy_empty_repo.jsonl
@@ -2,8 +2,6 @@
 {"event": {"type": "check-repos-end"}}
 {"event": {"type": "copy-content-start"}}
 {"event": {"type": "copy-content-end"}}
-{"event": {"type": "record-push-items-start"}}
-{"event": {"type": "record-push-items-end"}}
 {"event": {"type": "publish-start"}}
 {"event": {"type": "publish-end"}}
 {"event": {"type": "flush-ud-cache-start"}}

--- a/tests/logs/copy_repo/test_copy_repo/test_copy_empty_repo.txt
+++ b/tests/logs/copy_repo/test_copy_repo/test_copy_empty_repo.txt
@@ -3,8 +3,6 @@
 [    INFO] Copy content: started
 [ WARNING] another-filerepo: no content copied, tasks: e3e70682-c209-4cac-629f-6fbed82c07cd
 [    INFO] Copy content: finished
-[    INFO] Record push items: started
-[    INFO] Record push items: finished
 [    INFO] Publish: started
 [    INFO] Publish: finished
 [    INFO] Flush UD cache: started

--- a/tests/logs/copy_repo/test_copy_repo/test_copy_file_skip_publish.jsonl
+++ b/tests/logs/copy_repo/test_copy_repo/test_copy_file_skip_publish.jsonl
@@ -2,8 +2,6 @@
 {"event": {"type": "check-repos-end"}}
 {"event": {"type": "copy-content-start"}}
 {"event": {"type": "copy-content-end"}}
-{"event": {"type": "record-push-items-start"}}
-{"event": {"type": "record-push-items-end"}}
 {"event": {"type": "publish-skip"}}
 {"event": {"type": "flush-ud-cache-start"}}
 {"event": {"type": "flush-ud-cache-end"}}

--- a/tests/logs/copy_repo/test_copy_repo/test_copy_file_skip_publish.txt
+++ b/tests/logs/copy_repo/test_copy_repo/test_copy_file_skip_publish.txt
@@ -3,8 +3,6 @@
 [    INFO] Copy content: started
 [    INFO] another-filerepo: copied 1 iso(s), tasks: e3e70682-c209-4cac-629f-6fbed82c07cd
 [    INFO] Copy content: finished
-[    INFO] Record push items: started
-[    INFO] Record push items: finished
 [    INFO] Publish: skipped
 [    INFO] Flush UD cache: started
 [    INFO] UD cache flush is not enabled.

--- a/tests/logs/copy_repo/test_copy_repo/test_copy_repo.jsonl
+++ b/tests/logs/copy_repo/test_copy_repo/test_copy_repo.jsonl
@@ -2,8 +2,6 @@
 {"event": {"type": "check-repos-end"}}
 {"event": {"type": "copy-content-start"}}
 {"event": {"type": "copy-content-end"}}
-{"event": {"type": "record-push-items-start"}}
-{"event": {"type": "record-push-items-end"}}
 {"event": {"type": "publish-start"}}
 {"event": {"type": "publish-end"}}
 {"event": {"type": "flush-ud-cache-start"}}

--- a/tests/logs/copy_repo/test_copy_repo/test_copy_repo.txt
+++ b/tests/logs/copy_repo/test_copy_repo/test_copy_repo.txt
@@ -4,8 +4,6 @@
 [    INFO] another-filerepo: copied 2 iso(s), tasks: e3e70682-c209-4cac-629f-6fbed82c07cd
 [    INFO] another-yumrepo: copied 1 modulemd(s), 1 rpm(s), tasks: 82e2e662-f728-b4fa-4248-5e3a0a5d2f34
 [    INFO] Copy content: finished
-[    INFO] Record push items: started
-[    INFO] Record push items: finished
 [    INFO] Publish: started
 [    INFO] Publish: finished
 [    INFO] Flush UD cache: started

--- a/tests/logs/copy_repo/test_copy_repo/test_copy_repo_criteria.jsonl
+++ b/tests/logs/copy_repo/test_copy_repo/test_copy_repo_criteria.jsonl
@@ -2,8 +2,6 @@
 {"event": {"type": "check-repos-end"}}
 {"event": {"type": "copy-content-start"}}
 {"event": {"type": "copy-content-end"}}
-{"event": {"type": "record-push-items-start"}}
-{"event": {"type": "record-push-items-end"}}
 {"event": {"type": "publish-start"}}
 {"event": {"type": "publish-end"}}
 {"event": {"type": "flush-ud-cache-start"}}

--- a/tests/logs/copy_repo/test_copy_repo/test_copy_repo_criteria.txt
+++ b/tests/logs/copy_repo/test_copy_repo/test_copy_repo_criteria.txt
@@ -3,8 +3,6 @@
 [    INFO] Copy content: started
 [ WARNING] another-yumrepo: no content copied, tasks: 82e2e662-f728-b4fa-4248-5e3a0a5d2f34, e3e70682-c209-4cac-629f-6fbed82c07cd
 [    INFO] Copy content: finished
-[    INFO] Record push items: started
-[    INFO] Record push items: finished
 [    INFO] Publish: started
 [    INFO] Publish: finished
 [    INFO] Flush UD cache: started

--- a/tests/logs/copy_repo/test_copy_repo/test_copy_repo_multiple_content_types.jsonl
+++ b/tests/logs/copy_repo/test_copy_repo/test_copy_repo_multiple_content_types.jsonl
@@ -2,8 +2,6 @@
 {"event": {"type": "check-repos-end"}}
 {"event": {"type": "copy-content-start"}}
 {"event": {"type": "copy-content-end"}}
-{"event": {"type": "record-push-items-start"}}
-{"event": {"type": "record-push-items-end"}}
 {"event": {"type": "publish-start"}}
 {"event": {"type": "publish-end"}}
 {"event": {"type": "flush-ud-cache-start"}}

--- a/tests/logs/copy_repo/test_copy_repo/test_copy_repo_multiple_content_types.txt
+++ b/tests/logs/copy_repo/test_copy_repo/test_copy_repo_multiple_content_types.txt
@@ -4,8 +4,6 @@
 [    INFO] yet-another-yumrepo: copied 1 modulemd(s), 1 rpm(s), tasks: 82e2e662-f728-b4fa-4248-5e3a0a5d2f34, e3e70682-c209-4cac-629f-6fbed82c07cd
 [    INFO] another-yumrepo: copied 1 modulemd(s), 1 rpm(s), tasks: 23a7711a-8133-2876-37eb-dcd9e87a1613, d4713d60-c8a7-0639-eb11-67b367a9c378
 [    INFO] Copy content: finished
-[    INFO] Record push items: started
-[    INFO] Record push items: finished
 [    INFO] Publish: started
 [    INFO] Publish: finished
 [    INFO] Flush UD cache: started

--- a/tests/logs/copy_repo/test_copy_repo/test_copy_yum_repo.jsonl
+++ b/tests/logs/copy_repo/test_copy_repo/test_copy_yum_repo.jsonl
@@ -2,8 +2,6 @@
 {"event": {"type": "check-repos-end"}}
 {"event": {"type": "copy-content-start"}}
 {"event": {"type": "copy-content-end"}}
-{"event": {"type": "record-push-items-start"}}
-{"event": {"type": "record-push-items-end"}}
 {"event": {"type": "publish-start"}}
 {"event": {"type": "publish-end"}}
 {"event": {"type": "flush-ud-cache-start"}}

--- a/tests/logs/copy_repo/test_copy_repo/test_copy_yum_repo.txt
+++ b/tests/logs/copy_repo/test_copy_repo/test_copy_yum_repo.txt
@@ -3,8 +3,6 @@
 [    INFO] Copy content: started
 [    INFO] another-yumrepo: copied 1 erratum(s), 1 modulemd(s), 1 rpm(s), tasks: e3e70682-c209-4cac-629f-6fbed82c07cd
 [    INFO] Copy content: finished
-[    INFO] Record push items: started
-[    INFO] Record push items: finished
 [    INFO] Publish: started
 [    INFO] Publish: finished
 [    INFO] Flush UD cache: started


### PR DESCRIPTION
* in typical workflows the number of push items in copy repo task is very high (100K+ items) and it extremely overloads downstream systems (Pub) and makes this copy task unusable so let's now skip the push items recording as there is also very little value in storing all those push items.