### PR TITLE
Update codecov-action to v5 [RHELDST-40405]

### DIFF
--- a/.github/workflows/tox-test.yml
+++ b/.github/workflows/tox-test.yml
@@ -39,6 +39,8 @@ jobs:
         run: tox -e static
   coverage:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
     steps:
       - uses: actions/checkout@v2
       - name: Install OS packages
@@ -56,10 +58,12 @@ jobs:
       - name: Run Tox
         run: tox -e cov
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v4
-        env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+        uses: codecov/codecov-action@v5
+        if: github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref =='refs/heads/master')
         with:
+          use_oidc: true
+          flags: unit-tests
+          files: coverage.xml
           fail_ci_if_error: true
           verbose: true
   docs:

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ used by [release-engineering](https://github.com/release-engineering) publishing
 
 [![PyPI version](https://badge.fury.io/py/pubtools-pulp.svg)](https://badge.fury.io/py/pubtools-pulp)
 [![Build Status](https://travis-ci.com/release-engineering/pubtools-pulp.svg?branch=master)](https://travis-ci.com/release-engineering/pubtools-pulp)
-[![Coverage Status](https://coveralls.io/repos/github/release-engineering/pubtools-pulp/badge.svg?branch=master)](https://coveralls.io/github/release-engineering/pubtools-pulp?branch=master)
+[![Coverage Status](https://app.codecov.io/gh/release-engineering/pubtools-pulp)](https://app.codecov.io/gh/release-engineering/pubtools-pulp)
 
 - [Source](https://github.com/release-engineering/pubtools-pulp)
 - [Documentation](https://release-engineering.github.io/pubtools-pulp/)

--- a/test-requirements.in
+++ b/test-requirements.in
@@ -1,6 +1,5 @@
 pytest
 pytest-cov
-coveralls
 mock
 requests_mock
 rpmdyn

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -342,12 +342,7 @@ coverage[toml]==7.6.1 \
     --hash=sha256:fc5a77d0c516700ebad189b587de289a20a78324bc54baee03dd486f0855d234 \
     --hash=sha256:fd21f6ae3f08b41004dfb433fa895d858f3f5979e7762d052b12aef444e29afc
     # via
-    #   coveralls
     #   pytest-cov
-coveralls==4.0.1 \
-    --hash=sha256:7a6b1fa9848332c7b2221afb20f3df90272ac0167060f41b5fe90429b30b1809 \
-    --hash=sha256:7b2a0a2bcef94f295e3cf28dcc55ca40b71c77d1c2446b538e85f0f7bc21aa69
-    # via -r test-requirements.in
 cryptography==47.0.0 \
     --hash=sha256:0024b87d47ae2399165a6bfb20d24888881eeab83ae2566d62467c5ff0030ce7 \
     --hash=sha256:07efe86201817e7d3c18781ca9770bc0db04e1e48c994be384e4602bc38f8f27 \
@@ -417,9 +412,6 @@ distlib==0.4.0 \
     --hash=sha256:9659f7d87e46584a30b5780e43ac7a2143098441670ff0a49d5f9034c54a6c16 \
     --hash=sha256:feec40075be03a04501a973d81f633735b4b69f98b05450592310c0f401a4e0d
     # via virtualenv
-docopt==0.6.2 \
-    --hash=sha256:49b3a825280bd66b3aa83585ef59c4a8c82f2c8a522dbe754a8bc8d08c85c491
-    # via coveralls
 docutils==0.20.1 \
     --hash=sha256:96f387a2c5562db4476f09f13bbab2192e764cac08ebbf3a34a95d9b1e4a59d6 \
     --hash=sha256:f08a4e276c3a1583a86dce3e34aba3fe04d02bba2dd51ed16106244e8a923e3b
@@ -908,7 +900,6 @@ requests==2.32.4 \
     --hash=sha256:27babd3cda2a6d50b30443204ee89830707d396671944c998b5975b031ac2b2c \
     --hash=sha256:27d0316682c8a29834d3264820024b62a36942083d52caf2f14c0591336d3422
     # via
-    #   coveralls
     #   koji
     #   pubtools-pulplib
     #   pushsource


### PR DESCRIPTION
Updates codecov-action to v5, uses OIDC authentication, and adds the unit-tests flag to codecov reports. Only runs codecov-action on pull-requests and pushes to master.
Remove coveralls.