### PR TITLE
Flush engproduct ID once [RHELDST-30255]

### DIFF
--- a/src/pubtools/_pulp/tasks/common.py
+++ b/src/pubtools/_pulp/tasks/common.py
@@ -46,6 +46,11 @@ class UdCache(UdCacheClientService):
             if repo.eng_product_id:
                 out.append(client.flush_repo(repo.id))
 
+        # RHELDST-30255: turns out we should still flush eng product IDs, but only once per ID
+        unique_product_ids = set([r.eng_product_id for r in repos if r.eng_product_id])
+        for product_id in unique_product_ids:
+            out.append(client.flush_product(product_id))
+
         out.extend([client.flush_erratum(erratum.id) for erratum in (errata or [])])
 
         return out

--- a/src/pubtools/_pulp/ud.py
+++ b/src/pubtools/_pulp/ud.py
@@ -1,7 +1,6 @@
 import threading
 import os
 import logging
-import warnings
 
 
 import requests
@@ -105,9 +104,6 @@ class UdCacheClient(object):
             Future[None]
                 A future resolved once flush has completed.
         """
-        warnings.warn(
-            "`flush_product()` function will be deprecated.", DeprecationWarning
-        )
         return self._flush_object("eng-product", product_id)
 
     def flush_repo(self, repo_id):

--- a/tests/clear_repo/test_clear_repo.py
+++ b/tests/clear_repo/test_clear_repo.py
@@ -23,7 +23,6 @@ class FakeUdCache(object):
         self.flushed_repos = []
         self.flushed_products = []
 
-
     def flush_repo(self, repo_id):
         self.flushed_repos.append(repo_id)
         return f_return()
@@ -31,6 +30,7 @@ class FakeUdCache(object):
     def flush_product(self, product_id):
         self.flushed_products.append(product_id)
         return f_return()
+
 
 class FakeClearRepo(ClearRepo):
     """clear-repo with services overridden for test"""

--- a/tests/clear_repo/test_clear_repo.py
+++ b/tests/clear_repo/test_clear_repo.py
@@ -21,11 +21,16 @@ from pubtools._pulp.ud import UdCacheClient
 class FakeUdCache(object):
     def __init__(self):
         self.flushed_repos = []
+        self.flushed_products = []
+
 
     def flush_repo(self, repo_id):
         self.flushed_repos.append(repo_id)
         return f_return()
 
+    def flush_product(self, product_id):
+        self.flushed_products.append(product_id)
+        return f_return()
 
 class FakeClearRepo(ClearRepo):
     """clear-repo with services overridden for test"""
@@ -158,6 +163,7 @@ def test_clear_file_repo(command_tester, fake_collector):
 
     # It should have flushed these UD objects
     assert task_instance.udcache_client.flushed_repos == ["some-filerepo"]
+    assert task_instance.udcache_client.flushed_products == [123]
 
 
 def test_clear_file_skip_publish(command_tester):

--- a/tests/copy_repo/test_copy_repo.py
+++ b/tests/copy_repo/test_copy_repo.py
@@ -21,9 +21,14 @@ from pubtools._pulp.ud import UdCacheClient
 class FakeUdCache(object):
     def __init__(self):
         self.flushed_repos = []
+        self.flushed_products = []
 
     def flush_repo(self, repo_id):
         self.flushed_repos.append(repo_id)
+        return f_return()
+
+    def flush_product(self, product_id):
+        self.flushed_products.append(product_id)
         return f_return()
 
 
@@ -220,6 +225,7 @@ def test_copy_repo(command_tester, fake_collector):
         "another-filerepo",
         "another-yumrepo",
     ]
+    assert task_instance.udcache_client.flushed_products == [456, 890]
 
 
 def test_copy_file_skip_publish(command_tester):

--- a/tests/delete/test_delete_packages.py
+++ b/tests/delete/test_delete_packages.py
@@ -20,9 +20,14 @@ from pubtools._pulp.ud import UdCacheClient
 class FakeUdCache(object):
     def __init__(self):
         self.flushed_repos = []
+        self.flushed_products = []
 
     def flush_repo(self, repo_id):
         self.flushed_repos.append(repo_id)
+        return f_return()
+
+    def flush_product(self, product_id):
+        self.flushed_products.append(product_id)
         return f_return()
 
 

--- a/tests/fix_cves/test_fix_cves.py
+++ b/tests/fix_cves/test_fix_cves.py
@@ -19,6 +19,7 @@ from pubtools._pulp.tasks.fix_cves import FixCves, entry_point
 class FakeUdCache(object):
     def __init__(self):
         self.flushed_repos = []
+        self.flushed_products = []
         self.flushed_errata = []
 
     def flush_repo(self, repo_id):
@@ -27,6 +28,10 @@ class FakeUdCache(object):
 
     def flush_erratum(self, erratum_id):
         self.flushed_errata.append(erratum_id)
+        return f_return()
+
+    def flush_product(self, product_id):
+        self.flushed_products.append(product_id)
         return f_return()
 
 
@@ -170,6 +175,7 @@ def test_fix_cves_with_cache_cleanup(command_tester):
         ud_client = fake_fix_cves.udcache_client
 
         assert ud_client.flushed_repos == ["all-rpm-content", "repo"]
+        assert ud_client.flushed_products == [100, 101]
         assert ud_client.flushed_errata == ["RHSA-1234:56"]
 
 

--- a/tests/publish/test_publish.py
+++ b/tests/publish/test_publish.py
@@ -203,8 +203,8 @@ def test_repo_publish_cache_cleanup(command_tester):
 
 
 def test_product_id_flushed_once(command_tester):
-    """ A given eng product ID should only be flushed once even if it appears
-        in multiple repos
+    """A given eng product ID should only be flushed once even if it appears
+    in multiple repos
     """
     with FakePublish() as fake_publish:
         fake_pulp = fake_publish.pulp_client_controller
@@ -256,12 +256,19 @@ def test_product_id_flushed_once(command_tester):
         )
 
     # pulp repo is published
-    assert [hist.repository.id for hist in fake_pulp.publish_history] == ["product_id_flushed_once_1", "product_id_flushed_once_2", "repo1"]
+    assert [hist.repository.id for hist in fake_pulp.publish_history] == [
+        "product_id_flushed_once_1",
+        "product_id_flushed_once_2",
+        "repo1",
+    ]
     # flushed the UD object
-    assert fake_publish.udcache_client.flushed_repos == ["product_id_flushed_once_1", "product_id_flushed_once_2", "repo1"]
+    assert fake_publish.udcache_client.flushed_repos == [
+        "product_id_flushed_once_1",
+        "product_id_flushed_once_2",
+        "repo1",
+    ]
     # Assert the product ID was only flushed once
     assert fake_publish.udcache_client.flushed_products == [101]
-
 
 
 def test_repo_publish_cache_cleanup_skip_ud(command_tester):

--- a/tests/ud/test_ud_cache_client.py
+++ b/tests/ud/test_ud_cache_client.py
@@ -1,5 +1,4 @@
 import logging
-import pytest
 
 
 from pubtools._pulp.ud import UdCacheClient
@@ -21,8 +20,7 @@ def test_flush(requests_mock, caplog):
             requests_mock.register_uri("GET", url)
 
         # It should succeed
-        with pytest.deprecated_call():
-            client.flush_product(1234).result()
+        client.flush_product(1234).result()
         client.flush_repo("some-repo").result()
         client.flush_erratum("RHBA-1234").result()
 


### PR DESCRIPTION
Previously, the UD cache for an eng product ID was flushed whenever it was found in a repo. This functionality was removed, as it put heavy load on the UD cache's API. We later found the product ID should in fact be flushed.

This change adds back in the UD cache flushing for eng product IDs, but makes sure each ID is only flushed once, rather than flushed for each repo it's in.